### PR TITLE
:bug: Fix collapsing duplicate POs in `to_edge_list`

### DIFF
--- a/src/aigverse/networks/edge_list.hpp
+++ b/src/aigverse/networks/edge_list.hpp
@@ -148,10 +148,11 @@ template <typename Ntk>
         });
 
     // primary outputs
+    auto po_target = ntk.size();
     ntk.foreach_po(
-        [&ntk, regular_weight, inverted_weight, &el](const auto& po)
+        [&ntk, regular_weight, inverted_weight, &el, &po_target](const auto& po)
         {
-            el.edges.emplace_back(ntk.node_to_index(ntk.get_node(po)), ntk.size() + ntk.po_index(po),
+            el.edges.emplace_back(ntk.node_to_index(ntk.get_node(po)), po_target++,
                                   ntk.is_complemented(po) ? inverted_weight : regular_weight);
         });
 

--- a/test/adapters/test_edge_list.py
+++ b/test/adapters/test_edge_list.py
@@ -148,6 +148,18 @@ def test_constant_node_aig_to_edge_list(two_pi_and_two_po_aig: Aig) -> None:
     assert AigEdge(3, 5, 7) in edge_list  # AND gate to PO
 
 
+def test_duplicate_constant_outputs_aig_to_edge_list() -> None:
+    aig = Aig()
+    const0 = aig.get_constant(False)
+    aig.create_po(const0)
+    aig.create_po(const0)
+
+    edge_list = aig.to_edge_list()
+
+    assert len(edge_list) == 2
+    assert [(edge.source, edge.target, edge.weight) for edge in edge_list] == [(0, 1, 0), (0, 2, 0)]
+
+
 def test_medium_aig_to_edge_list(medium_structured_aig: Aig) -> None:
     aig = medium_structured_aig
 

--- a/test/adapters/test_networkx.py
+++ b/test/adapters/test_networkx.py
@@ -239,6 +239,27 @@ class TestNetworkxAdapter:
         assert "output_and" in output_names_list
 
     @staticmethod
+    def test_to_networkx_duplicate_constant_outputs() -> None:
+        """Test that duplicate constant outputs receive distinct synthetic PO nodes."""
+        from aigverse.networks import NamedAig
+
+        aig = NamedAig()
+        const0 = aig.get_constant(False)
+        aig.create_po(const0, "po0")
+        aig.create_po(const0, "po1")
+
+        g = aig.to_networkx(levels=True, fanouts=True)
+
+        po_nodes = sorted(node for node, data in g.nodes(data=True) if tuple(data["type"].tolist()) == (0, 0, 0, 1))
+
+        assert po_nodes == [aig.size, aig.size + 1]
+        assert g.number_of_edges() == 2
+        assert [list(g.predecessors(node)) for node in po_nodes] == [[0], [0]]
+        assert [node for node in po_nodes if g.degree[node] == 0] == []
+        assert g.edges[0, aig.size]["output_name"] == "po0"
+        assert g.edges[0, aig.size + 1]["output_name"] == "po1"
+
+    @staticmethod
     def test_to_networkx_without_names(simple_aig: Aig) -> None:
         """Test that regular Aig objects don't have name attributes."""
         g = simple_aig.to_networkx()


### PR DESCRIPTION
## Description

This pull request addresses the handling of duplicate constant outputs in AIG (And-Inverter Graph) to edge list and NetworkX conversions, ensuring that each output receives a distinct synthetic primary output (PO) node. The changes improve both the implementation and test coverage for these scenarios.

**Edge List and NetworkX Output Handling:**

* Ensures that when multiple POs are created from the same constant node, each receives a unique synthetic PO node in the edge list representation (`src/aigverse/networks/edge_list.hpp`).
* Updates the NetworkX conversion to assign distinct synthetic PO nodes for duplicate constant outputs, and verifies that output names are correctly attached to edges (`test/adapters/test_networkx.py`).

**Test Coverage Improvements:**

* Adds a test for duplicate constant outputs in the edge list conversion to confirm that two distinct edges are created with unique targets (`test/adapters/test_edge_list.py`).
* Adds a test for duplicate constant outputs in the NetworkX conversion, checking for distinct PO nodes, correct edge count, and proper output name assignment (`test/adapters/test_networkx.py`).

Fixes #357 <!--- Replace (issue) with the issue number that is fixed by this pull request. -->

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved edge list construction to correctly handle networks with duplicate constant outputs.

* **Tests**
  * Added test coverage for edge list generation with duplicate constant outputs.
  * Added test coverage for NetworkX graph conversion with duplicate constant outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcelwa/aigverse/pull/358)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->