### PR TITLE
:sparkles: Enable Cut View on AIG

### DIFF
--- a/docs/aigs.md
+++ b/docs/aigs.md
@@ -276,6 +276,69 @@ for node in fanout_aig.fanouts(aig.get_node(n4)):
     print(f"  Node {node}")
 ```
 
+### AIGs with Cut Views
+
+The {py:class}`~aigverse.networks.CutAig` class provides an isolated view on a single cut in a network. A cut has a single output (root) and a set of leaves (inputs). This is useful for analyzing subgraphs or extracting portions of a larger network.
+
+```{code-cell} ipython3
+from aigverse.networks import Aig, CutAig
+
+# Create a sample AIG
+aig = Aig()
+x1 = aig.create_pi()
+x2 = aig.create_pi()
+x3 = aig.create_pi()
+
+# Create logic
+f1 = aig.create_and(x1, x2)
+f2 = aig.create_and(f1, x3)
+aig.create_po(f2)
+
+# Create a cut view with x1, x2 as leaves and f1 as root
+# This is valid because f1 only depends on x1 and x2
+cut_aig = CutAig(aig, [x1, x2], f1)
+
+print(f"Cut has {cut_aig.num_pis} PIs (leaves)")
+print(f"Cut has {cut_aig.num_pos} PO (root)")
+print(f"Cut has {cut_aig.num_gates} gates")
+
+# Iterate over leaves (PIs in the cut)
+print("\nLeaf nodes:")
+for leaf in cut_aig.pis():
+    print(f"  Leaf: {leaf}")
+
+# Iterate over gates in the cut
+print("\nGates in cut:")
+for gate in cut_aig.gates():
+    print(f"  Gate: {gate}")
+```
+
+You can also create larger cuts that include multiple gates:
+
+```{code-cell} ipython3
+# Create a cut with all PIs as leaves and f2 as root
+# This cut includes both f1 and f2 gates
+cut_aig2 = CutAig(aig, [x1, x2, x3], f2)
+
+print(f"\nLarger cut has {cut_aig2.num_pis} PIs (leaves)")
+print(f"Larger cut has {cut_aig2.num_pos} PO (root)")
+print(f"Larger cut has {cut_aig2.num_gates} gates")
+
+# The leaves are all primary inputs
+print("\nLeaves in larger cut:")
+for leaf in cut_aig2.pis():
+    print(f"  Leaf: {leaf}")
+
+# The gates include both f1 and f2
+print("\nGates in larger cut:")
+for gate in cut_aig2.gates():
+    print(f"  Gate: {gate}")
+```
+
+:::{note}
+A cut is only valid if all dependencies of the root node are either included in the leaves or can be reached through nodes within the cut. The cut view assumes that all nodes' visited flags are set to 0 before creating the view.
+:::
+
 ### Sequential AIGs
 
 {py:class}`~aigverse.networks.SequentialAig`s extend standard AIGs to include registers, which allow modeling sequential circuits

--- a/docs/aigs.md
+++ b/docs/aigs.md
@@ -294,40 +294,31 @@ f1 = aig.create_and(x1, x2)
 f2 = aig.create_and(f1, x3)
 aig.create_po(f2)
 
-# Create a cut view with x1, x2 as leaves and f1 as root
+# Create a small cut view with x1, x2 as leaves and f1 as root
 # This is valid because f1 only depends on x1 and x2
 cut_aig = CutAig(aig, [x1, x2], f1)
 
-print(f"Cut has {cut_aig.num_pis} PIs (leaves)")
-print(f"Cut has {cut_aig.num_pos} PO (root)")
-print(f"Cut has {cut_aig.num_gates} gates")
+print(f"Small cut has {cut_aig.num_pis} PIs (leaves)")
+print(f"Small cut has {cut_aig.num_pos} POs (roots)")
+print(f"Small cut has {cut_aig.num_gates} gates")
 
 # Iterate over leaves (PIs in the cut)
-print("\nLeaf nodes:")
+print("\nLeaf nodes in small cut:")
 for leaf in cut_aig.pis():
     print(f"  Leaf: {leaf}")
 
 # Iterate over gates in the cut
-print("\nGates in cut:")
+print("\nGates in small cut:")
 for gate in cut_aig.gates():
     print(f"  Gate: {gate}")
-```
 
-You can also create larger cuts that include multiple gates:
-
-```{code-cell} ipython3
-# Create a cut with all PIs as leaves and f2 as root
+# Create a larger cut with all PIs as leaves and f2 as root
 # This cut includes both f1 and f2 gates
 cut_aig2 = CutAig(aig, [x1, x2, x3], f2)
 
 print(f"\nLarger cut has {cut_aig2.num_pis} PIs (leaves)")
-print(f"Larger cut has {cut_aig2.num_pos} PO (root)")
+print(f"Larger cut has {cut_aig2.num_pos} POs (roots)")
 print(f"Larger cut has {cut_aig2.num_gates} gates")
-
-# The leaves are all primary inputs
-print("\nLeaves in larger cut:")
-for leaf in cut_aig2.pis():
-    print(f"  Leaf: {leaf}")
 
 # The gates include both f1 and f2
 print("\nGates in larger cut:")
@@ -336,7 +327,7 @@ for gate in cut_aig2.gates():
 ```
 
 :::{note}
-A cut is only valid if all dependencies of the root node are either included in the leaves or can be reached through nodes within the cut. The cut view assumes that all nodes' visited flags are set to 0 before creating the view.
+A cut is only valid if all dependencies of the root node are either included in the leaves or can be reached through nodes within the cut. The cut view clears all nodes' visited flags before construction to ensure the cut is constructed correctly.
 :::
 
 ### Sequential AIGs

--- a/python/aigverse/networks.pyi
+++ b/python/aigverse/networks.pyi
@@ -580,7 +580,7 @@ class CutAig(Aig):
     def create_pi(self) -> AigSignal:
         """Not available on immutable view."""
 
-    def create_po(self, f: AigSignal) -> None:
+    def create_po(self, f: AigSignal) -> int:
         """Not available on immutable view."""
 
     def create_buf(self, a: AigSignal) -> AigSignal:

--- a/python/aigverse/networks.pyi
+++ b/python/aigverse/networks.pyi
@@ -577,61 +577,61 @@ class CutAig(Aig):
     def index_to_node(self, index: int) -> int:
         """Returns the node for an index."""
 
-    def create_pi(self) -> AigSignal:
+    def create_pi(self) -> NoReturn:
         """Not available on immutable view."""
 
-    def create_po(self, f: AigSignal) -> int:
+    def create_po(self, f: AigSignal) -> NoReturn:
         """Not available on immutable view."""
 
-    def create_buf(self, a: AigSignal) -> AigSignal:
+    def create_buf(self, a: AigSignal) -> NoReturn:
         """Not available on immutable view."""
 
-    def create_not(self, a: AigSignal) -> AigSignal:
+    def create_not(self, a: AigSignal) -> NoReturn:
         """Not available on immutable view."""
 
-    def create_and(self, a: AigSignal, b: AigSignal) -> AigSignal:
+    def create_and(self, a: AigSignal, b: AigSignal) -> NoReturn:
         """Not available on immutable view."""
 
-    def create_nand(self, a: AigSignal, b: AigSignal) -> AigSignal:
+    def create_nand(self, a: AigSignal, b: AigSignal) -> NoReturn:
         """Not available on immutable view."""
 
-    def create_or(self, a: AigSignal, b: AigSignal) -> AigSignal:
+    def create_or(self, a: AigSignal, b: AigSignal) -> NoReturn:
         """Not available on immutable view."""
 
-    def create_nor(self, a: AigSignal, b: AigSignal) -> AigSignal:
+    def create_nor(self, a: AigSignal, b: AigSignal) -> NoReturn:
         """Not available on immutable view."""
 
-    def create_xor(self, a: AigSignal, b: AigSignal) -> AigSignal:
+    def create_xor(self, a: AigSignal, b: AigSignal) -> NoReturn:
         """Not available on immutable view."""
 
-    def create_xnor(self, a: AigSignal, b: AigSignal) -> AigSignal:
+    def create_xnor(self, a: AigSignal, b: AigSignal) -> NoReturn:
         """Not available on immutable view."""
 
-    def create_lt(self, a: AigSignal, b: AigSignal) -> AigSignal:
+    def create_lt(self, a: AigSignal, b: AigSignal) -> NoReturn:
         """Not available on immutable view."""
 
-    def create_le(self, a: AigSignal, b: AigSignal) -> AigSignal:
+    def create_le(self, a: AigSignal, b: AigSignal) -> NoReturn:
         """Not available on immutable view."""
 
-    def create_maj(self, a: AigSignal, b: AigSignal, c: AigSignal) -> AigSignal:
+    def create_maj(self, a: AigSignal, b: AigSignal, c: AigSignal) -> NoReturn:
         """Not available on immutable view."""
 
-    def create_ite(self, cond: AigSignal, f_then: AigSignal, f_else: AigSignal) -> AigSignal:
+    def create_ite(self, cond: AigSignal, f_then: AigSignal, f_else: AigSignal) -> NoReturn:
         """Not available on immutable view."""
 
-    def create_xor3(self, a: AigSignal, b: AigSignal, c: AigSignal) -> AigSignal:
+    def create_xor3(self, a: AigSignal, b: AigSignal, c: AigSignal) -> NoReturn:
         """Not available on immutable view."""
 
-    def create_nary_and(self, fs: Sequence[AigSignal]) -> AigSignal:
+    def create_nary_and(self, fs: Sequence[AigSignal]) -> NoReturn:
         """Not available on immutable view."""
 
-    def create_nary_or(self, fs: Sequence[AigSignal]) -> AigSignal:
+    def create_nary_or(self, fs: Sequence[AigSignal]) -> NoReturn:
         """Not available on immutable view."""
 
-    def create_nary_xor(self, fs: Sequence[AigSignal]) -> AigSignal:
+    def create_nary_xor(self, fs: Sequence[AigSignal]) -> NoReturn:
         """Not available on immutable view."""
 
-    def clone_node(self, other: Aig, source: int, children: Sequence[AigSignal]) -> AigSignal:
+    def clone_node(self, other: Aig, source: int, children: Sequence[AigSignal]) -> NoReturn:
         """Not available on immutable view."""
 
 class AigRegister:

--- a/python/aigverse/networks.pyi
+++ b/python/aigverse/networks.pyi
@@ -502,9 +502,13 @@ class CutAig(Aig):
     """Implements an isolated view on a single cut in a network.
 
     This view creates a network from a single cut with a single output `root`
-    and a set of `leaves`. The view assumes that all nodes' visited flags are
-    set to 0 before creating the view and guarantees that all nodes in the view
-    will have a 0 visited flag after construction.
+    and a set of `leaves`. This is an immutable view; network-modifying methods
+    are not available.
+
+    Note:
+        This view clears all nodes' visited flags before construction to ensure
+        the cut is constructed correctly. The view guarantees that all nodes in
+        the view will have a 0 visited flag after construction.
     """
 
     @overload
@@ -566,6 +570,69 @@ class CutAig(Aig):
     @property
     def num_gates(self) -> int:
         """Number of logic gates in the cut view."""
+
+    def node_to_index(self, n: int) -> int:
+        """Returns the integer index of a node."""
+
+    def index_to_node(self, index: int) -> int:
+        """Returns the node for an index."""
+
+    def create_pi(self) -> AigSignal:
+        """Not available on immutable view."""
+
+    def create_po(self, f: AigSignal) -> None:
+        """Not available on immutable view."""
+
+    def create_buf(self, a: AigSignal) -> AigSignal:
+        """Not available on immutable view."""
+
+    def create_not(self, a: AigSignal) -> AigSignal:
+        """Not available on immutable view."""
+
+    def create_and(self, a: AigSignal, b: AigSignal) -> AigSignal:
+        """Not available on immutable view."""
+
+    def create_nand(self, a: AigSignal, b: AigSignal) -> AigSignal:
+        """Not available on immutable view."""
+
+    def create_or(self, a: AigSignal, b: AigSignal) -> AigSignal:
+        """Not available on immutable view."""
+
+    def create_nor(self, a: AigSignal, b: AigSignal) -> AigSignal:
+        """Not available on immutable view."""
+
+    def create_xor(self, a: AigSignal, b: AigSignal) -> AigSignal:
+        """Not available on immutable view."""
+
+    def create_xnor(self, a: AigSignal, b: AigSignal) -> AigSignal:
+        """Not available on immutable view."""
+
+    def create_lt(self, a: AigSignal, b: AigSignal) -> AigSignal:
+        """Not available on immutable view."""
+
+    def create_le(self, a: AigSignal, b: AigSignal) -> AigSignal:
+        """Not available on immutable view."""
+
+    def create_maj(self, a: AigSignal, b: AigSignal, c: AigSignal) -> AigSignal:
+        """Not available on immutable view."""
+
+    def create_ite(self, cond: AigSignal, f_then: AigSignal, f_else: AigSignal) -> AigSignal:
+        """Not available on immutable view."""
+
+    def create_xor3(self, a: AigSignal, b: AigSignal, c: AigSignal) -> AigSignal:
+        """Not available on immutable view."""
+
+    def create_nary_and(self, fs: Sequence[AigSignal]) -> AigSignal:
+        """Not available on immutable view."""
+
+    def create_nary_or(self, fs: Sequence[AigSignal]) -> AigSignal:
+        """Not available on immutable view."""
+
+    def create_nary_xor(self, fs: Sequence[AigSignal]) -> AigSignal:
+        """Not available on immutable view."""
+
+    def clone_node(self, other: Aig, source: int, children: Sequence[AigSignal]) -> AigSignal:
+        """Not available on immutable view."""
 
 class AigRegister:
     """Represents metadata for one sequential register."""

--- a/python/aigverse/networks.pyi
+++ b/python/aigverse/networks.pyi
@@ -498,6 +498,75 @@ class FanoutAig(Aig):
     def fanouts(self, n: int) -> list[int]:
         """Returns fanout nodes of node ``n``."""
 
+class CutAig(Aig):
+    """Implements an isolated view on a single cut in a network.
+
+    This view creates a network from a single cut with a single output `root`
+    and a set of `leaves`. The view assumes that all nodes' visited flags are
+    set to 0 before creating the view and guarantees that all nodes in the view
+    will have a 0 visited flag after construction.
+    """
+
+    @overload
+    def __init__(self, ntk: Aig, leaves: Sequence[int], root: AigSignal) -> None:
+        """Creates a cut view from a network, leaf nodes, and root signal.
+
+        Args:
+            ntk: The base network.
+            leaves: Vector of leaf nodes (boundary of the cut).
+            root: The root signal (output) of the cut.
+        """
+
+    @overload
+    def __init__(self, ntk: Aig, leaves: Sequence[AigSignal], root: AigSignal) -> None:
+        """Creates a cut view from a network, leaf signals, and root signal.
+
+        Args:
+            ntk: The base network.
+            leaves: Vector of leaf signals (boundary of the cut).
+            root: The root signal (output) of the cut.
+        """
+
+    def clone(self) -> CutAig:
+        """Creates a structural copy of the cut view."""
+
+    def __copy__(self) -> CutAig:
+        """Returns a shallow copy of the cut view."""
+
+    def __deepcopy__(self, memo: dict) -> CutAig:
+        """Returns a deep copy of the cut view."""
+
+    def nodes(self) -> list[int]:
+        """Returns a list of all nodes in the cut view."""
+
+    def gates(self) -> list[int]:
+        """Returns a list of all gate nodes in the cut view."""
+
+    def pis(self) -> list[int]:
+        """Returns a list of all primary input (leaf) nodes in the cut view."""
+
+    def pos(self) -> list[AigSignal]:
+        """Returns a list containing the root signal of the cut view."""
+
+    def is_pi(self, n: int) -> bool:
+        """Returns whether ``n`` is a primary input (leaf) in the cut view."""
+
+    @property
+    def size(self) -> int:
+        """Number of nodes in the cut view."""
+
+    @property
+    def num_pis(self) -> int:
+        """Number of primary inputs (leaves) in the cut view."""
+
+    @property
+    def num_pos(self) -> int:
+        """Number of primary outputs (always 1 for cut view)."""
+
+    @property
+    def num_gates(self) -> int:
+        """Number of logic gates in the cut view."""
+
 class AigRegister:
     """Represents metadata for one sequential register."""
 

--- a/src/aigverse/networks/logic_networks.cpp
+++ b/src/aigverse/networks/logic_networks.cpp
@@ -10,6 +10,7 @@
 #include <fmt/format.h>
 #include <mockturtle/networks/sequential.hpp>
 #include <mockturtle/traits.hpp>
+#include <mockturtle/views/cut_view.hpp>
 #include <mockturtle/views/depth_view.hpp>
 #include <mockturtle/views/fanout_view.hpp>
 #include <mockturtle/views/names_view.hpp>
@@ -330,9 +331,10 @@ void bind_network(nanobind::module_& m, const std::string& network_name)  // NOL
             "is_nary_or", [](const Ntk& ntk, const Node& n) { return ntk.is_nary_or(n); }, nb::arg("n"),
             R"pb(Returns whether ``n`` is an n-ary OR node.)pb")
         .def(
-            "to_edge_list", [](const Ntk& ntk, const int64_t regular_weight = 0, const int64_t inverted_weight = 1)
-            { return aigverse::to_edge_list(ntk, regular_weight, inverted_weight); }, nb::arg("regular_weight") = 0,
-            nb::arg("inverted_weight") = 1,
+            "to_edge_list",
+            [](const Ntk& ntk, const int64_t regular_weight = 0, const int64_t inverted_weight = 1)
+            { return aigverse::to_edge_list(ntk, regular_weight, inverted_weight); },
+            nb::arg("regular_weight") = 0, nb::arg("inverted_weight") = 1,
             R"pb(Converts the network to an edge list.
 
 Args:
@@ -529,6 +531,93 @@ Preserves only combinational structure and does not capture augmented view metad
             },
             nb::arg("n"), R"pb(Returns fanout nodes of node ``n``.)pb");
 
+    using CutNtk = mockturtle::cut_view<Ntk>;
+    nb::class_<CutNtk, Ntk>(m, fmt::format("Cut{}", network_name).c_str(),
+                            R"pb(Implements an isolated view on a single cut in a network.
+
+This view creates a network from a single cut with a single output `root`
+and a set of `leaves`. The view assumes that all nodes' visited flags are
+set to 0 before creating the view and guarantees that all nodes in the view
+will have a 0 visited flag after construction.)pb")
+        .def(nb::init<const Ntk&, const std::vector<Node>&, const Signal&>(), nb::arg("ntk"), nb::arg("leaves"),
+             nb::arg("root"),
+             R"pb(Creates a cut view from a network, leaf nodes, and root signal.
+
+Args:
+    ntk: The base network.
+    leaves: Vector of leaf nodes (boundary of the cut).
+    root: The root signal (output) of the cut.)pb")
+        .def(nb::init<const Ntk&, const std::vector<Signal>&, const Signal&>(), nb::arg("ntk"), nb::arg("leaves"),
+             nb::arg("root"),
+             R"pb(Creates a cut view from a network, leaf signals, and root signal.
+
+Args:
+    ntk: The base network.
+    leaves: Vector of leaf signals (boundary of the cut).
+    root: The root signal (output) of the cut.)pb")
+        .def(
+            "clone", [](const CutNtk& ntk) { return CutNtk{ntk}; }, R"pb(Creates a structural copy of the cut view.)pb")
+        .def(
+            "__copy__", [](const CutNtk& ntk) { return CutNtk{ntk}; }, R"pb(Returns a shallow copy of the cut view.)pb")
+        .def(
+            "__deepcopy__", [](const CutNtk& ntk, const nb::dict&) { return CutNtk{ntk}; }, nb::arg("memo"),
+            R"pb(Returns a deep copy of the cut view.)pb")
+        .def(
+            "nodes", [](const CutNtk& ntk) { return collect_nodes(ntk); },
+            R"pb(Returns a list of all nodes in the cut view.)pb")
+        .def(
+            "gates",
+            [](const CutNtk& ntk)
+            {
+                std::vector<Node> gates;
+                gates.reserve(ntk.num_gates());
+                ntk.foreach_gate([&gates](const auto& g) { gates.push_back(g); });
+                return gates;
+            },
+            R"pb(Returns a list of all gate nodes in the cut view.)pb")
+        .def(
+            "pis",
+            [](const CutNtk& ntk)
+            {
+                std::vector<Node> pis;
+                pis.reserve(ntk.num_pis());
+                ntk.foreach_pi([&pis](const auto& pi) { pis.push_back(pi); });
+                return pis;
+            },
+            R"pb(Returns a list of all primary input (leaf) nodes in the cut view.)pb")
+        .def(
+            "pos",
+            [](const CutNtk& ntk)
+            {
+                std::vector<Signal> pos;
+                pos.reserve(ntk.num_pos());
+                ntk.foreach_po([&pos](const auto& po) { pos.push_back(po); });
+                return pos;
+            },
+            R"pb(Returns a list containing the root signal of the cut view.)pb")
+        .def(
+            "is_pi", [](const CutNtk& ntk, const Node& n) { return ntk.is_pi(n); }, nb::arg("n"),
+            R"pb(Returns whether ``n`` is a primary input (leaf) in the cut view.)pb")
+        .def_prop_ro(
+            "size", [](const CutNtk& ntk) { return ntk.size(); }, R"pb(Number of nodes in the cut view.)pb")
+        .def_prop_ro(
+            "num_pis", [](const CutNtk& ntk) { return ntk.num_pis(); },
+            R"pb(Number of primary inputs (leaves) in the cut view.)pb")
+        .def_prop_ro(
+            "num_pos", [](const CutNtk& ntk) { return ntk.num_pos(); },
+            R"pb(Number of primary outputs (always 1 for cut view).)pb")
+        .def_prop_ro(
+            "num_gates", [](const CutNtk& ntk) { return ntk.num_gates(); },
+            R"pb(Number of logic gates in the cut view.)pb")
+        .def(
+            "__repr__",
+            [network_name](const CutNtk& ntk)
+            {
+                return fmt::format("Cut{}(leaves={}, gates={}, size={})", network_name, ntk.num_pis(), ntk.num_gates(),
+                                   ntk.size());
+            },
+            R"pb(Returns a developer-friendly string representation.)pb");
+
     using Register = mockturtle::register_t;  // NOLINT(readability-identifier-naming)
     nb::class_<Register>(m, fmt::format("{}Register", network_name).c_str(),
                          R"pb(Represents metadata for one sequential register.)pb")
@@ -620,9 +709,9 @@ Preserves only combinational structure and does not capture augmented view metad
         .def(
             "to_edge_list",
             [](const SequentialNtk& ntk, const int64_t regular_weight = 0, const int64_t inverted_weight = 1)
-            { return aigverse::to_edge_list(ntk, regular_weight, inverted_weight); }, nb::arg("regular_weight") = 0,
-            nb::arg("inverted_weight") = 1, R"pb(Converts the sequential network to an edge list.)pb",
-            nb::rv_policy::move)
+            { return aigverse::to_edge_list(ntk, regular_weight, inverted_weight); },
+            nb::arg("regular_weight") = 0, nb::arg("inverted_weight") = 1,
+            R"pb(Converts the sequential network to an edge list.)pb", nb::rv_policy::move)
         .def(
             "pis",
             [](const SequentialNtk& ntk)

--- a/src/aigverse/networks/logic_networks.cpp
+++ b/src/aigverse/networks/logic_networks.cpp
@@ -647,79 +647,94 @@ Args:
         .def(
             "create_pi",
             [](CutNtk&) -> Signal { throw std::runtime_error("create_pi is not available on immutable view"); },
-            R"pb(Not available on immutable view.)pb")
+            R"pb(Not available on immutable view.)pb", nb::sig("def create_pi(self) -> NoReturn"))
         .def(
             "create_po", [](CutNtk&, const Signal&) -> int
             { throw std::runtime_error("create_po is not available on immutable view"); }, nb::arg("f"),
-            R"pb(Not available on immutable view.)pb")
+            R"pb(Not available on immutable view.)pb", nb::sig("def create_po(self, f: AigSignal) -> NoReturn"))
         .def(
             "create_buf", [](CutNtk&, const Signal&) -> Signal
             { throw std::runtime_error("create_buf is not available on immutable view"); }, nb::arg("a"),
-            R"pb(Not available on immutable view.)pb")
+            R"pb(Not available on immutable view.)pb", nb::sig("def create_buf(self, a: AigSignal) -> NoReturn"))
         .def(
             "create_not", [](CutNtk&, const Signal&) -> Signal
             { throw std::runtime_error("create_not is not available on immutable view"); }, nb::arg("a"),
-            R"pb(Not available on immutable view.)pb")
+            R"pb(Not available on immutable view.)pb", nb::sig("def create_not(self, a: AigSignal) -> NoReturn"))
         .def(
             "create_and", [](CutNtk&, const Signal&, const Signal&) -> Signal
             { throw std::runtime_error("create_and is not available on immutable view"); }, nb::arg("a"), nb::arg("b"),
-            R"pb(Not available on immutable view.)pb")
+            R"pb(Not available on immutable view.)pb",
+            nb::sig("def create_and(self, a: AigSignal, b: AigSignal) -> NoReturn"))
         .def(
             "create_nand", [](CutNtk&, const Signal&, const Signal&) -> Signal
             { throw std::runtime_error("create_nand is not available on immutable view"); }, nb::arg("a"), nb::arg("b"),
-            R"pb(Not available on immutable view.)pb")
+            R"pb(Not available on immutable view.)pb",
+            nb::sig("def create_nand(self, a: AigSignal, b: AigSignal) -> NoReturn"))
         .def(
             "create_or", [](CutNtk&, const Signal&, const Signal&) -> Signal
             { throw std::runtime_error("create_or is not available on immutable view"); }, nb::arg("a"), nb::arg("b"),
-            R"pb(Not available on immutable view.)pb")
+            R"pb(Not available on immutable view.)pb",
+            nb::sig("def create_or(self, a: AigSignal, b: AigSignal) -> NoReturn"))
         .def(
             "create_nor", [](CutNtk&, const Signal&, const Signal&) -> Signal
             { throw std::runtime_error("create_nor is not available on immutable view"); }, nb::arg("a"), nb::arg("b"),
-            R"pb(Not available on immutable view.)pb")
+            R"pb(Not available on immutable view.)pb",
+            nb::sig("def create_nor(self, a: AigSignal, b: AigSignal) -> NoReturn"))
         .def(
             "create_xor", [](CutNtk&, const Signal&, const Signal&) -> Signal
             { throw std::runtime_error("create_xor is not available on immutable view"); }, nb::arg("a"), nb::arg("b"),
-            R"pb(Not available on immutable view.)pb")
+            R"pb(Not available on immutable view.)pb",
+            nb::sig("def create_xor(self, a: AigSignal, b: AigSignal) -> NoReturn"))
         .def(
             "create_xnor", [](CutNtk&, const Signal&, const Signal&) -> Signal
             { throw std::runtime_error("create_xnor is not available on immutable view"); }, nb::arg("a"), nb::arg("b"),
-            R"pb(Not available on immutable view.)pb")
+            R"pb(Not available on immutable view.)pb",
+            nb::sig("def create_xnor(self, a: AigSignal, b: AigSignal) -> NoReturn"))
         .def(
             "create_lt", [](CutNtk&, const Signal&, const Signal&) -> Signal
             { throw std::runtime_error("create_lt is not available on immutable view"); }, nb::arg("a"), nb::arg("b"),
-            R"pb(Not available on immutable view.)pb")
+            R"pb(Not available on immutable view.)pb",
+            nb::sig("def create_lt(self, a: AigSignal, b: AigSignal) -> NoReturn"))
         .def(
             "create_le", [](CutNtk&, const Signal&, const Signal&) -> Signal
             { throw std::runtime_error("create_le is not available on immutable view"); }, nb::arg("a"), nb::arg("b"),
-            R"pb(Not available on immutable view.)pb")
+            R"pb(Not available on immutable view.)pb",
+            nb::sig("def create_le(self, a: AigSignal, b: AigSignal) -> NoReturn"))
         .def(
             "create_maj", [](CutNtk&, const Signal&, const Signal&, const Signal&) -> Signal
             { throw std::runtime_error("create_maj is not available on immutable view"); }, nb::arg("a"), nb::arg("b"),
-            nb::arg("c"), R"pb(Not available on immutable view.)pb")
+            nb::arg("c"), R"pb(Not available on immutable view.)pb",
+            nb::sig("def create_maj(self, a: AigSignal, b: AigSignal, c: AigSignal) -> NoReturn"))
         .def(
             "create_ite", [](CutNtk&, const Signal&, const Signal&, const Signal&) -> Signal
             { throw std::runtime_error("create_ite is not available on immutable view"); }, nb::arg("cond"),
-            nb::arg("f_then"), nb::arg("f_else"), R"pb(Not available on immutable view.)pb")
+            nb::arg("f_then"), nb::arg("f_else"), R"pb(Not available on immutable view.)pb",
+            nb::sig("def create_ite(self, cond: AigSignal, f_then: AigSignal, f_else: AigSignal) -> NoReturn"))
         .def(
             "create_xor3", [](CutNtk&, const Signal&, const Signal&, const Signal&) -> Signal
             { throw std::runtime_error("create_xor3 is not available on immutable view"); }, nb::arg("a"), nb::arg("b"),
-            nb::arg("c"), R"pb(Not available on immutable view.)pb")
+            nb::arg("c"), R"pb(Not available on immutable view.)pb",
+            nb::sig("def create_xor3(self, a: AigSignal, b: AigSignal, c: AigSignal) -> NoReturn"))
         .def(
             "create_nary_and", [](CutNtk&, const std::vector<Signal>&) -> Signal
             { throw std::runtime_error("create_nary_and is not available on immutable view"); }, nb::arg("fs"),
-            R"pb(Not available on immutable view.)pb")
+            R"pb(Not available on immutable view.)pb",
+            nb::sig("def create_nary_and(self, fs: Sequence[AigSignal]) -> NoReturn"))
         .def(
             "create_nary_or", [](CutNtk&, const std::vector<Signal>&) -> Signal
             { throw std::runtime_error("create_nary_or is not available on immutable view"); }, nb::arg("fs"),
-            R"pb(Not available on immutable view.)pb")
+            R"pb(Not available on immutable view.)pb",
+            nb::sig("def create_nary_or(self, fs: Sequence[AigSignal]) -> NoReturn"))
         .def(
             "create_nary_xor", [](CutNtk&, const std::vector<Signal>&) -> Signal
             { throw std::runtime_error("create_nary_xor is not available on immutable view"); }, nb::arg("fs"),
-            R"pb(Not available on immutable view.)pb")
+            R"pb(Not available on immutable view.)pb",
+            nb::sig("def create_nary_xor(self, fs: Sequence[AigSignal]) -> NoReturn"))
         .def(
             "clone_node", [](CutNtk&, const Ntk&, const Node&, const std::vector<Signal>&) -> Signal
             { throw std::runtime_error("clone_node is not available on immutable view"); }, nb::arg("other"),
-            nb::arg("source"), nb::arg("children"), R"pb(Not available on immutable view.)pb");
+            nb::arg("source"), nb::arg("children"), R"pb(Not available on immutable view.)pb",
+            nb::sig("def clone_node(self, other: Aig, source: int, children: Sequence[AigSignal]) -> NoReturn"));
 
     using Register = mockturtle::register_t;  // NOLINT(readability-identifier-naming)
     nb::class_<Register>(m, fmt::format("{}Register", network_name).c_str(),

--- a/src/aigverse/networks/logic_networks.cpp
+++ b/src/aigverse/networks/logic_networks.cpp
@@ -23,9 +23,11 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstddef>
 #include <cstdint>
 #include <exception>
 #include <functional>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -647,9 +649,9 @@ Args:
             [](CutNtk&) -> Signal { throw std::runtime_error("create_pi is not available on immutable view"); },
             R"pb(Not available on immutable view.)pb")
         .def(
-            "create_po",
-            [](CutNtk&, const Signal&) { throw std::runtime_error("create_po is not available on immutable view"); },
-            nb::arg("f"), R"pb(Not available on immutable view.)pb")
+            "create_po", [](CutNtk&, const Signal&) -> int
+            { throw std::runtime_error("create_po is not available on immutable view"); }, nb::arg("f"),
+            R"pb(Not available on immutable view.)pb")
         .def(
             "create_buf", [](CutNtk&, const Signal&) -> Signal
             { throw std::runtime_error("create_buf is not available on immutable view"); }, nb::arg("a"),

--- a/src/aigverse/networks/logic_networks.cpp
+++ b/src/aigverse/networks/logic_networks.cpp
@@ -331,10 +331,9 @@ void bind_network(nanobind::module_& m, const std::string& network_name)  // NOL
             "is_nary_or", [](const Ntk& ntk, const Node& n) { return ntk.is_nary_or(n); }, nb::arg("n"),
             R"pb(Returns whether ``n`` is an n-ary OR node.)pb")
         .def(
-            "to_edge_list",
-            [](const Ntk& ntk, const int64_t regular_weight = 0, const int64_t inverted_weight = 1)
-            { return aigverse::to_edge_list(ntk, regular_weight, inverted_weight); },
-            nb::arg("regular_weight") = 0, nb::arg("inverted_weight") = 1,
+            "to_edge_list", [](const Ntk& ntk, const int64_t regular_weight = 0, const int64_t inverted_weight = 1)
+            { return aigverse::to_edge_list(ntk, regular_weight, inverted_weight); }, nb::arg("regular_weight") = 0,
+            nb::arg("inverted_weight") = 1,
             R"pb(Converts the network to an edge list.
 
 Args:
@@ -532,24 +531,43 @@ Preserves only combinational structure and does not capture augmented view metad
             nb::arg("n"), R"pb(Returns fanout nodes of node ``n``.)pb");
 
     using CutNtk = mockturtle::cut_view<Ntk>;
+
+    auto clear_visited = [](const Ntk& ntk) { ntk.foreach_node([&ntk](const auto& n) { ntk.set_visited(n, 0); }); };
+
     nb::class_<CutNtk, Ntk>(m, fmt::format("Cut{}", network_name).c_str(),
                             R"pb(Implements an isolated view on a single cut in a network.
 
 This view creates a network from a single cut with a single output `root`
-and a set of `leaves`. The view assumes that all nodes' visited flags are
-set to 0 before creating the view and guarantees that all nodes in the view
-will have a 0 visited flag after construction.)pb")
-        .def(nb::init<const Ntk&, const std::vector<Node>&, const Signal&>(), nb::arg("ntk"), nb::arg("leaves"),
-             nb::arg("root"),
-             R"pb(Creates a cut view from a network, leaf nodes, and root signal.
+and a set of `leaves`. This is an immutable view; network-modifying methods
+are not available.
+
+Note:
+    This view clears all nodes' visited flags before construction to ensure
+    the cut is constructed correctly. The view guarantees that all nodes in
+    the view will have a 0 visited flag after construction.)pb")
+        .def(
+            "__init__",
+            [clear_visited](CutNtk* self, const Ntk& ntk, const std::vector<Node>& leaves, const Signal& root)
+            {
+                clear_visited(ntk);
+                new (self) CutNtk(ntk, leaves, root);
+            },
+            nb::arg("ntk"), nb::arg("leaves"), nb::arg("root"),
+            R"pb(Creates a cut view from a network, leaf nodes, and root signal.
 
 Args:
     ntk: The base network.
     leaves: Vector of leaf nodes (boundary of the cut).
     root: The root signal (output) of the cut.)pb")
-        .def(nb::init<const Ntk&, const std::vector<Signal>&, const Signal&>(), nb::arg("ntk"), nb::arg("leaves"),
-             nb::arg("root"),
-             R"pb(Creates a cut view from a network, leaf signals, and root signal.
+        .def(
+            "__init__",
+            [clear_visited](CutNtk* self, const Ntk& ntk, const std::vector<Signal>& leaves, const Signal& root)
+            {
+                clear_visited(ntk);
+                new (self) CutNtk(ntk, leaves, root);
+            },
+            nb::arg("ntk"), nb::arg("leaves"), nb::arg("root"),
+            R"pb(Creates a cut view from a network, leaf signals, and root signal.
 
 Args:
     ntk: The base network.
@@ -569,8 +587,8 @@ Args:
             "gates",
             [](const CutNtk& ntk)
             {
-                std::vector<Node> gates;
-                gates.reserve(ntk.num_gates());
+                std::vector<Node> gates{};
+                gates.reserve(static_cast<size_t>(ntk.num_gates()));
                 ntk.foreach_gate([&gates](const auto& g) { gates.push_back(g); });
                 return gates;
             },
@@ -579,8 +597,8 @@ Args:
             "pis",
             [](const CutNtk& ntk)
             {
-                std::vector<Node> pis;
-                pis.reserve(ntk.num_pis());
+                std::vector<Node> pis{};
+                pis.reserve(static_cast<size_t>(ntk.num_pis()));
                 ntk.foreach_pi([&pis](const auto& pi) { pis.push_back(pi); });
                 return pis;
             },
@@ -589,8 +607,8 @@ Args:
             "pos",
             [](const CutNtk& ntk)
             {
-                std::vector<Signal> pos;
-                pos.reserve(ntk.num_pos());
+                std::vector<Signal> pos{};
+                pos.reserve(static_cast<size_t>(ntk.num_pos()));
                 ntk.foreach_po([&pos](const auto& po) { pos.push_back(po); });
                 return pos;
             },
@@ -610,13 +628,96 @@ Args:
             "num_gates", [](const CutNtk& ntk) { return ntk.num_gates(); },
             R"pb(Number of logic gates in the cut view.)pb")
         .def(
+            "node_to_index", [](const CutNtk& ntk, const Node& n) { return ntk.node_to_index(n); }, nb::arg("n"),
+            R"pb(Returns the integer index of a node.)pb")
+        .def(
+            "index_to_node", [](const CutNtk& ntk, const uint32_t index) { return ntk.index_to_node(index); },
+            nb::arg("index"), R"pb(Returns the node for an index.)pb")
+        .def(
             "__repr__",
             [network_name](const CutNtk& ntk)
             {
                 return fmt::format("Cut{}(leaves={}, gates={}, size={})", network_name, ntk.num_pis(), ntk.num_gates(),
                                    ntk.size());
             },
-            R"pb(Returns a developer-friendly string representation.)pb");
+            R"pb(Returns a developer-friendly string representation.)pb")
+        // Network-modifying methods that are exposed on Aig must be blocked on CutAig
+        .def(
+            "create_pi",
+            [](CutNtk&) -> Signal { throw std::runtime_error("create_pi is not available on immutable view"); },
+            R"pb(Not available on immutable view.)pb")
+        .def(
+            "create_po",
+            [](CutNtk&, const Signal&) { throw std::runtime_error("create_po is not available on immutable view"); },
+            nb::arg("f"), R"pb(Not available on immutable view.)pb")
+        .def(
+            "create_buf", [](CutNtk&, const Signal&) -> Signal
+            { throw std::runtime_error("create_buf is not available on immutable view"); }, nb::arg("a"),
+            R"pb(Not available on immutable view.)pb")
+        .def(
+            "create_not", [](CutNtk&, const Signal&) -> Signal
+            { throw std::runtime_error("create_not is not available on immutable view"); }, nb::arg("a"),
+            R"pb(Not available on immutable view.)pb")
+        .def(
+            "create_and", [](CutNtk&, const Signal&, const Signal&) -> Signal
+            { throw std::runtime_error("create_and is not available on immutable view"); }, nb::arg("a"), nb::arg("b"),
+            R"pb(Not available on immutable view.)pb")
+        .def(
+            "create_nand", [](CutNtk&, const Signal&, const Signal&) -> Signal
+            { throw std::runtime_error("create_nand is not available on immutable view"); }, nb::arg("a"), nb::arg("b"),
+            R"pb(Not available on immutable view.)pb")
+        .def(
+            "create_or", [](CutNtk&, const Signal&, const Signal&) -> Signal
+            { throw std::runtime_error("create_or is not available on immutable view"); }, nb::arg("a"), nb::arg("b"),
+            R"pb(Not available on immutable view.)pb")
+        .def(
+            "create_nor", [](CutNtk&, const Signal&, const Signal&) -> Signal
+            { throw std::runtime_error("create_nor is not available on immutable view"); }, nb::arg("a"), nb::arg("b"),
+            R"pb(Not available on immutable view.)pb")
+        .def(
+            "create_xor", [](CutNtk&, const Signal&, const Signal&) -> Signal
+            { throw std::runtime_error("create_xor is not available on immutable view"); }, nb::arg("a"), nb::arg("b"),
+            R"pb(Not available on immutable view.)pb")
+        .def(
+            "create_xnor", [](CutNtk&, const Signal&, const Signal&) -> Signal
+            { throw std::runtime_error("create_xnor is not available on immutable view"); }, nb::arg("a"), nb::arg("b"),
+            R"pb(Not available on immutable view.)pb")
+        .def(
+            "create_lt", [](CutNtk&, const Signal&, const Signal&) -> Signal
+            { throw std::runtime_error("create_lt is not available on immutable view"); }, nb::arg("a"), nb::arg("b"),
+            R"pb(Not available on immutable view.)pb")
+        .def(
+            "create_le", [](CutNtk&, const Signal&, const Signal&) -> Signal
+            { throw std::runtime_error("create_le is not available on immutable view"); }, nb::arg("a"), nb::arg("b"),
+            R"pb(Not available on immutable view.)pb")
+        .def(
+            "create_maj", [](CutNtk&, const Signal&, const Signal&, const Signal&) -> Signal
+            { throw std::runtime_error("create_maj is not available on immutable view"); }, nb::arg("a"), nb::arg("b"),
+            nb::arg("c"), R"pb(Not available on immutable view.)pb")
+        .def(
+            "create_ite", [](CutNtk&, const Signal&, const Signal&, const Signal&) -> Signal
+            { throw std::runtime_error("create_ite is not available on immutable view"); }, nb::arg("cond"),
+            nb::arg("f_then"), nb::arg("f_else"), R"pb(Not available on immutable view.)pb")
+        .def(
+            "create_xor3", [](CutNtk&, const Signal&, const Signal&, const Signal&) -> Signal
+            { throw std::runtime_error("create_xor3 is not available on immutable view"); }, nb::arg("a"), nb::arg("b"),
+            nb::arg("c"), R"pb(Not available on immutable view.)pb")
+        .def(
+            "create_nary_and", [](CutNtk&, const std::vector<Signal>&) -> Signal
+            { throw std::runtime_error("create_nary_and is not available on immutable view"); }, nb::arg("fs"),
+            R"pb(Not available on immutable view.)pb")
+        .def(
+            "create_nary_or", [](CutNtk&, const std::vector<Signal>&) -> Signal
+            { throw std::runtime_error("create_nary_or is not available on immutable view"); }, nb::arg("fs"),
+            R"pb(Not available on immutable view.)pb")
+        .def(
+            "create_nary_xor", [](CutNtk&, const std::vector<Signal>&) -> Signal
+            { throw std::runtime_error("create_nary_xor is not available on immutable view"); }, nb::arg("fs"),
+            R"pb(Not available on immutable view.)pb")
+        .def(
+            "clone_node", [](CutNtk&, const Ntk&, const Node&, const std::vector<Signal>&) -> Signal
+            { throw std::runtime_error("clone_node is not available on immutable view"); }, nb::arg("other"),
+            nb::arg("source"), nb::arg("children"), R"pb(Not available on immutable view.)pb");
 
     using Register = mockturtle::register_t;  // NOLINT(readability-identifier-naming)
     nb::class_<Register>(m, fmt::format("{}Register", network_name).c_str(),
@@ -709,9 +810,9 @@ Args:
         .def(
             "to_edge_list",
             [](const SequentialNtk& ntk, const int64_t regular_weight = 0, const int64_t inverted_weight = 1)
-            { return aigverse::to_edge_list(ntk, regular_weight, inverted_weight); },
-            nb::arg("regular_weight") = 0, nb::arg("inverted_weight") = 1,
-            R"pb(Converts the sequential network to an edge list.)pb", nb::rv_policy::move)
+            { return aigverse::to_edge_list(ntk, regular_weight, inverted_weight); }, nb::arg("regular_weight") = 0,
+            nb::arg("inverted_weight") = 1, R"pb(Converts the sequential network to an edge list.)pb",
+            nb::rv_policy::move)
         .def(
             "pis",
             [](const SequentialNtk& ntk)

--- a/test/networks/test_cut_aig.py
+++ b/test/networks/test_cut_aig.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import copy
+
+from aigverse.networks import Aig, CutAig
+
+
+def test_cut_aig() -> None:
+    """Test CutAig creation and basic properties."""
+    # Create a sample AIG
+    aig = Aig()
+    x1 = aig.create_pi()
+    x2 = aig.create_pi()
+    
+    f1 = aig.create_and(x1, x2)
+    aig.create_po(f1)
+    
+    # Create a cut view
+    leaves = [x1, x2]
+    root = f1
+    cut_aig = CutAig(aig, leaves, root)
+    
+    # Check basic properties
+    assert hasattr(cut_aig, "size")
+    assert hasattr(cut_aig, "num_gates")
+    assert hasattr(cut_aig, "num_pis")
+    assert hasattr(cut_aig, "num_pos")
+    
+    # The cut should have 2 leaves (PIs) and 1 gate
+    assert cut_aig.num_pis == 2
+    assert cut_aig.num_pos == 1
+    assert cut_aig.num_gates == 1
+    assert cut_aig.size == 4  # constant + 2 PIs + 1 gate
+
+
+def test_cut_aig_with_signals() -> None:
+    """Test CutAig creation using signals instead of nodes."""
+    aig = Aig()
+    a = aig.create_pi()
+    b = aig.create_pi()
+    c = aig.create_pi()
+    d = aig.create_pi()
+    
+    f1 = aig.create_and(a, b)
+    f2 = aig.create_and(c, d)
+    f3 = aig.create_xor(f1, f2)
+    aig.create_po(f3)
+    
+    # Create a cut view with all PIs as leaves
+    leaves = [a, b, c, d]
+    root = f3
+    cut_aig = CutAig(aig, leaves, root)
+    
+    # Should contain all 4 PIs as leaves
+    assert cut_aig.num_pis == 4
+    assert cut_aig.num_pos == 1
+    # Should have the XOR gate (decomposed to AND gates internally)
+    assert cut_aig.num_gates == 5
+
+
+def test_cut_aig_iteration() -> None:
+    """Test iteration over nodes in CutAig."""
+    aig = Aig()
+    x1 = aig.create_pi()
+    x2 = aig.create_pi()
+    
+    f1 = aig.create_and(x1, x2)
+    aig.create_po(f1)
+    
+    # Create cut for the output
+    leaves = [x1, x2]
+    root = f1
+    cut_aig = CutAig(aig, leaves, root)
+    
+    # Iterate over all nodes
+    nodes = list(cut_aig.nodes())
+    assert len(nodes) == cut_aig.size
+    assert 0 in nodes  # constant node
+    
+    # Iterate over PIs
+    pis = list(cut_aig.pis())
+    assert len(pis) == cut_aig.num_pis
+    
+    # Iterate over gates
+    gates = list(cut_aig.gates())
+    assert len(gates) == cut_aig.num_gates
+    
+    # Iterate over POs
+    pos = list(cut_aig.pos())
+    assert len(pos) == 1
+
+
+def test_cut_aig_index_mapping() -> None:
+    """Test node to index and index to node mapping in CutAig."""
+    aig = Aig()
+    x1 = aig.create_pi()
+    x2 = aig.create_pi()
+    
+    f1 = aig.create_and(x1, x2)
+    aig.create_po(f1)
+    
+    cut_aig = CutAig(aig, [x1, x2], f1)
+    
+    # Test node_to_index and index_to_node
+    for node in cut_aig.nodes():
+        index = cut_aig.node_to_index(node)
+        recovered_node = cut_aig.index_to_node(index)
+        assert recovered_node == node
+
+
+def test_cut_aig_is_pi() -> None:
+    """Test is_pi method in CutAig."""
+    aig = Aig()
+    x1 = aig.create_pi()
+    x2 = aig.create_pi()
+    
+    f1 = aig.create_and(x1, x2)
+    aig.create_po(f1)
+    
+    cut_aig = CutAig(aig, [x1, x2], f1)
+    
+    # Check that leaf nodes are PIs in the cut
+    assert cut_aig.is_pi(aig.get_node(x1))
+    assert cut_aig.is_pi(aig.get_node(x2))
+    
+    # Check that gate node is not a PI
+    assert not cut_aig.is_pi(aig.get_node(f1))
+
+
+def test_cut_aig_repr() -> None:
+    """Test __repr__ method in CutAig."""
+    aig = Aig()
+    x1 = aig.create_pi()
+    x2 = aig.create_pi()
+    
+    f1 = aig.create_and(x1, x2)
+    aig.create_po(f1)
+    
+    cut_aig = CutAig(aig, [x1, x2], f1)
+    
+    repr_str = repr(cut_aig)
+    assert "CutAig" in repr_str
+    assert "leaves=2" in repr_str
+    assert "gates=1" in repr_str
+
+
+def test_cut_aig_clone_and_copy() -> None:
+    """Test clone, __copy__, and __deepcopy__ in CutAig."""
+    aig = Aig()
+    x1 = aig.create_pi()
+    x2 = aig.create_pi()
+    
+    f1 = aig.create_and(x1, x2)
+    aig.create_po(f1)
+    
+    cut_aig = CutAig(aig, [x1, x2], f1)
+    
+    cloned = cut_aig.clone()
+    shallow = copy.copy(cut_aig)
+    deep = copy.deepcopy(cut_aig)
+    
+    for candidate in (cloned, shallow, deep):
+        assert isinstance(candidate, CutAig)
+        assert candidate.num_pis == 2
+        assert candidate.num_pos == 1
+        assert candidate.num_gates == 1

--- a/test/networks/test_cut_aig.py
+++ b/test/networks/test_cut_aig.py
@@ -214,5 +214,11 @@ def test_cut_aig_immutability() -> None:
         cut_aig.create_lt(x1, x2)
     with pytest.raises(RuntimeError, match="create_le is not available on immutable view"):
         cut_aig.create_le(x1, x2)
+    with pytest.raises(RuntimeError, match="create_nary_and is not available on immutable view"):
+        cut_aig.create_nary_and([x1, x2])
+    with pytest.raises(RuntimeError, match="create_nary_or is not available on immutable view"):
+        cut_aig.create_nary_or([x1, x2])
+    with pytest.raises(RuntimeError, match="create_nary_xor is not available on immutable view"):
+        cut_aig.create_nary_xor([x1, x2])
     with pytest.raises(RuntimeError, match="clone_node is not available on immutable view"):
         cut_aig.clone_node(aig, aig.get_node(x1), [x1])

--- a/test/networks/test_cut_aig.py
+++ b/test/networks/test_cut_aig.py
@@ -184,41 +184,32 @@ def test_cut_aig_immutability() -> None:
     f1 = aig.create_and(x1, x2)
     aig.create_po(f1)
     cut_aig = CutAig(aig, [x1, x2], f1)
-    with pytest.raises(RuntimeError, match="create_pi is not available on immutable view"):
-        cut_aig.create_pi()
-    with pytest.raises(RuntimeError, match="create_po is not available on immutable view"):
-        cut_aig.create_po(f1)
-    with pytest.raises(RuntimeError, match="create_and is not available on immutable view"):
-        cut_aig.create_and(x1, x2)
-    with pytest.raises(RuntimeError, match="create_or is not available on immutable view"):
-        cut_aig.create_or(x1, x2)
-    with pytest.raises(RuntimeError, match="create_xor is not available on immutable view"):
-        cut_aig.create_xor(x1, x2)
-    with pytest.raises(RuntimeError, match="create_not is not available on immutable view"):
-        cut_aig.create_not(x1)
-    with pytest.raises(RuntimeError, match="create_nand is not available on immutable view"):
-        cut_aig.create_nand(x1, x2)
-    with pytest.raises(RuntimeError, match="create_nor is not available on immutable view"):
-        cut_aig.create_nor(x1, x2)
-    with pytest.raises(RuntimeError, match="create_xnor is not available on immutable view"):
-        cut_aig.create_xnor(x1, x2)
-    with pytest.raises(RuntimeError, match="create_buf is not available on immutable view"):
-        cut_aig.create_buf(x1)
-    with pytest.raises(RuntimeError, match="create_maj is not available on immutable view"):
-        cut_aig.create_maj(x1, x2, f1)
-    with pytest.raises(RuntimeError, match="create_ite is not available on immutable view"):
-        cut_aig.create_ite(x1, x2, f1)
-    with pytest.raises(RuntimeError, match="create_xor3 is not available on immutable view"):
-        cut_aig.create_xor3(x1, x2, f1)
-    with pytest.raises(RuntimeError, match="create_lt is not available on immutable view"):
-        cut_aig.create_lt(x1, x2)
-    with pytest.raises(RuntimeError, match="create_le is not available on immutable view"):
-        cut_aig.create_le(x1, x2)
-    with pytest.raises(RuntimeError, match="create_nary_and is not available on immutable view"):
-        cut_aig.create_nary_and([x1, x2])
-    with pytest.raises(RuntimeError, match="create_nary_or is not available on immutable view"):
-        cut_aig.create_nary_or([x1, x2])
-    with pytest.raises(RuntimeError, match="create_nary_xor is not available on immutable view"):
-        cut_aig.create_nary_xor([x1, x2])
-    with pytest.raises(RuntimeError, match="clone_node is not available on immutable view"):
-        cut_aig.clone_node(aig, aig.get_node(x1), [x1])
+
+    cases = [
+        ("create_pi", ()),
+        ("create_po", (f1,)),
+        ("create_and", (x1, x2)),
+        ("create_or", (x1, x2)),
+        ("create_xor", (x1, x2)),
+        ("create_not", (x1,)),
+        ("create_nand", (x1, x2)),
+        ("create_nor", (x1, x2)),
+        ("create_xnor", (x1, x2)),
+        ("create_buf", (x1,)),
+        ("create_maj", (x1, x2, f1)),
+        ("create_ite", (x1, x2, f1)),
+        ("create_xor3", (x1, x2, f1)),
+        ("create_lt", (x1, x2)),
+        ("create_le", (x1, x2)),
+        ("create_nary_and", ([x1, x2],)),
+        ("create_nary_or", ([x1, x2],)),
+        ("create_nary_xor", ([x1, x2],)),
+        ("clone_node", (aig, aig.get_node(x1), [x1])),
+    ]
+
+    for method_name, args in cases:
+        with pytest.raises(
+            RuntimeError,
+            match=rf"{method_name} is not available on immutable view",
+        ):
+            getattr(cut_aig, method_name)(*args)

--- a/test/networks/test_cut_aig.py
+++ b/test/networks/test_cut_aig.py
@@ -16,14 +16,18 @@ def test_cut_aig() -> None:
     f1 = aig.create_and(x1, x2)
     aig.create_po(f1)
 
+    # Create a cut view
     leaves = [x1, x2]
     root = f1
     cut_aig = CutAig(aig, leaves, root)
 
+    # Check basic properties
     assert hasattr(cut_aig, "size")
     assert hasattr(cut_aig, "num_gates")
     assert hasattr(cut_aig, "num_pis")
     assert hasattr(cut_aig, "num_pos")
+
+    # The cut should have 2 leaves (PIs) and 1 gate
     assert cut_aig.num_pis == 2
     assert cut_aig.num_pos == 1
     assert cut_aig.num_gates == 1
@@ -42,9 +46,12 @@ def test_cut_aig_with_signals() -> None:
     f3 = aig.create_xor(f1, f2)
     aig.create_po(f3)
 
+    # Create a cut view with all PIs as leaves
     leaves = [a, b, c, d]
     root = f3
     cut_aig = CutAig(aig, leaves, root)
+
+    # Should contain all 4 PIs as leaves
     assert cut_aig.num_pis == 4
     assert cut_aig.num_gates == 5
 
@@ -58,18 +65,26 @@ def test_cut_aig_iteration() -> None:
     f1 = aig.create_and(x1, x2)
     aig.create_po(f1)
 
+    # Create cut for the output
     leaves = [x1, x2]
     root = f1
     cut_aig = CutAig(aig, leaves, root)
-    nodes = cut_aig.nodes()
-    assert len(nodes) == cut_aig.size
-    assert 0 in nodes
 
-    pis = cut_aig.pis()
+    # Iterate over all nodes
+    nodes = list(cut_aig.nodes())
+    assert len(nodes) == cut_aig.size
+    assert 0 in nodes  # constant node
+
+    # Iterate over PIs
+    pis = list(cut_aig.pis())
     assert len(pis) == cut_aig.num_pis
-    gates = cut_aig.gates()
+
+    # Iterate over gates
+    gates = list(cut_aig.gates())
     assert len(gates) == cut_aig.num_gates
-    pos = cut_aig.pos()
+
+    # Iterate over POs
+    pos = list(cut_aig.pos())
     assert len(pos) == 1
 
 
@@ -84,6 +99,7 @@ def test_cut_aig_index_mapping() -> None:
 
     cut_aig = CutAig(aig, [x1, x2], f1)
 
+    # Test node_to_index and index_to_node
     for node in cut_aig.nodes():
         index = cut_aig.node_to_index(node)
         recovered_node = cut_aig.index_to_node(index)
@@ -99,8 +115,12 @@ def test_cut_aig_is_pi() -> None:
     aig.create_po(f1)
 
     cut_aig = CutAig(aig, [x1, x2], f1)
+
+    # Check that leaf nodes are PIs in the cut
     assert cut_aig.is_pi(aig.get_node(x1))
     assert cut_aig.is_pi(aig.get_node(x2))
+
+    # Check that gate node is not a PI
     assert not cut_aig.is_pi(aig.get_node(f1))
 
 

--- a/test/networks/test_cut_aig.py
+++ b/test/networks/test_cut_aig.py
@@ -2,35 +2,31 @@ from __future__ import annotations
 
 import copy
 
+import pytest
+
 from aigverse.networks import Aig, CutAig
 
 
 def test_cut_aig() -> None:
     """Test CutAig creation and basic properties."""
-    # Create a sample AIG
     aig = Aig()
     x1 = aig.create_pi()
     x2 = aig.create_pi()
-    
+
     f1 = aig.create_and(x1, x2)
     aig.create_po(f1)
-    
-    # Create a cut view
+
     leaves = [x1, x2]
     root = f1
     cut_aig = CutAig(aig, leaves, root)
-    
-    # Check basic properties
+
     assert hasattr(cut_aig, "size")
     assert hasattr(cut_aig, "num_gates")
     assert hasattr(cut_aig, "num_pis")
     assert hasattr(cut_aig, "num_pos")
-    
-    # The cut should have 2 leaves (PIs) and 1 gate
     assert cut_aig.num_pis == 2
     assert cut_aig.num_pos == 1
     assert cut_aig.num_gates == 1
-    assert cut_aig.size == 4  # constant + 2 PIs + 1 gate
 
 
 def test_cut_aig_with_signals() -> None:
@@ -40,21 +36,16 @@ def test_cut_aig_with_signals() -> None:
     b = aig.create_pi()
     c = aig.create_pi()
     d = aig.create_pi()
-    
+
     f1 = aig.create_and(a, b)
     f2 = aig.create_and(c, d)
     f3 = aig.create_xor(f1, f2)
     aig.create_po(f3)
-    
-    # Create a cut view with all PIs as leaves
+
     leaves = [a, b, c, d]
     root = f3
     cut_aig = CutAig(aig, leaves, root)
-    
-    # Should contain all 4 PIs as leaves
     assert cut_aig.num_pis == 4
-    assert cut_aig.num_pos == 1
-    # Should have the XOR gate (decomposed to AND gates internally)
     assert cut_aig.num_gates == 5
 
 
@@ -63,30 +54,22 @@ def test_cut_aig_iteration() -> None:
     aig = Aig()
     x1 = aig.create_pi()
     x2 = aig.create_pi()
-    
+
     f1 = aig.create_and(x1, x2)
     aig.create_po(f1)
-    
-    # Create cut for the output
+
     leaves = [x1, x2]
     root = f1
     cut_aig = CutAig(aig, leaves, root)
-    
-    # Iterate over all nodes
-    nodes = list(cut_aig.nodes())
+    nodes = cut_aig.nodes()
     assert len(nodes) == cut_aig.size
-    assert 0 in nodes  # constant node
-    
-    # Iterate over PIs
-    pis = list(cut_aig.pis())
+    assert 0 in nodes
+
+    pis = cut_aig.pis()
     assert len(pis) == cut_aig.num_pis
-    
-    # Iterate over gates
-    gates = list(cut_aig.gates())
+    gates = cut_aig.gates()
     assert len(gates) == cut_aig.num_gates
-    
-    # Iterate over POs
-    pos = list(cut_aig.pos())
+    pos = cut_aig.pos()
     assert len(pos) == 1
 
 
@@ -95,13 +78,12 @@ def test_cut_aig_index_mapping() -> None:
     aig = Aig()
     x1 = aig.create_pi()
     x2 = aig.create_pi()
-    
+
     f1 = aig.create_and(x1, x2)
     aig.create_po(f1)
-    
+
     cut_aig = CutAig(aig, [x1, x2], f1)
-    
-    # Test node_to_index and index_to_node
+
     for node in cut_aig.nodes():
         index = cut_aig.node_to_index(node)
         recovered_node = cut_aig.index_to_node(index)
@@ -113,17 +95,12 @@ def test_cut_aig_is_pi() -> None:
     aig = Aig()
     x1 = aig.create_pi()
     x2 = aig.create_pi()
-    
     f1 = aig.create_and(x1, x2)
     aig.create_po(f1)
-    
+
     cut_aig = CutAig(aig, [x1, x2], f1)
-    
-    # Check that leaf nodes are PIs in the cut
     assert cut_aig.is_pi(aig.get_node(x1))
     assert cut_aig.is_pi(aig.get_node(x2))
-    
-    # Check that gate node is not a PI
     assert not cut_aig.is_pi(aig.get_node(f1))
 
 
@@ -132,12 +109,10 @@ def test_cut_aig_repr() -> None:
     aig = Aig()
     x1 = aig.create_pi()
     x2 = aig.create_pi()
-    
     f1 = aig.create_and(x1, x2)
     aig.create_po(f1)
-    
+
     cut_aig = CutAig(aig, [x1, x2], f1)
-    
     repr_str = repr(cut_aig)
     assert "CutAig" in repr_str
     assert "leaves=2" in repr_str
@@ -149,18 +124,75 @@ def test_cut_aig_clone_and_copy() -> None:
     aig = Aig()
     x1 = aig.create_pi()
     x2 = aig.create_pi()
-    
     f1 = aig.create_and(x1, x2)
     aig.create_po(f1)
-    
+
     cut_aig = CutAig(aig, [x1, x2], f1)
-    
+
     cloned = cut_aig.clone()
     shallow = copy.copy(cut_aig)
     deep = copy.deepcopy(cut_aig)
-    
     for candidate in (cloned, shallow, deep):
         assert isinstance(candidate, CutAig)
         assert candidate.num_pis == 2
         assert candidate.num_pos == 1
         assert candidate.num_gates == 1
+
+
+def test_cut_aig_with_nodes() -> None:
+    """Test CutAig creation using nodes instead of signals."""
+    aig = Aig()
+    x1 = aig.create_pi()
+    x2 = aig.create_pi()
+    f1 = aig.create_and(x1, x2)
+    aig.create_po(f1)
+
+    leaves = [aig.get_node(x1), aig.get_node(x2)]
+    root = f1
+    cut_aig = CutAig(aig, leaves, root)
+    assert cut_aig.num_pis == 2
+    assert cut_aig.num_pos == 1
+    assert cut_aig.num_gates == 1
+    assert cut_aig.size == 4
+
+
+def test_cut_aig_immutability() -> None:
+    """Test that network-modifying methods raise RuntimeError on CutAig."""
+    aig = Aig()
+    x1 = aig.create_pi()
+    x2 = aig.create_pi()
+    f1 = aig.create_and(x1, x2)
+    aig.create_po(f1)
+    cut_aig = CutAig(aig, [x1, x2], f1)
+    with pytest.raises(RuntimeError, match="create_pi is not available on immutable view"):
+        cut_aig.create_pi()
+    with pytest.raises(RuntimeError, match="create_po is not available on immutable view"):
+        cut_aig.create_po(f1)
+    with pytest.raises(RuntimeError, match="create_and is not available on immutable view"):
+        cut_aig.create_and(x1, x2)
+    with pytest.raises(RuntimeError, match="create_or is not available on immutable view"):
+        cut_aig.create_or(x1, x2)
+    with pytest.raises(RuntimeError, match="create_xor is not available on immutable view"):
+        cut_aig.create_xor(x1, x2)
+    with pytest.raises(RuntimeError, match="create_not is not available on immutable view"):
+        cut_aig.create_not(x1)
+    with pytest.raises(RuntimeError, match="create_nand is not available on immutable view"):
+        cut_aig.create_nand(x1, x2)
+    with pytest.raises(RuntimeError, match="create_nor is not available on immutable view"):
+        cut_aig.create_nor(x1, x2)
+    with pytest.raises(RuntimeError, match="create_xnor is not available on immutable view"):
+        cut_aig.create_xnor(x1, x2)
+    with pytest.raises(RuntimeError, match="create_buf is not available on immutable view"):
+        cut_aig.create_buf(x1)
+    with pytest.raises(RuntimeError, match="create_maj is not available on immutable view"):
+        cut_aig.create_maj(x1, x2, f1)
+    with pytest.raises(RuntimeError, match="create_ite is not available on immutable view"):
+        cut_aig.create_ite(x1, x2, f1)
+    with pytest.raises(RuntimeError, match="create_xor3 is not available on immutable view"):
+        cut_aig.create_xor3(x1, x2, f1)
+    with pytest.raises(RuntimeError, match="create_lt is not available on immutable view"):
+        cut_aig.create_lt(x1, x2)
+    with pytest.raises(RuntimeError, match="create_le is not available on immutable view"):
+        cut_aig.create_le(x1, x2)
+    with pytest.raises(RuntimeError, match="clone_node is not available on immutable view"):
+        cut_aig.clone_node(aig, aig.get_node(x1), [x1])


### PR DESCRIPTION
## Description

Expose cut view (and maybe in the future window view) is convenient for developers to do structure level change. 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Immutable cut-view class for logic networks: construct from leaves+root, read-only inspection (nodes, gates, pis/pos, counts), copy/clone support, and informative string representation. Mutating operations raise runtime errors on cut views.
* **Documentation**
  * New tutorial subsection with ipython examples and validity notes for cut views.
* **Tests**
  * End-to-end tests covering counts, iteration, index↔node roundtrips, repr, copy semantics, and immutability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->