### PR TITLE
👷 Track the pinned mockturtle revision with a Renovate custom manager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,6 +16,27 @@
     "github-actions",
     "pre-commit",
     "pep621",
+    "custom.regex",
+  ],
+  customManagers: [
+    {
+      // Renovate has no native manager for CMake FetchContent, so the pinned
+      // mockturtle revision is tracked via a regex manager instead. The pin is
+      // a full commit SHA that always points at the head of the `mnt` branch of
+      // our fork, hence git-refs + currentDigest against that branch.
+      customType: "regex",
+      description: "Update the mockturtle revision pinned for CMake FetchContent",
+      managerFilePatterns: [
+        "cmake/ExternalDependencies.cmake"
+      ],
+      matchStrings: [
+        "set\\(MOCKTURTLE_REV\\s+\"(?<currentDigest>[0-9a-f]{40})\""
+      ],
+      depNameTemplate: "marcelwa/mockturtle",
+      packageNameTemplate: "https://github.com/marcelwa/mockturtle",
+      currentValueTemplate: "mnt",
+      datasourceTemplate: "git-refs",
+    }
   ],
   lockFileMaintenance: {
     enabled: true,
@@ -53,6 +74,20 @@
         "python"
       ],
       commitMessagePrefix: "⬆\uFE0F\uD83D\uDC0D",
+    },
+    {
+      matchManagers: [
+        "custom.regex"
+      ],
+      addLabels: [
+        "dependencies",
+        "C++",
+        "build_system"
+      ],
+      commitMessagePrefix: "⬆\uFE0F\uD83D\uDC22",
+      // `:automergeDigest` (inherited from extends) would otherwise merge these
+      // unattended. A mockturtle bump changes the C++ core, so it gets reviewed.
+      automerge: false,
     },
     {
       description: "Group and automerge all patch updates",


### PR DESCRIPTION
## Description

Renovate has no native manager for CMake `FetchContent`, so `MOCKTURTLE_REV` in
`cmake/ExternalDependencies.cmake` has never been picked up by any of the automated
dependency updates — it has only ever been bumped by hand.

This adds a `custom.regex` manager that matches the pinned commit SHA and resolves it
through the `git-refs` datasource against the `mnt` branch of `marcelwa/mockturtle`,
which is exactly what the pin tracks today (verified: the pinned SHA
`8f0322e3` is the current `refs/heads/mnt` head).

Motivation is broader than mockturtle: the upcoming ABC bridge work depends on landing
a change in the mockturtle fork first, and that pin needs to move routinely rather than
being remembered manually.

### Notes

- `enabledManagers` is an explicit allowlist, so `custom.regex` had to be added there
  too — without it the manager would be silently inert.
- Digest updates are explicitly opted **out** of the inherited `:automergeDigest`
  behaviour. An unattended merge is fine for an Action SHA; a mockturtle bump changes
  the C++ core, so it gets a human review.
- Labels reuse existing ones only (`dependencies`, `C++`, `build_system`) — no new
  labels are introduced.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbUqcnZayPooFgekEXVSjz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved maintenance automation for a pinned build dependency.
  - Dependency update proposals now receive clearer categorization and commit descriptions.
  - Automated updates require review instead of being merged automatically, helping ensure build changes are validated before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->