### PR TITLE
:bug: Fixed `to_edge_list` documentation notebook

### DIFF
--- a/docs/aigs.md
+++ b/docs/aigs.md
@@ -371,6 +371,7 @@ You can export AIGs as edge lists, which are useful for integration with graph l
 import matplotlib.pyplot as plt
 import networkx as nx
 from networkx.drawing.nx_agraph import graphviz_layout
+import pygraphviz
 
 from aigverse import to_edge_list
 

--- a/docs/aigs.md
+++ b/docs/aigs.md
@@ -371,7 +371,7 @@ You can export AIGs as edge lists, which are useful for integration with graph l
 import matplotlib.pyplot as plt
 import networkx as nx
 from networkx.drawing.nx_agraph import graphviz_layout
-import pygraphviz
+import pygraphviz  # required for graphviz_layout
 
 from aigverse import to_edge_list
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,6 +236,7 @@ docs = [
     "sphinx>=8.2.3; python_version >= '3.11'",
     "networkx>=3.0.0",
     "matplotlib>=3.0.0",
+    "graphviz>=0.20.3",
     "pygraphviz>=1.9.0",
 ]
 test = [


### PR DESCRIPTION
## Description

Fixes the `to_edge_list` notebook in the documentation. In #145, the `import pygraphviz` statement was removed because it appeared redundant. It is, however, required for `networkx.drawing.nx_agraph.graphviz_layout` to function.

Fixes #147 <!--- Replace (issue) with the issue number that is fixed by this pull request. -->

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
