### PR TITLE
🐛 Fix ASCII AIGER parsing for constant outputs

### DIFF
--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -42,7 +42,7 @@ find_package(nanobind CONFIG REQUIRED PATHS "${nanobind_ROOT}" NO_DEFAULT_PATH)
 
 # Fetch mockturtle library
 set(MOCKTURTLE_REV
-    "d7d833f96deccb4b73f04acb7d31af95a072956d"
+    "8f0322e370933fe3260127873c3fd74a551786ef"
     CACHE STRING "mockturtle identifier (tag, branch or commit hash)")
 set(MOCKTURTLE_REPO_OWNER
     "marcelwa"

--- a/test/inout/test_read_aiger.py
+++ b/test/inout/test_read_aiger.py
@@ -168,9 +168,6 @@ def test_read_ascii_aiger_constant_outputs(tmp_path: Path) -> None:
 
     Args:
         tmp_path: Pytest temporary path fixture.
-
-    Returns:
-        None
     """
     aag_file = tmp_path / "const_out.aag"
     aag_file.write_text("aag 0 0 0 2 0\n0\n1\n")

--- a/test/inout/test_read_aiger.py
+++ b/test/inout/test_read_aiger.py
@@ -161,3 +161,19 @@ def test_read_sequential_aiger():
     assert saig.ro_at(0) == ro_node
     assert saig.ri_at(0) == ri_signal
     assert saig.ri_to_ro(ri_signal) == ro_node
+
+
+def test_read_ascii_aiger_constant_outputs(tmp_path: Path):
+    """Test reading ASCII AIGER files with constant outputs (literal 0 or 1)."""
+    aag_file = tmp_path / "const_out.aag"
+    aag_file.write_text("aag 0 0 0 2 0\n0\n1\n")
+
+    aig = read_ascii_aiger_into_aig(aag_file)
+    assert aig.num_pis == 0
+    assert aig.num_pos == 2
+    assert aig.num_gates == 0
+
+    saig = read_ascii_aiger_into_sequential_aig(aag_file)
+    assert saig.num_pis == 0
+    assert saig.num_pos == 2
+    assert saig.num_gates == 0

--- a/test/inout/test_read_aiger.py
+++ b/test/inout/test_read_aiger.py
@@ -163,8 +163,15 @@ def test_read_sequential_aiger():
     assert saig.ri_to_ro(ri_signal) == ro_node
 
 
-def test_read_ascii_aiger_constant_outputs(tmp_path: Path):
-    """Test reading ASCII AIGER files with constant outputs (literal 0 or 1)."""
+def test_read_ascii_aiger_constant_outputs(tmp_path: Path) -> None:
+    """Test reading ASCII AIGER files with constant outputs (literal 0 or 1).
+
+    Args:
+        tmp_path: Pytest temporary path fixture.
+
+    Returns:
+        None
+    """
     aag_file = tmp_path / "const_out.aag"
     aag_file.write_text("aag 0 0 0 2 0\n0\n1\n")
 


### PR DESCRIPTION
Fixes #386.

### Summary
This PR fixes an issue where reading ASCII AIGER files () with constant outputs (literal `0` for constant FALSE or literal `1` for constant TRUE) failed with `RuntimeError: Error reading ASCII AIGER file`.

### Root Cause & Fix
- Upstream `lorina` (`lib/lorina/lorina/aiger.hpp` in `mockturtle`) hardcoded a lower bound check of `2` for output literals (`check_index_validity(lit, 2, 2 * _m + 1)`), rejecting literal 0 and 1 output definitions.
- Pushed fix to [marcelwa/mockturtle@8f0322e](https://github.com/marcelwa/mockturtle/commit/8f0322e370933fe3260127873c3fd74a551786ef) changing the lower bound for output literals to `0`.
- Updated `MOCKTURTLE_REV` in `cmake/ExternalDependencies.cmake` to `8f0322e370933fe3260127873c3fd74a551786ef`.
- Added unit test `test_read_ascii_aiger_constant_outputs` in `test/inout/test_read_aiger.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and validation of ASCII AIGER files containing constant outputs.
  * Ensured constant-output files are correctly represented with no inputs or gates.

* **Chores**
  * Updated an internal supporting component to a newer revision for continued compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->