### PR TITLE
:fire: Drop macOS 13 due to GitHub Actions sunsetting support

### DIFF
--- a/.github/workflows/aigverse-pypi-deployment.yml
+++ b/.github/workflows/aigverse-pypi-deployment.yml
@@ -79,8 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on:
-          [ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-15, windows-2025]
+        runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, windows-2025]
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/aigverse-python-tests.yml
+++ b/.github/workflows/aigverse-python-tests.yml
@@ -74,8 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on:
-          [ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-15, windows-2025]
+        runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, windows-2025]
     steps:
       - name: Clone Repository
         uses: actions/checkout@v5


### PR DESCRIPTION
## Description

This PR removes support for macOS 13, and hence, support for Intel-based Macs. The reason is that [GitHub Actions is sunsetting support in December](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/).

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
