### PR TITLE
:memo: Fix `pygraphviz` oversight in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,8 +295,9 @@ tt_list = [[int(tt.get_bit(i)) for i in range(tt.num_bits())] for tt in tts]
 
 ## Contributing
 
-Contributions are welcome! If you'd like to contribute to `aigverse`, please submit a pull request or open an issue. I
-appreciate feedback and suggestions for improving the library.
+Contributions are welcome! If you'd like to contribute to `aigverse`, please see the
+[contribution guide](https://aigverse.readthedocs.io/en/latest/contributing.html). I appreciate feedback and suggestions
+for improving the library.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # aigverse: A Python Library for Logic Networks, Synthesis, and Optimization
 
 [![Python Bindings](https://img.shields.io/github/actions/workflow/status/marcelwa/aigverse/aigverse-pypi-deployment.yml?label=Bindings&logo=python&style=flat-square)](https://github.com/marcelwa/aigverse/actions/workflows/aigverse-pypi-deployment.yml)
-[![License](https://img.shields.io/github/license/marcelwa/aigverse?label=License&style=flat-square)](https://github.com/marcelwa/aigverse/blob/main/LICENSE)
+[![Documentation Status](https://img.shields.io/readthedocs/aigverse?label=Docs&logo=readthedocs&style=flat-square)](https://aigverse.readthedocs.io/)
 [![PyPI](https://img.shields.io/static/v1?label=PyPI&message=aigverse&logo=pypi&color=informational&style=flat-square)](https://pypi.org/project/aigverse/)
+[![License](https://img.shields.io/github/license/marcelwa/aigverse?label=License&style=flat-square)](https://github.com/marcelwa/aigverse/blob/main/LICENSE)
 [![Release](https://img.shields.io/github/v/release/marcelwa/aigverse?label=aigverse&style=flat-square)](https://github.com/marcelwa/aigverse/releases)
 
 > [!Important]

--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -254,6 +254,46 @@ While the above commands install the project in editable mode, so that changes t
 any changes to the C++ code will require a rebuild of the Python package.
 :::
 
+:::::{note}
+When attempting to build the documentation, you must make sure to have `graphviz` installed on your system. Installing
+the documentation or development dependencies will fail if `graphviz` cannot be detected.
+
+::::{tab-set}
+
+:::{tab-item} Ubuntu
+
+```console
+$ sudo apt-get install graphviz
+```
+
+:::
+
+:::{tab-item} macOS
+
+```console
+$ brew install graphviz
+```
+
+:::
+
+:::{tab-item} Windows
+
+```console
+$ winget install graphviz
+```
+
+or
+
+```console
+$ choco install graphviz
+```
+
+:::
+
+::::
+
+:::::
+
 The way the Python package build process in the above commands works is that a wheel for the project is built
 in an isolated environment and then installed into the virtual environment.
 Due to the build isolation, the corresponding C++ build directory cannot be reused for subsequent builds.
@@ -405,6 +445,46 @@ On top of the API documentation, we provide a set of tutorials and examples that
 These are written in Markdown using [myst-nb](https://myst-nb.readthedocs.io/en/latest/), which allows to execute Python code blocks in the documentation.
 The code blocks are executed during the documentation build process, and the output is included in the documentation.
 This allows us to provide up-to-date examples and tutorials that are guaranteed to work with the latest version of the library.
+
+:::::{note}
+When attempting to build the documentation, you must make sure to have `graphviz` installed on your system. Installing
+the documentation or development dependencies will fail if `graphviz` cannot be detected.
+
+::::{tab-set}
+
+:::{tab-item} Ubuntu
+
+```console
+$ sudo apt-get install graphviz
+```
+
+:::
+
+:::{tab-item} macOS
+
+```console
+$ brew install graphviz
+```
+
+:::
+
+:::{tab-item} Windows
+
+```console
+$ winget install graphviz
+```
+
+or
+
+```console
+$ choco install graphviz
+```
+
+:::
+
+::::
+
+:::::
 
 You can build the documentation using the {code}`nox` session {code}`docs`.
 

--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -24,6 +24,7 @@ Ready to contribute to the project? This guide will get you started.
 
    ```console
    $ git clone git@github.com/marcelwa/aigverse.git
+   $ git submodule update --init --recursive
    ```
 
    :::

--- a/noxfile.py
+++ b/noxfile.py
@@ -112,7 +112,10 @@ def docs(session: nox.Session) -> None:
     if shutil.which("dot") is None:
         session.error(
             "Graphviz is required for building the documentation. "
-            "Please install it using your package manager (e.g., `brew install graphviz`)."
+            "Please install it using your package manager. For example:\n"
+            "  - macOS: `brew install graphviz`\n"
+            "  - Ubuntu: `sudo apt install graphviz`\n"
+            "  - Windows: `winget install graphviz` or `choco install graphviz`\n"
         )
 
     parser = argparse.ArgumentParser()

--- a/noxfile.py
+++ b/noxfile.py
@@ -108,6 +108,13 @@ def minimums(session: nox.Session) -> None:
 @nox.session(reuse_venv=True)
 def docs(session: nox.Session) -> None:
     """Build the docs. Use "--non-interactive" to avoid serving. Pass "-b linkcheck" to check links."""
+    # Check for graphviz installation
+    if shutil.which("dot") is None:
+        session.error(
+            "Graphviz is required for building the documentation. "
+            "Please install it using your package manager (e.g., `brew install graphviz`)."
+        )
+
     parser = argparse.ArgumentParser()
     parser.add_argument("-b", dest="builder", default="html", help="Build target (default: html)")
     args, posargs = parser.parse_known_args(session.posargs)


### PR DESCRIPTION
## Description

This PR fixes an oversight in the documentation that didn't inform users to install Graphviz if they want to build the documentation locally. Additionally, `nox -s docs` now checks if Graphviz is installed before attempting to download and install `pygraphviz`. 

Fixes #115  <!--- Replace (issue) with the issue number that is fixed by this pull request. -->

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
