### PR TITLE
:recycle: Make optimization function parameters keyword-only

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -13,7 +13,8 @@ This version also includes an API rework for AIG optimization workflows.
 
 - **Networks**: `Aig`, `SequentialAig`, `NamedAig`, etc., `AigEdge`, `AigEdgeList`, `AigIndexList` and helper
   types are now in `aigverse.networks`.
-- **Algorithms**: `balancing`, `equivalence_checking`, `simulate`, etc. are now in `aigverse.algorithms`.
+- **Algorithms**: `balancing`, `equivalence_checking`, `simulate`, etc. are now in `aigverse.algorithms`. All of their
+  parameters except the input networks are now keyword-only for better readability.
 - **IO**: Reading/Writing functions are now in `aigverse.io`.
 - **Utils**: `TruthTable` and its free operation functions are now in `aigverse.utils`.
 
@@ -123,7 +124,8 @@ Network query methods are now **read-only properties** instead of callable metho
 | `signal.get_complement()` | `signal.complement` |
 | `signal.get_data()`       | `signal.data`       |
 
-Migration hint: replace method calls with direct property access (drop `()`), e.g. `signal.get_index()` -> `signal.index`.
+Migration hint: replace method calls with direct property access (drop `()`), e.g. `signal.get_index()` ->
+`signal.index`.
 
 #### Before
 

--- a/python/aigverse/algorithms.pyi
+++ b/python/aigverse/algorithms.pyi
@@ -8,6 +8,7 @@ import aigverse.utils
 def equivalence_checking(
     spec: aigverse.networks.Aig,
     impl: aigverse.networks.Aig,
+    *,
     conflict_limit: int = 0,
     functional_reduction: bool = True,
     verbose: bool = False,
@@ -30,7 +31,7 @@ def equivalence_checking(
     """
 
 def cleanup_dangling(
-    ntk: aigverse.networks.Aig, remove_dangling_pis: bool = False, remove_redundant_pos: bool = False
+    ntk: aigverse.networks.Aig, *, remove_dangling_pis: bool = False, remove_redundant_pos: bool = False
 ) -> aigverse.networks.Aig:
     """Removes dangling logic (dead nodes) from a network.
 
@@ -45,6 +46,7 @@ def cleanup_dangling(
 
 def sop_refactoring(
     ntk: aigverse.networks.Aig,
+    *,
     max_pis: int = 6,
     allow_zero_gain: bool = False,
     use_reconvergence_cut: bool = False,
@@ -78,6 +80,7 @@ def sop_refactoring(
 
 def aig_resubstitution(
     ntk: aigverse.networks.Aig,
+    *,
     max_pis: int = 8,
     max_divisors: int = 150,
     max_inserts: int = 2,
@@ -110,6 +113,7 @@ def aig_resubstitution(
 
 def aig_cut_rewriting(
     ntk: aigverse.networks.Aig,
+    *,
     cut_size: int = 4,
     cut_limit: int = 8,
     minimize_truth_table: bool = True,
@@ -142,6 +146,7 @@ def aig_cut_rewriting(
 
 def balancing(
     ntk: aigverse.networks.Aig,
+    *,
     cut_size: int = 4,
     cut_limit: int = 8,
     minimize_truth_table: bool = True,

--- a/src/aigverse/algorithms/balancing.cpp
+++ b/src/aigverse/algorithms/balancing.cpp
@@ -57,9 +57,9 @@ void balancing(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
             throw std::invalid_argument(fmt::format(
                 "Unknown rebalance function: '{}'. Possible values are 'sop' and 'esop'.", rebalance_function));
         },
-        nb::arg("ntk"), nb::arg("cut_size") = 4, nb::arg("cut_limit") = 8, nb::arg("minimize_truth_table") = true,
-        nb::arg("only_on_critical_path") = false, nb::arg("rebalance_function") = "sop",
-        nb::arg("sop_both_phases") = true, nb::arg("verbose") = false,
+        nb::arg("ntk"), nb::kw_only(), nb::arg("cut_size") = 4, nb::arg("cut_limit") = 8,
+        nb::arg("minimize_truth_table") = true, nb::arg("only_on_critical_path") = false,
+        nb::arg("rebalance_function") = "sop", nb::arg("sop_both_phases") = true, nb::arg("verbose") = false,
         R"pb(Balances a network using SOP or ESOP-based local restructuring.
 
 Args:

--- a/src/aigverse/algorithms/cleanup_dangling.cpp
+++ b/src/aigverse/algorithms/cleanup_dangling.cpp
@@ -22,7 +22,7 @@ void cleanup(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
         "cleanup_dangling",
         [](const Ntk& ntk, const bool remove_dangling_pis = false, const bool remove_redundant_pos = false) -> Ntk
         { return mockturtle::cleanup_dangling(ntk, remove_dangling_pis, remove_redundant_pos); }, nb::arg("ntk"),
-        nb::arg("remove_dangling_pis") = false, nb::arg("remove_redundant_pos") = false,
+        nb::kw_only(), nb::arg("remove_dangling_pis") = false, nb::arg("remove_redundant_pos") = false,
         R"pb(Removes dangling logic (dead nodes) from a network.
 
 Args:

--- a/src/aigverse/algorithms/equivalence_checking.cpp
+++ b/src/aigverse/algorithms/equivalence_checking.cpp
@@ -44,8 +44,8 @@ void equivalence_checking(nanobind::module_& m)  // NOLINT(misc-use-internal-lin
 
             return mockturtle::equivalence_checking(miter.value(), params);
         },
-        nb::arg("spec"), nb::arg("impl"), nb::arg("conflict_limit") = 0, nb::arg("functional_reduction") = true,
-        nb::arg("verbose") = false,
+        nb::arg("spec"), nb::arg("impl"), nb::kw_only(), nb::arg("conflict_limit") = 0,
+        nb::arg("functional_reduction") = true, nb::arg("verbose") = false,
         R"pb(Checks functional equivalence between a specification and implementation network using SAT solving.
 
 Args:

--- a/src/aigverse/algorithms/refactoring.cpp
+++ b/src/aigverse/algorithms/refactoring.cpp
@@ -63,7 +63,7 @@ void refactoring(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
                 throw std::runtime_error("Unknown error in mockturtle::sop_refactoring");
             }
         },
-        nb::arg("ntk"), nb::arg("max_pis") = 6, nb::arg("allow_zero_gain") = false,
+        nb::arg("ntk"), nb::kw_only(), nb::arg("max_pis") = 6, nb::arg("allow_zero_gain") = false,
         nb::arg("use_reconvergence_cut") = false, nb::arg("use_dont_cares") = false,
         nb::arg("use_quick_factoring") = true, nb::arg("try_both_polarities") = true,
         nb::arg("consider_inverter_cost") = false, nb::arg("verbose") = false, nb::arg("inplace") = false,

--- a/src/aigverse/algorithms/resubstitution.cpp
+++ b/src/aigverse/algorithms/resubstitution.cpp
@@ -46,10 +46,10 @@ void resubstitution(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
             return run_transform(ntk, inplace,
                                  [params](Ntk& target) { mockturtle::aig_resubstitution(target, params); });
         },
-        nb::arg("ntk"), nb::arg("max_pis") = 8, nb::arg("max_divisors") = 150, nb::arg("max_inserts") = 2,
-        nb::arg("skip_fanout_limit_for_roots") = 1000, nb::arg("skip_fanout_limit_for_divisors") = 100,
-        nb::arg("verbose") = false, nb::arg("use_dont_cares") = false, nb::arg("window_size") = 12,
-        nb::arg("preserve_depth") = false, nb::arg("inplace") = false,
+        nb::arg("ntk"), nb::kw_only(), nb::arg("max_pis") = 8, nb::arg("max_divisors") = 150,
+        nb::arg("max_inserts") = 2, nb::arg("skip_fanout_limit_for_roots") = 1000,
+        nb::arg("skip_fanout_limit_for_divisors") = 100, nb::arg("verbose") = false, nb::arg("use_dont_cares") = false,
+        nb::arg("window_size") = 12, nb::arg("preserve_depth") = false, nb::arg("inplace") = false,
         R"pb(Performs AIG resubstitution-based optimization.
 
 Args:

--- a/src/aigverse/algorithms/rewriting.cpp
+++ b/src/aigverse/algorithms/rewriting.cpp
@@ -47,10 +47,10 @@ void rewriting(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
 
             return mockturtle::cut_rewriting(ntk, aig_npn_resyn_engine, params);
         },
-        nb::arg("ntk"), nb::arg("cut_size") = 4, nb::arg("cut_limit") = 8, nb::arg("minimize_truth_table") = true,
-        nb::arg("allow_zero_gain") = false, nb::arg("use_dont_cares") = false, nb::arg("min_cand_cut_size") = 3,
-        nb::arg("min_cand_cut_size_override") = std::nullopt, nb::arg("preserve_depth") = false,
-        nb::arg("verbose") = false, nb::arg("very_verbose") = false,
+        nb::arg("ntk"), nb::kw_only(), nb::arg("cut_size") = 4, nb::arg("cut_limit") = 8,
+        nb::arg("minimize_truth_table") = true, nb::arg("allow_zero_gain") = false, nb::arg("use_dont_cares") = false,
+        nb::arg("min_cand_cut_size") = 3, nb::arg("min_cand_cut_size_override") = std::nullopt,
+        nb::arg("preserve_depth") = false, nb::arg("verbose") = false, nb::arg("very_verbose") = false,
         R"pb(Rewrites an AIG network using cut-based NPN resynthesis.
 
 Args:

--- a/src/aigverse/algorithms/transform_helpers.hpp
+++ b/src/aigverse/algorithms/transform_helpers.hpp
@@ -12,6 +12,16 @@
 namespace aigverse::detail
 {
 
+/**
+ * @brief Helper function to run a transformation either in-place or on a copy of the input network.
+ *
+ * @tparam Ntk The type of the logic network.
+ * @tparam Fn The type of the transformation function, which should accept a non-const reference to an Ntk.
+ * @param ntk The input logic network to transform.
+ * @param inplace Whether to perform the transformation in-place on the input network (if true) or on a copy (if false).
+ * @param fn The transformation function to apply.
+ * @return The transformed network if not in-place, otherwise std::nullopt.
+ */
 template <typename Ntk, typename Fn>
 std::optional<Ntk> run_transform(Ntk& ntk, const bool inplace, Fn&& fn)
 {


### PR DESCRIPTION
## Description

This pull request updates the API for AIG optimization workflows to improve usability and consistency. The most significant change is that all algorithm parameters, except for the input network(s), are now keyword-only, which enhances code readability and reduces the risk of passing arguments in the wrong order. The documentation and Python interface files have been updated accordingly.

### API Improvements for Algorithms

* All algorithm functions in `aigverse.algorithms` now require parameters (other than the input network(s)) to be specified as keyword-only arguments, making the API clearer and less error-prone. (`python/aigverse/algorithms.pyi`, `src/aigverse/algorithms/balancing.cpp`, `src/aigverse/algorithms/cleanup_dangling.cpp`, `src/aigverse/algorithms/equivalence_checking.cpp`, `src/aigverse/algorithms/refactoring.cpp`, `src/aigverse/algorithms/resubstitution.cpp`, `src/aigverse/algorithms/rewriting.cpp`) [[1]](diffhunk://#diff-4db562933ccf591784f893a35f4deeb19d29778102d503248e3671e5eb993765R11) [[2]](diffhunk://#diff-4db562933ccf591784f893a35f4deeb19d29778102d503248e3671e5eb993765L33-R34) [[3]](diffhunk://#diff-4db562933ccf591784f893a35f4deeb19d29778102d503248e3671e5eb993765R49) [[4]](diffhunk://#diff-4db562933ccf591784f893a35f4deeb19d29778102d503248e3671e5eb993765R83) [[5]](diffhunk://#diff-4db562933ccf591784f893a35f4deeb19d29778102d503248e3671e5eb993765R116) [[6]](diffhunk://#diff-4db562933ccf591784f893a35f4deeb19d29778102d503248e3671e5eb993765R149) [[7]](diffhunk://#diff-b3b54bf657bfc77bae65d8e39a17936517f7c94ab067df32bfdfb9f3f884cdc8L60-R62) [[8]](diffhunk://#diff-90504f2fadc46e9cf926eac7415e04c79737707d2235d9bfeee2d0389f70ec4cL25-R25) [[9]](diffhunk://#diff-a08ad323cfb27994bb5c58b44313eaeb664f809043f65997c8a6025d042243d9L47-R48) [[10]](diffhunk://#diff-13edd9322a53ee558bbe2388baf5c195af7a7631baa8c742c7f5fab0a6147560L66-R66) [[11]](diffhunk://#diff-c493e8e90e91566d4f241b5a88a79f5cad252ab43f65c6de6a0b453dd5334856L49-R52) [[12]](diffhunk://#diff-f84e415c71fab072ace7dc26ef0e70650295e256877284de9ebb9466741b8bfeL50-R53)

### Documentation Updates

* The upgrade guide (`UPGRADING.md`) has been updated to document the new keyword-only parameter requirement for all algorithms, helping users migrate their code.
* Minor formatting improvements in migration hints for property access changes in `UPGRADING.md`.

### Code Quality

* Added a detailed docstring for the `run_transform` helper function to clarify its usage and template parameters. (`src/aigverse/algorithms/transform_helpers.hpp`)

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration guide with detailed information about required changes to algorithm function parameter syntax and their new keyword-only requirements.

* **Refactor**
  * Algorithm functions have been updated to require all optional parameters to be passed exclusively as keyword-only arguments, significantly improving API consistency, code clarity, and long-term maintainability of your implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->