### PR TITLE
:arrow_up: Update mockturtle to latest mnt commit

### DIFF
--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -42,20 +42,20 @@ find_package(nanobind CONFIG REQUIRED PATHS "${nanobind_ROOT}" NO_DEFAULT_PATH)
 
 # Fetch mockturtle library
 set(MOCKTURTLE_REV
-    "1a91a7495560ae2e510316a32ca15651756dfebc"
+    "d7d833f96deccb4b73f04acb7d31af95a072956d"
     CACHE STRING "mockturtle identifier (tag, branch or commit hash)")
 set(MOCKTURTLE_REPO_OWNER
     "marcelwa"
     CACHE STRING "mockturtle repository owner (change when using a fork)")
 
 # Configure mockturtle options before fetching
-set(MOCKTURTLE_EXAMPLES
+set(MOCKTURTLE_BUILD_EXAMPLES
     OFF
     CACHE BOOL "" FORCE)
-set(MOCKTURTLE_EXPERIMENTS
+set(MOCKTURTLE_BUILD_EXPERIMENTS
     OFF
     CACHE BOOL "" FORCE)
-set(MOCKTURTLE_TEST
+set(MOCKTURTLE_BUILD_TESTS
     OFF
     CACHE BOOL "" FORCE)
 # Ensure all static libraries built by mockturtle are position-independent This

--- a/src/aigverse/networks/index_list.cpp
+++ b/src/aigverse/networks/index_list.cpp
@@ -8,7 +8,7 @@
 
 #include <fmt/format.h>
 #include <fmt/ranges.h>  // NOLINT(misc-include-cleaner)
-#include <mockturtle/utils/index_list.hpp>
+#include <mockturtle/utils/index_list/index_list.hpp>
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>  // NOLINT(misc-include-cleaner)
 #include <nanobind/stl/tuple.h>   // NOLINT(misc-include-cleaner)

--- a/src/aigverse/networks/index_list.hpp
+++ b/src/aigverse/networks/index_list.hpp
@@ -8,7 +8,7 @@
 
 #include <fmt/format.h>
 #include <fmt/ranges.h>  // NOLINT(misc-include-cleaner)
-#include <mockturtle/utils/index_list.hpp>
+#include <mockturtle/utils/index_list/index_list.hpp>
 
 #include <cstdint>
 #include <tuple>

--- a/src/aigverse/types.hpp
+++ b/src/aigverse/types.hpp
@@ -7,7 +7,7 @@
 #include <kitty/dynamic_truth_table.hpp>
 #include <mockturtle/networks/aig.hpp>
 #include <mockturtle/networks/sequential.hpp>
-#include <mockturtle/utils/index_list.hpp>
+#include <mockturtle/utils/index_list/index_list.hpp>
 #include <mockturtle/views/depth_view.hpp>
 #include <mockturtle/views/fanout_view.hpp>
 #include <mockturtle/views/names_view.hpp>

--- a/src/aigverse/utils/truth_table.cpp
+++ b/src/aigverse/utils/truth_table.cpp
@@ -444,7 +444,9 @@ Raises:
             "create_majority", [](aigverse::truth_table& self) { kitty::create_majority(self); },
             R"pb(Fills the truth table with the majority function.)pb")
         .def("clear", &kitty::clear<aigverse::truth_table>, R"pb(Clears all bits to ``0``.)pb")
-        .def("count_ones", &kitty::count_ones<aigverse::truth_table>, R"pb(Returns the number of set bits.)pb")
+        .def(
+            "count_ones", [](const aigverse::truth_table& self) { return kitty::count_ones(self); },
+            R"pb(Returns the number of set bits.)pb")
         .def("count_zeroes", &kitty::count_zeros<aigverse::truth_table>, R"pb(Returns the number of cleared bits.)pb")
         .def(
             "is_const0", [](const aigverse::truth_table& self) { return kitty::is_const0(self); },


### PR DESCRIPTION
## Description

Updates the `mockturtle` dependency to the latest commit on the `mnt` branch of [marcelwa/mockturtle](https://github.com/marcelwa/mockturtle), after merging upstream [lsils/mockturtle](https://github.com/lsils/mockturtle) `master` into `mnt` (pulling in 28 upstream commits).

Two breaking upstream changes needed accompanying fixes to keep aigverse building:

- The CMake options `MOCKTURTLE_EXAMPLES` / `MOCKTURTLE_EXPERIMENTS` / `MOCKTURTLE_TEST` were renamed upstream to `MOCKTURTLE_BUILD_EXAMPLES` / `MOCKTURTLE_BUILD_EXPERIMENTS` / `MOCKTURTLE_BUILD_TESTS`; `cmake/ExternalDependencies.cmake` now sets the new names.
- `mockturtle/utils/index_list.hpp` moved to `mockturtle/utils/index_list/index_list.hpp` upstream; updated the three `#include`s in aigverse that referenced the old path.

CI workflow files in the mockturtle fork (`linux.yml`, `macos.yml`, `windows.yml`) had merge conflicts against upstream's older, unmodernized CI; resolved by keeping the fork's existing modernized workflows since those are intentional fork-local customizations, not something to regress.

Verified locally with a full CMake configure + build of all five `aigverse-*` extension targets against the updated ref.

I also audited the rest of `cmake/` for other outdated dependencies — `mockturtle` (via `FetchContent`) is the only dependency declared there; everything else (GitHub Actions, pre-commit hooks) is already kept current by Renovate, so there was nothing else to bump in this PR.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the bundled logic-network library to a newer revision.
  * Disabled building optional examples, experiments, and tests for the bundled dependency.
  * Updated internal references to the dependency’s reorganized index-list utilities, preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->