### PR TITLE
👷 Add Zizmor security scanning workflow

### DIFF
--- a/.github/workflows/aigverse-codeql.yml
+++ b/.github/workflows/aigverse-codeql.yml
@@ -93,10 +93,14 @@ jobs:
 
       - name: Configure CMake
         if: matrix.language == 'cpp'
+        # kept absolute (not simplified to a relative path) because CMake caches this value and
+        # nanobind's build-time custom commands may invoke it from other working directories
+        env:
+          WORKSPACE: ${{ github.workspace }}
         run: >
           cmake -S . -B build
           -DCMAKE_BUILD_TYPE=Debug
-          -DPython_EXECUTABLE=.venv/bin/python
+          -DPython_EXECUTABLE="$WORKSPACE/.venv/bin/python"
 
       - name: Build
         if: matrix.language == 'cpp'

--- a/.github/workflows/aigverse-codeql.yml
+++ b/.github/workflows/aigverse-codeql.yml
@@ -31,14 +31,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   analyze:
     name: ${{matrix.emoji}} Analysis
     runs-on: ubuntu-latest
     permissions:
-      actions: read
-      contents: read
-      security-events: write
+      actions: read # required by github/codeql-action/init to check the workflow run
+      contents: read # required to check out the repository
+      security-events: write # required to upload the SARIF results
 
     strategy:
       fail-fast: false
@@ -57,6 +59,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
@@ -66,7 +69,7 @@ jobs:
           max-size: 10G
 
       - name: Set up mold as linker
-        uses: rui314/setup-mold@v1
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
@@ -93,7 +96,7 @@ jobs:
         run: >
           cmake -S . -B build
           -DCMAKE_BUILD_TYPE=Debug
-          -DPython_EXECUTABLE=${{ github.workspace }}/.venv/bin/python
+          -DPython_EXECUTABLE=.venv/bin/python
 
       - name: Build
         if: matrix.language == 'cpp'

--- a/.github/workflows/aigverse-pypi-deployment.yml
+++ b/.github/workflows/aigverse-pypi-deployment.yml
@@ -38,10 +38,7 @@ on:
       - ".github/workflows/aigverse-pypi-deployment.yml"
   workflow_dispatch:
 
-permissions:
-  attestations: write
-  contents: read
-  id-token: write
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -51,17 +48,19 @@ jobs:
   build_sdist:
     name: 📦 Build Source Distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # required to check out the repository
     steps:
       - name: Clone Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
-          enable-cache: true
-          save-cache: ${{ github.ref == 'refs/heads/main' }}
+          enable-cache: false
 
       - name: Build sdist
         run: uv build --sdist
@@ -79,6 +78,8 @@ jobs:
   build_wheels:
     name: 🛞 Wheels for ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: read # required to check out the repository
 
     strategy:
       fail-fast: false
@@ -89,6 +90,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up MSVC development environment (Windows only)
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
@@ -102,13 +104,12 @@ jobs:
 
       - if: runner.os == 'Linux'
         name: Setup mold
-        uses: rui314/setup-mold@v1
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
-          enable-cache: true
-          save-cache: ${{ github.ref == 'refs/heads/main' }}
+          enable-cache: false
 
       - name: Build wheels
         uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3
@@ -125,6 +126,9 @@ jobs:
     runs-on: ubuntu-latest
     name: 🚀 Publish to PyPI
     if: github.event_name == 'release' && github.event.action == 'published'
+    permissions:
+      attestations: write # required to publish the build provenance attestation
+      id-token: write # required by actions/attest-build-provenance and PyPI trusted publishing
     environment:
       name: pypi
       url: https://pypi.org/p/aigverse

--- a/.github/workflows/aigverse-python-tests.yml
+++ b/.github/workflows/aigverse-python-tests.yml
@@ -35,6 +35,8 @@ on:
       - "uv.lock"
       - ".github/workflows/aigverse-python-tests.yml"
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -44,9 +46,13 @@ jobs:
     name: 🚨 Lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read # required to check out the repository
     steps:
       - name: Clone repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
@@ -72,6 +78,8 @@ jobs:
   python-tests:
     name: 🐍 ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: read # required to check out the repository
     strategy:
       fail-fast: false
       matrix:
@@ -79,6 +87,8 @@ jobs:
     steps:
       - name: Clone Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
@@ -89,7 +99,7 @@ jobs:
 
       - if: runner.os == 'Linux'
         name: Setup mold
-        uses: rui314/setup-mold@v1
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -48,10 +48,14 @@ jobs:
         run: uv sync --only-group build --no-install-project
 
       - name: Generate compilation database
+        # kept absolute (not simplified to a relative path) because CMake caches this value and
+        # nanobind's build-time custom commands may invoke it from other working directories
+        env:
+          WORKSPACE: ${{ github.workspace }}
         run: >
           cmake -B build -S .
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-          -DPython_EXECUTABLE=.venv/bin/python
+          -DPython_EXECUTABLE="$WORKSPACE/.venv/bin/python"
 
       - name: Run clang-tidy
         id: linter

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -18,20 +18,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   clangtidy:
     runs-on: ubuntu-latest
     name: 🚨 Clang-Tidy
+    permissions:
+      contents: read
+      pull-requests: write # required to post/update the clang-tidy thread comment on the PR
 
     steps:
       - name: Clone Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake libpython3-dev
@@ -49,7 +51,7 @@ jobs:
         run: >
           cmake -B build -S .
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-          -DPython_EXECUTABLE=${{ github.workspace }}/.venv/bin/python
+          -DPython_EXECUTABLE=.venv/bin/python
 
       - name: Run clang-tidy
         id: linter

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,38 @@
+name: 🌈 • Zizmor
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/**"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/**"
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: 🌈 Zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # required to upload results to the code scanning API
+
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        with:
+          persona: pedantic
+          # fork PRs get a read-only GITHUB_TOKEN and cannot upload SARIF to code scanning
+          advanced-security: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}


### PR DESCRIPTION
## Description

Adds [Zizmor](https://docs.zizmor.sh/) — a static analyzer for GitHub Actions workflows — using
`zizmorcore/zizmor-action` with the `pedantic` persona, uploading findings to the code scanning API.
Same pattern just set up in cda-tum/fiction.

The SARIF upload (`advanced-security`) is disabled for pull requests originating from forks, since those
get a read-only `GITHUB_TOKEN` and would otherwise fail on the `security-events: write` permission the
upload needs.

**Update:** this PR now also fixes every finding Zizmor surfaces against the existing workflows (~24,
across `template-injection`, `excessive-permissions`, `artipacked`, `cache-poisoning`, and `unpinned-uses`),
rather than leaving them for follow-up:
- Scoped `permissions:` blocks to what each job actually needs, instead of relying on the broad default
  (workflow-level `permissions: {}` plus a minimal per-job grant)
- `persist-credentials: false` on all checkouts (none of these push back to the repo)
- Pinned `rui314/setup-mold` to a commit SHA instead of the mutable `@v1` tag, everywhere it's used
- Disabled `setup-uv`'s build cache in the PyPI packaging workflow, closing a cache-poisoning path into
  published artifacts, and dropped the resulting dead `save-cache` input
- Dropped the redundant `github.workspace` prefix from a couple of CMake `-S` invocations, since those
  steps already run from there
- Kept `-DPython_EXECUTABLE=${{ github.workspace }}/.venv/bin/python` absolute (routed through an `env`
  var instead of simplified to a relative path like the `-S` cases above) — CMake caches this value, and
  nanobind's build-time custom commands may invoke it from a working directory other than where configure
  ran, where a relative path wouldn't resolve. Caught by CodeRabbit during review of the first pass at
  this fix, which had simplified it to a relative path
- On the Clang-Tidy Review workflow, which triggers on both `push` and `pull_request`: dropped the
  `contents: write` grant since this repo's `thread-comments` config only ever activates on non-fork pull
  requests (needs `pull-requests: write`), never on the push path that would need `contents: write`

Every workflow is individually clean under `zizmor --persona pedantic` now.

Fixes # (issue)

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSn4o2B7uBAa4EXnN3dJTW