### PR TITLE
🔧 Pin validate-pyproject-schema-store below broken 2026.07.20 release

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -62,6 +62,13 @@
         "patch"
       ],
       automerge: true
+    },
+    {
+      description: "2026.07.20 crashes validate-pyproject with UnboundLocalError on any [tool.uv] table; unpin once fixed upstream (see GalacticDynamics/quax-blocks#55)",
+      matchPackageNames: [
+        "henryiii/validate-pyproject-schema-store"
+      ],
+      allowedVersions: "<= 2026.07.17"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- `henryiii/validate-pyproject-schema-store` `2026.07.20` crashes `validate-pyproject` (`UnboundLocalError: cannot access local variable 'data_keys'`) on any `pyproject.toml` containing a `[tool.uv]` table, which this repo has. This broke pre-commit.ci on #396.
- Bug is in the generated `uv.json` schema validator upstream, not in this repo — already reported and repro'd identically in [GalacticDynamics/quax-blocks#55](https://github.com/GalacticDynamics/quax-blocks/issues/55). No fix released yet as of 2026-07-25.
- Adds a Renovate `packageRule` capping `allowedVersions` at `2026.07.17` for this dependency so Renovate stops re-proposing the broken bump every weekend. Remove the rule once upstream ships a fix.

## Test plan
- [ ] Merge and confirm Renovate no longer proposes `henryiii/validate-pyproject-schema-store` > `2026.07.17` on its next run
- [ ] Remove this rule once upstream fixes the `UnboundLocalError` bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the `validate-pyproject-schema-store` dependency to versions up to `2026.07.17` to prevent crashes related to `[tool.uv]` configuration tables.
  * Documented that the version restriction can be removed once the upstream issue is resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->