### PR TITLE
🐛 Fix the named AIG example in the AIG documentation

### DIFF
--- a/docs/aigs.md
+++ b/docs/aigs.md
@@ -195,7 +195,7 @@ named_aig.create_po(carry, "carry_output")
 
 # Retrieve names
 print(f"Network name: {named_aig.get_network_name()}")
-print(f"PI names: {[named_aig.get_name(pi) for pi in named_aig.pis()]}")
+print(f"PI names: {[named_aig.get_name(named_aig.make_signal(pi)) for pi in named_aig.pis()]}")
 print(f"Signal name (sum): {named_aig.get_name(sum)}")
 print(f"Signal name (carry): {named_aig.get_name(carry)}")
 print(f"PO name at index 0: {named_aig.get_output_name(0)}")


### PR DESCRIPTION
## Description

The named-AIG example in `docs/aigs.md` raises a `TypeError`, so the notebook execution
of that page fails:

```
TypeError: get_name(): incompatible function arguments. The following argument types are supported:
    1. get_name(self, s: aigverse.networks.AigSignal) -> str

Invoked with types: aigverse.networks.NamedAig, int
```

`pis()` yields node indices, while `get_name()` takes an `AigSignal`. Wrapping the node
in `make_signal()` makes the example print the primary input names it was always meant
to:

```
PI names: ['a', 'b', 'cin']
```

This is pre-existing on `main` and unrelated to any ABC work — it surfaced while building
the docs for that.

## Verification

```console
$ uvx nox -s docs -- -b html
build succeeded.
```

Previously the same build reported `Executing notebook failed: CellExecutionError` for
`docs/aigs.md`.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbUqcnZayPooFgekEXVSjz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Named AIG example to convert primary-input nodes into signals before retrieving their names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->