### PR TITLE
Refactor(NetworkX): Move arrows out of the covers of labels

### DIFF
--- a/docs/machine_learning.md
+++ b/docs/machine_learning.md
@@ -74,7 +74,7 @@ plt.figure(figsize=(12, 8))
 plt.title("AIG with Attribute Labels")
 
 # Draw the graph structure (just the edges and arrows)
-nx.draw(G, pos, with_labels=False, node_size=0, arrowsize=20)
+nx.draw_networkx_nodes(G, pos, node_size=0)
 
 # Draw the node labels with a bounding box
 nx.draw_networkx_labels(
@@ -83,6 +83,16 @@ nx.draw_networkx_labels(
     labels=node_labels,
     font_size=10,
     bbox={"facecolor": "lightblue", "edgecolor": "black", "boxstyle": "round,pad=0.5"},
+)
+
+# Draw the network edges
+nx.draw_networkx_edges(
+    G,
+    pos,
+    node_size=5000,
+    arrows ="True",
+    arrowstyle="->",
+    arrowsize=20,
 )
 
 # Draw the edge labels to show edge attributes


### PR DESCRIPTION
## Description

The DAG is supposed to have arrows, in  [machine-learning-integration](https://github.com/marcelwa/aigverse/blob/main/docs/machine_learning.md#machine-learning-integration). But actually it is covered by the `bbox`.

## Solution
Use `draw_networkx_edges` with proper `node_size=5000`, which leads to a further arrow head position from the node centre.


## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
