### PR TITLE
✨ Add a benchmark loader with EPFL support

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,7 +40,7 @@
     {
       // The benchmark loader pins the revision of the EPFL suite it fetches, so
       // that two people running the same code get the same circuits. Renovate
-      // proposes the bump; the circuits themselves do occasionally change.
+      // proposes the bump, should the circuits ever change.
       customType: "regex",
       description: "Update the pinned revision of the EPFL benchmark suite",
       managerFilePatterns: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -36,6 +36,23 @@
       packageNameTemplate: "https://github.com/marcelwa/mockturtle",
       currentValueTemplate: "mnt",
       datasourceTemplate: "git-refs",
+    },
+    {
+      // The benchmark loader pins the revision of the EPFL suite it fetches, so
+      // that two people running the same code get the same circuits. Renovate
+      // proposes the bump; the circuits themselves do occasionally change.
+      customType: "regex",
+      description: "Update the pinned revision of the EPFL benchmark suite",
+      managerFilePatterns: [
+        "python/aigverse/benchmarks/_epfl.py"
+      ],
+      matchStrings: [
+        "DEFAULT_REVISION\\s*=\\s*\"(?<currentDigest>[0-9a-f]{40})\""
+      ],
+      depNameTemplate: "lsils/benchmarks",
+      packageNameTemplate: "https://github.com/lsils/benchmarks",
+      currentValueTemplate: "master",
+      datasourceTemplate: "git-refs",
     }
   ],
   lockFileMaintenance: {

--- a/.github/workflows/aigverse-benchmark-tests.yml
+++ b/.github/workflows/aigverse-benchmark-tests.yml
@@ -1,0 +1,60 @@
+name: 📊 • Benchmarks
+
+# The benchmark loader downloads circuits from github.com/lsils/benchmarks. Those
+# tests are skipped everywhere else, so that a network hiccup cannot turn the
+# whole test matrix red; this workflow is the only place they actually run.
+
+on:
+  merge_group:
+  push:
+    branches: ["main"]
+    paths:
+      - "python/aigverse/benchmarks/**"
+      - "test/benchmarks/**"
+      - ".github/workflows/aigverse-benchmark-tests.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      # GitHub Actions does not support YAML anchors, so this repeats the list above
+      - "python/aigverse/benchmarks/**"
+      - "test/benchmarks/**"
+      - ".github/workflows/aigverse-benchmark-tests.yml"
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark-tests:
+    name: 📊 Benchmark downloads
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read # required to check out the repository
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
+        with:
+          key: "ubuntu-24.04-aigverse"
+          save: ${{ github.ref == 'refs/heads/main' }}
+          max-size: 10G
+
+      - name: Setup mold
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          save-cache: ${{ github.ref == 'refs/heads/main' }}
+
+      # Exercising the real download path is the entire point of this job, so it
+      # deliberately does not pre-seed the benchmark cache.
+      - name: 📊 Test the benchmark loader
+        run: uvx nox -s tests-3.12 -- -m benchmarks

--- a/.github/workflows/aigverse-benchmark-tests.yml
+++ b/.github/workflows/aigverse-benchmark-tests.yml
@@ -1,8 +1,9 @@
 name: 📊 • Benchmarks
 
 # The benchmark loader downloads circuits from github.com/lsils/benchmarks. Those
-# tests are skipped everywhere else, so that a network hiccup cannot turn the
-# whole test matrix red; this workflow is the only place they actually run.
+# tests are marked `network` and skipped everywhere else, so that a hiccup at
+# github.com cannot turn the whole test matrix red; this workflow is the only
+# place they actually run.
 
 on:
   merge_group:
@@ -11,6 +12,9 @@ on:
     paths:
       - "python/aigverse/benchmarks/**"
       - "test/benchmarks/**"
+      - "test/conftest.py"
+      - "noxfile.py"
+      - "pyproject.toml"
       - ".github/workflows/aigverse-benchmark-tests.yml"
   pull_request:
     branches: ["main"]
@@ -18,6 +22,9 @@ on:
       # GitHub Actions does not support YAML anchors, so this repeats the list above
       - "python/aigverse/benchmarks/**"
       - "test/benchmarks/**"
+      - "test/conftest.py"
+      - "noxfile.py"
+      - "pyproject.toml"
       - ".github/workflows/aigverse-benchmark-tests.yml"
 
 permissions: {}
@@ -28,10 +35,14 @@ concurrency:
 
 jobs:
   benchmark-tests:
-    name: 📊 Benchmark downloads
-    runs-on: ubuntu-24.04
+    name: 📊 ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: read # required to check out the repository
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, windows-2025]
     steps:
       - name: Clone Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -41,11 +52,12 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
         with:
-          key: "ubuntu-24.04-aigverse"
+          key: "${{ matrix.runs-on }}-aigverse"
           save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 10G
 
-      - name: Setup mold
+      - if: runner.os == 'Linux'
+        name: Setup mold
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Install the latest version of uv
@@ -54,7 +66,11 @@ jobs:
           enable-cache: true
           save-cache: ${{ github.ref == 'refs/heads/main' }}
 
-      # Exercising the real download path is the entire point of this job, so it
-      # deliberately does not pre-seed the benchmark cache.
+      # `nox -s tests` covers every supported Python version. The loader is pure
+      # Python, and the cache path it builds is the sort of thing that differs
+      # between platforms, so both axes are worth the matrix.
+      #
+      # Deliberately no pre-seeded benchmark cache: exercising the real download
+      # path is the entire point of this job.
       - name: 📊 Test the benchmark loader
-        run: uvx nox -s tests-3.12 -- -m benchmarks
+        run: uvx nox -s tests --verbose -- -m network

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ representations for downstream data science and ML pipelines.
 - **High-Level API**: Simplify logic synthesis tasks with a Pythonic interface for AIG manipulation and optimization.
 - **ML/Data Science Interoperability**: Optional adapters for graph and array representations used in Python data
   science and machine learning workflows.
+- **Benchmark Suites**: On-demand access to standard benchmark circuits (e.g., the EPFL suite), downloaded once and
+  cached locally.
 
 ## 🤔 Motivation
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,26 @@ print(mux.num_pis, mux.num_pos, mux.num_gates)
 print(decoder.num_pis, decoder.num_pos, decoder.num_gates)
 ```
 
+### 📊 Benchmark Loading
+
+The `aigverse.benchmarks` module fetches standard benchmark suites on demand and caches them locally, so a script
+can name a benchmark instead of carrying a downloader and a checked-in copy of the data. The
+[EPFL combinational suite](https://github.com/lsils/benchmarks) is supported out of the box.
+
+```python
+from aigverse.benchmarks import epfl, epfl_names
+
+# List the benchmark names in a category
+print(epfl_names("arithmetic"))  # ('adder', 'bar', 'div', ...)
+
+# Downloads once and caches thereafter, returned as a NamedAig
+aig = epfl("ctrl")
+print(f"{aig.num_pis} inputs, {aig.num_pos} outputs, {aig.num_gates} AND gates")
+```
+
+For more details, including cache configuration and revision pinning, see the
+[benchmarks documentation](https://aigverse.readthedocs.io/en/latest/benchmarks.html).
+
 ### ✅ Equivalence Checking
 
 Equivalence of AIGs (e.g., after optimization) can be checked using SAT-based equivalence checking.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -110,6 +110,6 @@ set_benchmark_cache("/scratch/benchmarks")  # process-wide
 aig = epfl("adder", cache_dir="/tmp/here")  # this call only
 ```
 
-or set `AIGVERSE_BENCHMARK_CACHE` in the environment. The precedence is
-{py:func}`~aigverse.benchmarks.set_benchmark_cache`, then the environment variable, then
+or set `AIGVERSE_BENCHMARK_CACHE` in the environment. The precedence is the per-call
+`cache_dir`, then {py:func}`~aigverse.benchmarks.set_benchmark_cache`, then the environment variable, then
 the platform default.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,90 @@
+---
+file_format: mystnb
+kernelspec:
+  name: python3
+---
+
+# Benchmarks
+
+Experiments need circuits. `aigverse` can fetch standard benchmark suites on demand and
+cache them locally, so a script names a benchmark instead of carrying a downloader and a
+checked-in copy of the data.
+
+Nothing is bundled with `aigverse` and nothing is downloaded at import time — the first
+call that needs a file fetches it.
+
+## The EPFL suite
+
+The [EPFL combinational benchmark suite](https://github.com/lsils/benchmarks) is the
+standard yardstick for logic synthesis: twenty circuits split into ten _arithmetic_ and
+ten _random/control_ designs.
+
+```{code-cell} ipython3
+from aigverse.benchmarks import epfl, epfl_names
+
+print(epfl_names("arithmetic"))
+print(epfl_names("random_control"))
+```
+
+Loading one gives a {py:class}`~aigverse.networks.NamedAig`, which is an
+{py:class}`~aigverse.networks.Aig` that kept the input and output names from the AIGER
+symbol table, so the names come along at no cost:
+
+```{code-cell} ipython3
+from aigverse.networks import DepthAig
+
+aig = epfl("ctrl")
+print(f"{aig.num_pis} inputs, {aig.num_pos} outputs")
+print(f"{aig.num_gates} AND gates, {DepthAig(aig).num_levels} levels")
+```
+
+Sweeping the small end of the suite is then a loop:
+
+```{code-cell} ipython3
+for name in ("ctrl", "router", "int2float", "dec"):
+    design = epfl(name)
+    print(f"{name:12s} {design.num_gates:5d} gates  {DepthAig(design).num_levels:3d} levels")
+```
+
+:::{warning}
+The suite spans four orders of magnitude. `ctrl` has 174 AND gates; `hyp` has over
+214,000 and is a several-hundred-megabyte proposition once loaded and optimized. Start
+small.
+:::
+
+If only the AIGER file is wanted — to hand to another tool, say — use
+{py:func}`~aigverse.benchmarks.epfl_path`, which downloads and returns the path without
+parsing.
+
+## Pinning a revision
+
+The benchmark repository is versioned by commit rather than by release, and its circuits
+do change. By default the loader tracks `master`; pass an explicit `revision` to make a
+result reproducible:
+
+```python
+aig = epfl("adder", revision="9e5d0ec")
+```
+
+Each revision is cached separately, so switching between them does not re-download
+anything you already have.
+
+## Where downloads are cached
+
+By default, benchmarks land in a per-user cache directory — `~/.cache/aigverse/benchmarks`
+on Linux, `~/Library/Caches/aigverse/benchmarks` on macOS, and `%LOCALAPPDATA%` on
+Windows. Notably _not_ the working directory, so a sweep run inside a repository checkout
+does not scatter circuits through it.
+
+Override it in whichever way suits:
+
+```python
+from aigverse.benchmarks import set_benchmark_cache
+
+set_benchmark_cache("/scratch/benchmarks")  # process-wide
+aig = epfl("adder", cache_dir="/tmp/here")  # this call only
+```
+
+or set `AIGVERSE_BENCHMARK_CACHE` in the environment. The precedence is
+{py:func}`~aigverse.benchmarks.set_benchmark_cache`, then the environment variable, then
+the platform default.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -30,7 +30,7 @@ Loading one gives a {py:class}`~aigverse.networks.NamedAig`, which is an
 {py:class}`~aigverse.networks.Aig` that kept the input and output names from the AIGER
 symbol table, so the names come along at no cost:
 
-```{code-cell} ipython3
+```python
 from aigverse.networks import DepthAig
 
 aig = epfl("ctrl")
@@ -38,13 +38,31 @@ print(f"{aig.num_pis} inputs, {aig.num_pos} outputs")
 print(f"{aig.num_gates} AND gates, {DepthAig(aig).num_levels} levels")
 ```
 
-Sweeping the small end of the suite is then a loop:
-
-```{code-cell} ipython3
-for name in ("ctrl", "router", "int2float", "dec"):
-    design = epfl(name)
-    print(f"{name:12s} {design.num_gates:5d} gates  {DepthAig(design).num_levels:3d} levels")
+```text
+7 inputs, 26 outputs
+174 AND gates, 10 levels
 ```
+
+Sweeping part of the suite is then a loop:
+
+```python
+for name in epfl_names("random_control"):
+    design = epfl(name)
+    print(
+        f"{name:12s} {design.num_gates:6d} gates  {DepthAig(design).num_levels:4d} levels"
+    )
+```
+
+:::{note}
+Unusually for these docs, the examples that load a circuit are **not** executed at build
+time. Everything else here is, and normally that is what keeps the examples honest — but
+an executed `epfl(...)` would make every documentation build depend on `github.com` being
+reachable and prompt, and a stalled download of a one-kilobyte file is enough to fail the
+build outright.
+
+The API these examples show is covered end-to-end by the test suite instead, including a
+job that performs real downloads, which is the right place for that guarantee.
+:::
 
 :::{warning}
 The suite spans four orders of magnitude. `ctrl` has 174 AND gates; `hyp` has over
@@ -56,18 +74,25 @@ If only the AIGER file is wanted — to hand to another tool, say — use
 {py:func}`~aigverse.benchmarks.epfl_path`, which downloads and returns the path without
 parsing.
 
-## Pinning a revision
+## Revisions
 
 The benchmark repository is versioned by commit rather than by release, and its circuits
-do change. By default the loader tracks `master`; pass an explicit `revision` to make a
-result reproducible:
+do change. The loader therefore defaults to a **pinned commit** rather than to `master`,
+so that two people running the same code get the same circuits.
+
+That is not only about reproducibility across machines. A moving default would not even be
+self-consistent: whoever already had a warm cache would keep the old circuit forever, while
+a newcomer downloaded the new one, and the two would silently disagree.
+
+Ask for something else when you want it:
 
 ```python
-aig = epfl("adder", revision="9e5d0ec")
+aig = epfl("adder", revision="master")  # whatever is current
+aig = epfl("adder", revision="9e5d0ec")  # some other commit
 ```
 
 Each revision is cached separately, so switching between them does not re-download
-anything you already have.
+anything you already have. The pin itself is kept current by Renovate.
 
 ## Where downloads are cached
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -30,7 +30,9 @@ Loading one gives a {py:class}`~aigverse.networks.NamedAig`, which is an
 {py:class}`~aigverse.networks.Aig` that kept the input and output names from the AIGER
 symbol table, so the names come along at no cost:
 
-```python
+```{code-cell} ipython3
+:tags: [skip-execution]
+
 from aigverse.networks import DepthAig
 
 aig = epfl("ctrl")
@@ -45,7 +47,9 @@ print(f"{aig.num_gates} AND gates, {DepthAig(aig).num_levels} levels")
 
 Sweeping part of the suite is then a loop:
 
-```python
+```{code-cell} ipython3
+:tags: [skip-execution]
+
 for name in epfl_names("random_control"):
     design = epfl(name)
     print(
@@ -76,9 +80,9 @@ parsing.
 
 ## Revisions
 
-The benchmark repository is versioned by commit rather than by release, and its circuits
-do change. The loader therefore defaults to a **pinned commit** rather than to `master`,
-so that two people running the same code get the same circuits.
+The benchmark repository is versioned by commit rather than by release. Its circuits
+don't usually change. The loader defaults to a **pinned commit** rather than to
+`master`, so that two people running the same code get the same circuits.
 
 That is not only about reproducibility across machines. A moving default would not even be
 self-consistent: whoever already had a warm cache would keep the old circuit forever, while

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -57,17 +57,6 @@ for name in epfl_names("random_control"):
     )
 ```
 
-:::{note}
-Unusually for these docs, the examples that load a circuit are **not** executed at build
-time. Everything else here is, and normally that is what keeps the examples honest — but
-an executed `epfl(...)` would make every documentation build depend on `github.com` being
-reachable and prompt, and a stalled download of a one-kilobyte file is enough to fail the
-build outright.
-
-The API these examples show is covered end-to-end by the test suite instead, including a
-job that performs real downloads, which is the right place for that guarantee.
-:::
-
 :::{warning}
 The suite spans four orders of magnitude. `ctrl` has 174 AND gates; `hyp` has over
 214,000 and is a several-hundred-megabyte proposition once loaded and optimized. Start

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,6 +91,11 @@ myst_substitutions = {
 }
 myst_heading_anchors = 3
 nitpicky = True
+nitpick_ignore = [
+    # autoapi stringifies `tuple[str, ...]` as `tuple[str, Ellipsis]`, and then
+    # nitpicky mode cannot resolve `Ellipsis` as a class. The annotation is fine.
+    ("py:class", "Ellipsis"),
+]
 
 # -- Options for {MyST}NB ----------------------------------------------------
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,7 @@ aigs
 truth_tables
 algorithms
 generators
+benchmarks
 machine_learning
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ Key features include:
 - High-performance C++ backend with a Pythonic interface
 - Optional adapters for graph and numeric interoperability in machine learning and data science workflows
 - Comprehensive tools for logic synthesis and optimization
+- On-demand access to standard benchmark suites (e.g., EPFL), downloaded once and cached locally
 
 `aigverse` is designed as reusable bridge infrastructure rather than as a full end-to-end EDA toolchain.
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -64,6 +64,16 @@ def _run_tests(
     extra_command: Sequence[str] = (),
     pytest_run_args: Sequence[str] = (),
 ) -> None:
+    """Install the project into the session and run pytest against it.
+
+    Args:
+        session: The nox session to install into and run in.
+        install_args: Extra arguments forwarded to every `uv` invocation, used to
+            pin resolution for the minimums session.
+        extra_command: A command to run after installing and before testing.
+        pytest_run_args: Extra arguments forwarded to pytest. Note that a `-m`
+            passed here replaces the one in `addopts` rather than adding to it.
+    """
     env = {"UV_PROJECT_ENVIRONMENT": session.virtualenv.location}
 
     if shutil.which("cmake") is None and shutil.which("cmake3") is None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -77,10 +77,11 @@ def _run_tests(
     if os.environ.get("CI"):
         # CI keeps full coverage: also install the torch group and re-include
         # torch-marked tests that are deselected by default locally. The
-        # benchmark tests stay out -- they download circuits, and a network
-        # hiccup must not turn the whole matrix red. They have their own job.
+        # network-marked tests stay out -- they download circuits, and a
+        # hiccup at github.com must not turn the whole matrix red. They have
+        # their own job.
         only_group_args += ["--only-group", "torch"]
-        pytest_run_args = [*pytest_run_args, "-m", "not benchmarks"]
+        pytest_run_args = [*pytest_run_args, "-m", "not network"]
     session.run(
         "uv",
         "sync",

--- a/noxfile.py
+++ b/noxfile.py
@@ -76,9 +76,11 @@ def _run_tests(
     only_group_args: list[str] = ["--only-group", "build", "--only-group", "test"]
     if os.environ.get("CI"):
         # CI keeps full coverage: also install the torch group and re-include
-        # torch-marked tests that are deselected by default locally.
+        # torch-marked tests that are deselected by default locally. The
+        # benchmark tests stay out -- they download circuits, and a network
+        # hiccup must not turn the whole matrix red. They have their own job.
         only_group_args += ["--only-group", "torch"]
-        pytest_run_args = [*pytest_run_args, "-m", "torch or not torch"]
+        pytest_run_args = [*pytest_run_args, "-m", "not benchmarks"]
     session.run(
         "uv",
         "sync",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,13 +102,14 @@ markers = [
     "io: Tests for read/write and serialization",
     "generators: Tests for network generators",
     "adapters: Tests for optional adapter integrations",
+    "benchmarks: Tests that download benchmark circuits (skipped by default)",
     "tts: Tests for truth table utilities",
     "torch: Tests that require the optional PyTorch dependency (skipped by default)",
 ]
 addopts = [
     "-ra",
     "--numprocesses=auto", # Automatically use all available CPU cores for parallel testing
-    "-m", "not torch", # Skip torch-marked tests by default; override with -m "torch or not torch"
+    "-m", "not torch and not benchmarks", # Skip torch- and network-dependent tests by default
 ]
 log_level = "INFO"
 testpaths = ["test/"]
@@ -192,6 +193,8 @@ isort.required-imports = ["from __future__ import annotations"]
 "python/aigverse/__init__.py" = ["RUF067"]
 "test/**" = ["T20", "ANN", "D", "INP001", "S301", "S403"]
 "docs/**" = ["T20", "ERA001", "INP001"]
+# the loaders document the exceptions that propagate out of their helpers
+"python/aigverse/benchmarks/*.py" = ["DOC502"]
 "noxfile.py" = ["T20", "TID251", "ERA001"]
 "tools/*.py" = ["S603", "S607"]
 "*.pyi" = ["D418", "PYI002", "PYI021", "A003", "N999"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,14 +102,15 @@ markers = [
     "io: Tests for read/write and serialization",
     "generators: Tests for network generators",
     "adapters: Tests for optional adapter integrations",
-    "benchmarks: Tests that download benchmark circuits (skipped by default)",
+    "benchmarks: Tests for benchmark loading",
+    "network: Tests that require internet access (skipped by default)",
     "tts: Tests for truth table utilities",
     "torch: Tests that require the optional PyTorch dependency (skipped by default)",
 ]
 addopts = [
     "-ra",
     "--numprocesses=auto", # Automatically use all available CPU cores for parallel testing
-    "-m", "not torch and not benchmarks", # Skip torch- and network-dependent tests by default
+    "-m", "not torch and not network", # Skip torch- and network-dependent tests by default
 ]
 log_level = "INFO"
 testpaths = ["test/"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,9 @@ archs = "auto64"
 build-frontend = "build[uv]"
 test-groups = ["test", "torch"]
 test-sources = ["test/"]
-test-command = 'pytest test/ -m "torch or not torch"'
+# the -m here replaces the one in [tool.pytest] addopts rather than adding to it,
+# so the network exclusion has to be repeated or wheel CI would download circuits
+test-command = 'pytest test/ -m "(torch or not torch) and not network"'
 
 
 [tool.cibuildwheel.macos]

--- a/python/aigverse/benchmarks/__init__.py
+++ b/python/aigverse/benchmarks/__init__.py
@@ -1,0 +1,41 @@
+"""Standard benchmark suites for logic synthesis.
+
+Fetches well-known benchmark circuits on demand and caches them locally, so a
+script or an experiment can name a benchmark rather than shipping a downloader
+and a copy of the data.
+
+Nothing is downloaded at import time and no benchmark is bundled with
+`aigverse`; the first call that needs a file fetches it.
+
+Example:
+    >>> from aigverse.benchmarks import epfl
+    >>> aig = epfl("ctrl")  # doctest: +SKIP
+    >>> aig.num_gates  # doctest: +SKIP
+    174
+"""
+
+from __future__ import annotations
+
+from ._cache import CACHE_ENV_VAR, benchmark_cache, set_benchmark_cache
+from ._epfl import (
+    DEFAULT_REVISION,
+    EPFL_ARITHMETIC,
+    EPFL_BENCHMARKS,
+    EPFL_RANDOM_CONTROL,
+    epfl,
+    epfl_names,
+    epfl_path,
+)
+
+__all__ = [
+    "CACHE_ENV_VAR",
+    "DEFAULT_REVISION",
+    "EPFL_ARITHMETIC",
+    "EPFL_BENCHMARKS",
+    "EPFL_RANDOM_CONTROL",
+    "benchmark_cache",
+    "epfl",
+    "epfl_names",
+    "epfl_path",
+    "set_benchmark_cache",
+]

--- a/python/aigverse/benchmarks/__init__.py
+++ b/python/aigverse/benchmarks/__init__.py
@@ -5,13 +5,8 @@ script or an experiment can name a benchmark rather than shipping a downloader
 and a copy of the data.
 
 Nothing is downloaded at import time and no benchmark is bundled with
-`aigverse`; the first call that needs a file fetches it.
-
-Example:
-    >>> from aigverse.benchmarks import epfl
-    >>> aig = epfl("ctrl")  # doctest: +SKIP
-    >>> aig.num_gates  # doctest: +SKIP
-    174
+`aigverse`; the first call that needs a file fetches it. See the
+:doc:`/benchmarks` guide for a runnable example.
 """
 
 from __future__ import annotations

--- a/python/aigverse/benchmarks/_cache.py
+++ b/python/aigverse/benchmarks/_cache.py
@@ -1,0 +1,79 @@
+"""Where downloaded benchmark files are kept."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+__all__ = ["CACHE_ENV_VAR", "benchmark_cache", "set_benchmark_cache"]
+
+# Name of the environment variable overriding the cache location.
+CACHE_ENV_VAR = "AIGVERSE_BENCHMARK_CACHE"
+
+_override: Path | None = None
+
+
+def _default_cache() -> Path:
+    """Pick the per-user cache directory for the current platform.
+
+    Follows the XDG base directory specification on Linux and the conventional
+    locations elsewhere, rather than taking a dependency on ``platformdirs`` for
+    one directory.
+
+    Returns:
+        The default cache directory. It is not created here.
+    """
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA")
+        root = Path(base) if base else Path.home() / "AppData" / "Local"
+    elif sys.platform == "darwin":
+        root = Path.home() / "Library" / "Caches"
+    else:
+        base = os.environ.get("XDG_CACHE_HOME")
+        root = Path(base) if base else Path.home() / ".cache"
+
+    return root / "aigverse" / "benchmarks"
+
+
+def set_benchmark_cache(path: str | os.PathLike[str] | None) -> Path | None:
+    """Sets or clears the directory downloaded benchmarks are cached in.
+
+    Applies process-wide and is intended to be called once during setup; it is
+    not thread-safe.
+
+    Args:
+        path: The directory to use, or ``None`` to clear a previous override and
+            fall back to the environment variable and the platform default.
+
+    Returns:
+        The resolved directory, or ``None`` if the override was cleared.
+    """
+    global _override  # ruff: ignore[global-statement]
+
+    if path is None:
+        _override = None
+        return None
+
+    _override = Path(path).expanduser().resolve()
+    return _override
+
+
+def benchmark_cache() -> Path:
+    """Resolves the directory downloaded benchmarks are cached in.
+
+    Resolution order: an explicit override set via :func:`set_benchmark_cache`,
+    then the ``AIGVERSE_BENCHMARK_CACHE`` environment variable, then a per-user
+    cache directory appropriate to the platform.
+
+    Returns:
+        The cache directory. It is not created here.
+    """
+    if _override is not None:
+        return _override
+
+    configured = os.environ.get(CACHE_ENV_VAR)
+    if configured:
+        return Path(configured).expanduser().resolve()
+
+    return _default_cache()

--- a/python/aigverse/benchmarks/_epfl.py
+++ b/python/aigverse/benchmarks/_epfl.py
@@ -129,10 +129,15 @@ def _check_revision(revision: str) -> str:
         ValueError: If the revision is empty, absolute, contains a ``..``
             component, or holds characters a git ref cannot.
     """
-    if not _SAFE_REVISION.match(revision) or ".." in revision.split("/"):
+    # `.` and empty components are rejected alongside `..`: the filesystem
+    # collapses `a/./b`, `a//b` and `a/` onto the same directory as another
+    # revision, which would quietly serve one revision's circuits for another.
+    components = revision.split("/")
+    if not _SAFE_REVISION.match(revision) or any(part in {"", ".", ".."} for part in components):
         msg = (
             f"invalid revision {revision!r}: expected a git commit, tag or branch, "
-            f"which must not be absolute or contain a '..' component"
+            f"which must not be absolute, end in a slash, or contain an empty, "
+            f"'.' or '..' component"
         )
         raise ValueError(msg)
     return revision

--- a/python/aigverse/benchmarks/_epfl.py
+++ b/python/aigverse/benchmarks/_epfl.py
@@ -5,12 +5,17 @@ yardstick for logic synthesis. These helpers fetch its AIGER files on demand,
 cache them, and hand back networks, so a script can name a benchmark instead of
 carrying a downloader and a checked-in copy of the data.
 
+The 20 arithmetic and random/control circuits are supported. The suite's three
+MtM benchmarks are not: they live on Zenodo rather than in the git repository.
+
 Nothing is downloaded at import time, and nothing is bundled with `aigverse`.
 """
 
 from __future__ import annotations
 
+import re
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import TYPE_CHECKING
 
@@ -33,10 +38,19 @@ __all__ = [
 
 _URL = "https://raw.githubusercontent.com/lsils/benchmarks/{revision}/{category}/{name}.aig"
 
-# The suite is versioned by commit rather than by release. Pinning the default
-# keeps a benchmark meaning the same thing tomorrow as it does today; pass
-# `revision=` to follow the branch instead.
-DEFAULT_REVISION = "master"
+# The suite is versioned by commit rather than by release, and its circuits do
+# change. The default is therefore a pinned commit rather than `master`: two
+# people running the same code must get the same circuits, and a moving default
+# would not even be self-consistent, since whoever already has a warm cache would
+# keep the old file forever while a newcomer downloads the new one.
+#
+# Kept current by the `lsils/benchmarks` custom manager in renovate.json5.
+DEFAULT_REVISION = "0060e156826e733d69bf5b3322d1bdd0d03a1f9a"
+
+# A revision becomes a path component of the cache, so it has to be one: an
+# absolute value would discard the cache root entirely and `..` would climb out
+# of it. Git refs may contain slashes, so those are allowed and simply nest.
+_SAFE_REVISION = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
 
 #: The ten arithmetic benchmarks.
 EPFL_ARITHMETIC: frozenset[str] = frozenset({
@@ -66,7 +80,12 @@ EPFL_RANDOM_CONTROL: frozenset[str] = frozenset({
     "voter",
 })
 
-#: Every benchmark in the suite.
+#: Every benchmark this loader supports.
+#:
+#: The suite as published has 23 circuits. The three MtM ("more than ten
+#: million gates") benchmarks are not among these: they are distributed via
+#: Zenodo rather than the git repository, and at several gigabytes apiece they
+#: want a different delivery story than an on-demand download.
 EPFL_BENCHMARKS: frozenset[str] = EPFL_ARITHMETIC | EPFL_RANDOM_CONTROL
 
 _CATEGORIES: dict[str, frozenset[str]] = {
@@ -95,6 +114,28 @@ def epfl_names(category: str | None = None) -> tuple[str, ...]:
         known = ", ".join(sorted(_CATEGORIES))
         msg = f"unknown category {category!r}; available categories: {known}"
         raise ValueError(msg) from None
+
+
+def _check_revision(revision: str) -> str:
+    """Rejects a revision that would not be safe as a cache path component.
+
+    Args:
+        revision: The revision to check.
+
+    Returns:
+        The revision, unchanged.
+
+    Raises:
+        ValueError: If the revision is empty, absolute, contains a ``..``
+            component, or holds characters a git ref cannot.
+    """
+    if not _SAFE_REVISION.match(revision) or ".." in revision.split("/"):
+        msg = (
+            f"invalid revision {revision!r}: expected a git commit, tag or branch, "
+            f"which must not be absolute or contain a '..' component"
+        )
+        raise ValueError(msg)
+    return revision
 
 
 def _category_of(name: str) -> str:
@@ -133,6 +174,8 @@ def epfl_path(
     Args:
         name: The benchmark name, e.g. ``"adder"``. See :func:`epfl_names`.
         revision: Git revision of the benchmark repository to fetch from.
+            Defaults to a pinned commit, so results are reproducible; pass
+            ``"master"`` to follow the branch instead.
         cache_dir: Directory to cache into, overriding the configured one.
         timeout: Seconds to wait for the download.
 
@@ -140,10 +183,12 @@ def epfl_path(
         Path to the local AIGER file.
 
     Raises:
-        ValueError: If ``name`` is not part of the suite.
+        ValueError: If ``name`` is not part of the suite, or ``revision`` is not
+            usable as a path component.
         OSError: If the benchmark could not be downloaded.
     """
     category = _category_of(name)
+    _check_revision(revision)
 
     from pathlib import Path as _Path
 
@@ -153,7 +198,9 @@ def epfl_path(
     if target.is_file() and target.stat().st_size > 0:
         return target
 
-    url = _URL.format(revision=revision, category=category, name=name)
+    # quote() keeps the slashes a ref may legitimately contain, and escapes
+    # anything else that would change the meaning of the URL
+    url = _URL.format(revision=urllib.parse.quote(revision, safe="/"), category=category, name=name)
     directory.mkdir(parents=True, exist_ok=True)
 
     # Download to a sibling first: an interrupted transfer must not leave a
@@ -188,6 +235,8 @@ def epfl(
     Args:
         name: The benchmark name, e.g. ``"adder"``. See :func:`epfl_names`.
         revision: Git revision of the benchmark repository to fetch from.
+            Defaults to a pinned commit, so results are reproducible; pass
+            ``"master"`` to follow the branch instead.
         cache_dir: Directory to cache into, overriding the configured one.
         timeout: Seconds to wait for the download.
 
@@ -195,7 +244,8 @@ def epfl(
         The benchmark network, with its I/O names.
 
     Raises:
-        ValueError: If ``name`` is not part of the suite.
+        ValueError: If ``name`` is not part of the suite, or ``revision`` is not
+            usable as a path component.
         OSError: If the benchmark could not be downloaded.
         RuntimeError: If the downloaded file could not be parsed.
     """

--- a/python/aigverse/benchmarks/_epfl.py
+++ b/python/aigverse/benchmarks/_epfl.py
@@ -213,12 +213,18 @@ def epfl_path(
     partial = target.with_suffix(".aig.part")
     try:
         with urllib.request.urlopen(url, timeout=timeout) as response:  # ruff: ignore[suspicious-url-open-usage]
-            partial.write_bytes(response.read())
+            data = response.read()
     except (urllib.error.URLError, TimeoutError) as exc:
         partial.unlink(missing_ok=True)
         msg = f"could not download the EPFL benchmark {name!r} from {url}: {exc}"
         raise OSError(msg) from exc
 
+    if not data:
+        partial.unlink(missing_ok=True)
+        msg = f"downloaded EPFL benchmark {name!r} is empty"
+        raise OSError(msg)
+
+    partial.write_bytes(data)
     partial.replace(target)
     return target
 

--- a/python/aigverse/benchmarks/_epfl.py
+++ b/python/aigverse/benchmarks/_epfl.py
@@ -1,0 +1,205 @@
+"""The EPFL combinational benchmark suite.
+
+The suite lives at https://github.com/lsils/benchmarks and is the standard
+yardstick for logic synthesis. These helpers fetch its AIGER files on demand,
+cache them, and hand back networks, so a script can name a benchmark instead of
+carrying a downloader and a checked-in copy of the data.
+
+Nothing is downloaded at import time, and nothing is bundled with `aigverse`.
+"""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+from typing import TYPE_CHECKING
+
+from ._cache import benchmark_cache
+
+if TYPE_CHECKING:
+    import os
+    from pathlib import Path
+
+    from ..networks import NamedAig
+
+__all__ = [
+    "EPFL_ARITHMETIC",
+    "EPFL_BENCHMARKS",
+    "EPFL_RANDOM_CONTROL",
+    "epfl",
+    "epfl_names",
+    "epfl_path",
+]
+
+_URL = "https://raw.githubusercontent.com/lsils/benchmarks/{revision}/{category}/{name}.aig"
+
+# The suite is versioned by commit rather than by release. Pinning the default
+# keeps a benchmark meaning the same thing tomorrow as it does today; pass
+# `revision=` to follow the branch instead.
+DEFAULT_REVISION = "master"
+
+#: The ten arithmetic benchmarks.
+EPFL_ARITHMETIC: frozenset[str] = frozenset({
+    "adder",
+    "bar",
+    "div",
+    "hyp",
+    "log2",
+    "max",
+    "multiplier",
+    "sin",
+    "sqrt",
+    "square",
+})
+
+#: The ten random/control benchmarks.
+EPFL_RANDOM_CONTROL: frozenset[str] = frozenset({
+    "arbiter",
+    "cavlc",
+    "ctrl",
+    "dec",
+    "i2c",
+    "int2float",
+    "mem_ctrl",
+    "priority",
+    "router",
+    "voter",
+})
+
+#: Every benchmark in the suite.
+EPFL_BENCHMARKS: frozenset[str] = EPFL_ARITHMETIC | EPFL_RANDOM_CONTROL
+
+_CATEGORIES: dict[str, frozenset[str]] = {
+    "arithmetic": EPFL_ARITHMETIC,
+    "random_control": EPFL_RANDOM_CONTROL,
+}
+
+
+def epfl_names(category: str | None = None) -> tuple[str, ...]:
+    """Lists the available benchmark names.
+
+    Args:
+        category: ``"arithmetic"`` or ``"random_control"``, or ``None`` for all.
+
+    Returns:
+        The names, sorted.
+
+    Raises:
+        ValueError: If ``category`` is not a known category.
+    """
+    if category is None:
+        return tuple(sorted(EPFL_BENCHMARKS))
+    try:
+        return tuple(sorted(_CATEGORIES[category]))
+    except KeyError:
+        known = ", ".join(sorted(_CATEGORIES))
+        msg = f"unknown category {category!r}; available categories: {known}"
+        raise ValueError(msg) from None
+
+
+def _category_of(name: str) -> str:
+    """Finds the category a benchmark belongs to.
+
+    Args:
+        name: The benchmark name.
+
+    Returns:
+        The category directory it lives in.
+
+    Raises:
+        ValueError: If ``name`` is not part of the suite.
+    """
+    for category, members in _CATEGORIES.items():
+        if name in members:
+            return category
+
+    known = ", ".join(sorted(EPFL_BENCHMARKS))
+    msg = f"unknown EPFL benchmark {name!r}; available benchmarks: {known}"
+    raise ValueError(msg)
+
+
+def epfl_path(
+    name: str,
+    *,
+    revision: str = DEFAULT_REVISION,
+    cache_dir: str | os.PathLike[str] | None = None,
+    timeout: float = 60.0,
+) -> Path:
+    """Downloads an EPFL benchmark and returns the local file.
+
+    The download is cached, so repeated calls cost nothing after the first. Use
+    this when the AIGER file itself is wanted; :func:`epfl` parses it for you.
+
+    Args:
+        name: The benchmark name, e.g. ``"adder"``. See :func:`epfl_names`.
+        revision: Git revision of the benchmark repository to fetch from.
+        cache_dir: Directory to cache into, overriding the configured one.
+        timeout: Seconds to wait for the download.
+
+    Returns:
+        Path to the local AIGER file.
+
+    Raises:
+        ValueError: If ``name`` is not part of the suite.
+        OSError: If the benchmark could not be downloaded.
+    """
+    category = _category_of(name)
+
+    from pathlib import Path as _Path
+
+    root = _Path(cache_dir).expanduser() if cache_dir is not None else benchmark_cache()
+    directory = root / revision / category
+    target = directory / f"{name}.aig"
+    if target.is_file() and target.stat().st_size > 0:
+        return target
+
+    url = _URL.format(revision=revision, category=category, name=name)
+    directory.mkdir(parents=True, exist_ok=True)
+
+    # Download to a sibling first: an interrupted transfer must not leave a
+    # truncated file behind that later calls would happily treat as cached.
+    partial = target.with_suffix(".aig.part")
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:  # ruff: ignore[suspicious-url-open-usage]
+            partial.write_bytes(response.read())
+    except (urllib.error.URLError, TimeoutError) as exc:
+        partial.unlink(missing_ok=True)
+        msg = f"could not download the EPFL benchmark {name!r} from {url}: {exc}"
+        raise OSError(msg) from exc
+
+    partial.replace(target)
+    return target
+
+
+def epfl(
+    name: str,
+    *,
+    revision: str = DEFAULT_REVISION,
+    cache_dir: str | os.PathLike[str] | None = None,
+    timeout: float = 60.0,
+) -> NamedAig:
+    """Loads an EPFL benchmark as a network.
+
+    The result is a :class:`~aigverse.networks.NamedAig`, which is an
+    :class:`~aigverse.networks.Aig` carrying the input and output names from the
+    AIGER symbol table. It is accepted anywhere an ``Aig`` is, so the names come
+    along at no cost to the caller.
+
+    Args:
+        name: The benchmark name, e.g. ``"adder"``. See :func:`epfl_names`.
+        revision: Git revision of the benchmark repository to fetch from.
+        cache_dir: Directory to cache into, overriding the configured one.
+        timeout: Seconds to wait for the download.
+
+    Returns:
+        The benchmark network, with its I/O names.
+
+    Raises:
+        ValueError: If ``name`` is not part of the suite.
+        OSError: If the benchmark could not be downloaded.
+        RuntimeError: If the downloaded file could not be parsed.
+    """
+    from ..io import read_aiger_into_aig
+
+    path = epfl_path(name, revision=revision, cache_dir=cache_dir, timeout=timeout)
+    return read_aiger_into_aig(path)

--- a/python/aigverse/benchmarks/_epfl.py
+++ b/python/aigverse/benchmarks/_epfl.py
@@ -38,11 +38,12 @@ __all__ = [
 
 _URL = "https://raw.githubusercontent.com/lsils/benchmarks/{revision}/{category}/{name}.aig"
 
-# The suite is versioned by commit rather than by release, and its circuits do
-# change. The default is therefore a pinned commit rather than `master`: two
-# people running the same code must get the same circuits, and a moving default
-# would not even be self-consistent, since whoever already has a warm cache would
-# keep the old file forever while a newcomer downloads the new one.
+# The suite is versioned by commit rather than by release. Its circuits don't
+# usually change, but the default is a pinned commit rather than `master`
+# regardless: two people running the same code must get the same circuits, and
+# a moving default would not even be self-consistent, since whoever already has
+# a warm cache would keep the old file forever while a newcomer downloads the
+# new one.
 #
 # Kept current by the `lsils/benchmarks` custom manager in renovate.json5.
 DEFAULT_REVISION = "0060e156826e733d69bf5b3322d1bdd0d03a1f9a"
@@ -52,7 +53,7 @@ DEFAULT_REVISION = "0060e156826e733d69bf5b3322d1bdd0d03a1f9a"
 # of it. Git refs may contain slashes, so those are allowed and simply nest.
 _SAFE_REVISION = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
 
-#: The ten arithmetic benchmarks.
+# The ten arithmetic benchmarks.
 EPFL_ARITHMETIC: frozenset[str] = frozenset({
     "adder",
     "bar",
@@ -66,7 +67,7 @@ EPFL_ARITHMETIC: frozenset[str] = frozenset({
     "square",
 })
 
-#: The ten random/control benchmarks.
+# The ten random/control benchmarks.
 EPFL_RANDOM_CONTROL: frozenset[str] = frozenset({
     "arbiter",
     "cavlc",
@@ -80,12 +81,12 @@ EPFL_RANDOM_CONTROL: frozenset[str] = frozenset({
     "voter",
 })
 
-#: Every benchmark this loader supports.
-#:
-#: The suite as published has 23 circuits. The three MtM ("more than ten
-#: million gates") benchmarks are not among these: they are distributed via
-#: Zenodo rather than the git repository, and at several gigabytes apiece they
-#: want a different delivery story than an on-demand download.
+# Every benchmark this loader supports.
+#
+# The suite as published has 23 circuits. The three MtM ("more than ten
+# million gates") benchmarks are not among these: they are distributed via
+# Zenodo rather than the git repository, and at several gigabytes apiece they
+# want a different delivery story than an on-demand download.
 EPFL_BENCHMARKS: frozenset[str] = EPFL_ARITHMETIC | EPFL_RANDOM_CONTROL
 
 _CATEGORIES: dict[str, frozenset[str]] = {

--- a/test/benchmarks/test_cache.py
+++ b/test/benchmarks/test_cache.py
@@ -1,0 +1,90 @@
+"""Tests for benchmark cache resolution."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from aigverse.benchmarks import CACHE_ENV_VAR, benchmark_cache, set_benchmark_cache
+
+
+@pytest.fixture(autouse=True)
+def _clear_override() -> None:
+    """Clears an override left behind by a previous test."""
+    set_benchmark_cache(None)
+
+
+def test_the_explicit_override_wins(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`set_benchmark_cache` takes precedence over the environment.
+
+    Args:
+        tmp_path: Directory used as the override.
+        monkeypatch: Used to set a competing environment variable.
+    """
+    monkeypatch.setenv(CACHE_ENV_VAR, str(tmp_path / "from-env"))
+    set_benchmark_cache(tmp_path / "explicit")
+
+    assert benchmark_cache() == (tmp_path / "explicit").resolve()
+
+
+def test_the_environment_variable_is_used(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no override, the environment decides.
+
+    Args:
+        tmp_path: Directory pointed at by the variable.
+        monkeypatch: Used to set the variable.
+    """
+    monkeypatch.setenv(CACHE_ENV_VAR, str(tmp_path))
+
+    assert benchmark_cache() == tmp_path.resolve()
+
+
+def test_clearing_the_override_falls_back(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Passing None must restore the lower-precedence sources.
+
+    Args:
+        tmp_path: Directory used for both sources in turn.
+        monkeypatch: Used to set the environment variable.
+    """
+    monkeypatch.setenv(CACHE_ENV_VAR, str(tmp_path / "from-env"))
+    set_benchmark_cache(tmp_path / "explicit")
+    assert set_benchmark_cache(None) is None
+
+    assert benchmark_cache() == (tmp_path / "from-env").resolve()
+
+
+def test_the_default_is_a_per_user_cache_directory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With nothing configured, benchmarks land somewhere conventional.
+
+    Not the working directory: a sweep run from a repository checkout must not
+    scatter downloaded circuits through it.
+
+    Args:
+        monkeypatch: Used to clear the environment variable.
+    """
+    monkeypatch.delenv(CACHE_ENV_VAR, raising=False)
+
+    default = benchmark_cache()
+
+    assert default.parts[-2:] == ("aigverse", "benchmarks")
+    assert default.is_absolute()
+    assert default != Path.cwd()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="XDG_CACHE_HOME is a POSIX convention")
+def test_xdg_cache_home_is_honoured(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """On Linux the XDG base directory specification decides where the cache goes.
+
+    Args:
+        tmp_path: Directory used as XDG_CACHE_HOME.
+        monkeypatch: Used to set the environment.
+    """
+    monkeypatch.delenv(CACHE_ENV_VAR, raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+
+    if sys.platform == "darwin":
+        pytest.skip("macOS uses ~/Library/Caches rather than XDG")
+
+    assert benchmark_cache() == tmp_path / "aigverse" / "benchmarks"

--- a/test/benchmarks/test_epfl.py
+++ b/test/benchmarks/test_epfl.py
@@ -6,11 +6,13 @@ default; the rest runs offline against a fake server or the cache.
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 import pytest
 
 from aigverse.benchmarks import (
+    DEFAULT_REVISION,
     EPFL_ARITHMETIC,
     EPFL_BENCHMARKS,
     EPFL_RANDOM_CONTROL,
@@ -70,7 +72,7 @@ def test_a_cached_file_is_reused(tmp_path: Path) -> None:
     Args:
         tmp_path: Cache directory for this test.
     """
-    cached = tmp_path / "master" / "arithmetic" / "adder.aig"
+    cached = tmp_path / DEFAULT_REVISION / "arithmetic" / "adder.aig"
     cached.parent.mkdir(parents=True)
     cached.write_bytes(b"not really an aiger file, but non-empty")
 
@@ -84,7 +86,7 @@ def test_an_empty_cached_file_is_not_trusted(tmp_path: Path, monkeypatch: pytest
         tmp_path: Cache directory for this test.
         monkeypatch: Used to make any download attempt fail loudly.
     """
-    stale = tmp_path / "master" / "arithmetic" / "adder.aig"
+    stale = tmp_path / DEFAULT_REVISION / "arithmetic" / "adder.aig"
     stale.parent.mkdir(parents=True)
     stale.write_bytes(b"")
 
@@ -126,16 +128,16 @@ def test_the_revision_is_part_of_the_cache_path(tmp_path: Path) -> None:
     Args:
         tmp_path: Cache directory for this test.
     """
-    for revision in ("master", "abcdef0"):
+    for revision in (DEFAULT_REVISION, "abcdef0"):
         cached = tmp_path / revision / "random_control" / "ctrl.aig"
         cached.parent.mkdir(parents=True)
         cached.write_bytes(b"placeholder")
 
-    assert epfl_path("ctrl", cache_dir=tmp_path).parent.parent.name == "master"
+    assert epfl_path("ctrl", cache_dir=tmp_path).parent.parent.name == DEFAULT_REVISION
     assert epfl_path("ctrl", revision="abcdef0", cache_dir=tmp_path).parent.parent.name == "abcdef0"
 
 
-@pytest.mark.benchmarks
+@pytest.mark.network
 def test_downloading_and_parsing_a_small_benchmark(tmp_path: Path) -> None:
     """The end-to-end path, against the real repository.
 
@@ -153,7 +155,7 @@ def test_downloading_and_parsing_a_small_benchmark(tmp_path: Path) -> None:
     assert ntk.num_gates == 174
 
 
-@pytest.mark.benchmarks
+@pytest.mark.network
 def test_the_second_call_hits_the_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Downloading twice would make a benchmark sweep needlessly slow.
 
@@ -170,3 +172,64 @@ def test_the_second_call_hits_the_cache(tmp_path: Path, monkeypatch: pytest.Monk
     monkeypatch.setattr("urllib.request.urlopen", _refuse)
 
     assert epfl_path("ctrl", cache_dir=tmp_path) == first
+
+
+def test_the_default_revision_is_pinned() -> None:
+    """The default must be a commit, not a branch.
+
+    A moving default would not even be self-consistent: whoever already has a
+    warm cache keeps the old circuit forever, while a newcomer downloads the new
+    one, and the two silently disagree.
+    """
+    assert re.fullmatch(r"[0-9a-f]{40}", DEFAULT_REVISION)
+
+
+@pytest.mark.parametrize(
+    "revision",
+    ["../../../etc", "/absolute", "a/../../b", "..", "", "with space", "semi;colon", "-leading-dash"],
+    ids=["traversal", "absolute", "nested-traversal", "bare-dotdot", "empty", "space", "semicolon", "leading-dash"],
+)
+def test_an_unsafe_revision_is_rejected(revision: str, tmp_path: Path) -> None:
+    """A revision becomes a cache path component, so it must be constrained.
+
+    An absolute value would discard the cache root outright and `..` would climb
+    out of it, letting a caller write benchmark files anywhere.
+
+    Args:
+        revision: The revision under test.
+        tmp_path: Cache directory for this test.
+    """
+    with pytest.raises(ValueError, match="invalid revision"):
+        epfl_path("adder", revision=revision, cache_dir=tmp_path)
+
+
+def test_an_unsafe_revision_writes_nothing_outside_the_cache(tmp_path: Path) -> None:
+    """The rejection must happen before anything touches the filesystem.
+
+    Args:
+        tmp_path: Parent of both the cache and the directory that must stay empty.
+    """
+    cache = tmp_path / "cache"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    with pytest.raises(ValueError, match="invalid revision"):
+        epfl_path("adder", revision="../outside", cache_dir=cache)
+
+    assert list(outside.iterdir()) == []
+    assert not cache.exists()
+
+
+@pytest.mark.parametrize("revision", ["master", "v1.0", "feature/some-branch", DEFAULT_REVISION])
+def test_a_legitimate_revision_is_accepted(revision: str, tmp_path: Path) -> None:
+    """Branches, tags and slash-bearing refs are all valid revisions.
+
+    Args:
+        revision: The revision under test.
+        tmp_path: Cache directory for this test.
+    """
+    cached = tmp_path / revision / "arithmetic" / "adder.aig"
+    cached.parent.mkdir(parents=True)
+    cached.write_bytes(b"placeholder")
+
+    assert epfl_path("adder", revision=revision, cache_dir=tmp_path) == cached

--- a/test/benchmarks/test_epfl.py
+++ b/test/benchmarks/test_epfl.py
@@ -1,0 +1,172 @@
+"""Tests for the EPFL benchmark loader.
+
+Everything that would touch the network is marked `benchmarks` and skipped by
+default; the rest runs offline against a fake server or the cache.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from aigverse.benchmarks import (
+    EPFL_ARITHMETIC,
+    EPFL_BENCHMARKS,
+    EPFL_RANDOM_CONTROL,
+    epfl,
+    epfl_names,
+    epfl_path,
+)
+from aigverse.networks import Aig, NamedAig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_the_suite_has_the_expected_shape() -> None:
+    """The EPFL suite is twenty circuits in two categories of ten."""
+    assert len(EPFL_ARITHMETIC) == 10
+    assert len(EPFL_RANDOM_CONTROL) == 10
+    assert len(EPFL_BENCHMARKS) == 20
+    assert not EPFL_ARITHMETIC & EPFL_RANDOM_CONTROL
+
+
+def test_the_name_sets_are_immutable() -> None:
+    """The tables are frozen, so a caller cannot corrupt them for everyone else."""
+    assert isinstance(EPFL_ARITHMETIC, frozenset)
+    assert isinstance(EPFL_RANDOM_CONTROL, frozenset)
+    assert isinstance(EPFL_BENCHMARKS, frozenset)
+    with pytest.raises(AttributeError):
+        EPFL_ARITHMETIC.add("nope")  # ty: ignore[unresolved-attribute]
+
+
+def test_names_are_listed_sorted_and_by_category() -> None:
+    """`epfl_names` is the discoverable entry point, so it must be ordered."""
+    assert epfl_names() == tuple(sorted(EPFL_BENCHMARKS))
+    assert epfl_names("arithmetic") == tuple(sorted(EPFL_ARITHMETIC))
+    assert epfl_names("random_control") == tuple(sorted(EPFL_RANDOM_CONTROL))
+    assert "adder" in epfl_names("arithmetic")
+    assert "adder" not in epfl_names("random_control")
+
+
+def test_unknown_category_is_rejected() -> None:
+    """An unknown category names the ones that do exist."""
+    with pytest.raises(ValueError, match="unknown category 'sequential'") as excinfo:
+        epfl_names("sequential")
+    assert "arithmetic" in str(excinfo.value)
+
+
+def test_unknown_benchmark_is_rejected_before_any_download() -> None:
+    """A typo must fail immediately and list the alternatives, not hit the network."""
+    with pytest.raises(ValueError, match="unknown EPFL benchmark 'addr'") as excinfo:
+        epfl_path("addr")
+    assert "adder" in str(excinfo.value)
+
+
+def test_a_cached_file_is_reused(tmp_path: Path) -> None:
+    """A populated cache must satisfy the request without any network access.
+
+    Args:
+        tmp_path: Cache directory for this test.
+    """
+    cached = tmp_path / "master" / "arithmetic" / "adder.aig"
+    cached.parent.mkdir(parents=True)
+    cached.write_bytes(b"not really an aiger file, but non-empty")
+
+    assert epfl_path("adder", cache_dir=tmp_path) == cached
+
+
+def test_an_empty_cached_file_is_not_trusted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A zero-byte leftover must be re-fetched rather than returned.
+
+    Args:
+        tmp_path: Cache directory for this test.
+        monkeypatch: Used to make any download attempt fail loudly.
+    """
+    stale = tmp_path / "master" / "arithmetic" / "adder.aig"
+    stale.parent.mkdir(parents=True)
+    stale.write_bytes(b"")
+
+    def _refuse(*_args: object, **_kwargs: object) -> object:
+        msg = "download attempted"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr("urllib.request.urlopen", _refuse)
+
+    with pytest.raises(AssertionError, match="download attempted"):
+        epfl_path("adder", cache_dir=tmp_path)
+
+
+def test_a_failed_download_leaves_no_partial_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An interrupted transfer must not leave something the cache would trust.
+
+    Args:
+        tmp_path: Cache directory for this test.
+        monkeypatch: Used to make the download fail.
+    """
+    import urllib.error
+
+    def _fail(*_args: object, **_kwargs: object) -> object:
+        msg = "no route to host"
+        raise urllib.error.URLError(msg)
+
+    monkeypatch.setattr("urllib.request.urlopen", _fail)
+
+    with pytest.raises(OSError, match="could not download the EPFL benchmark 'ctrl'"):
+        epfl_path("ctrl", cache_dir=tmp_path)
+
+    assert list(tmp_path.rglob("*.aig")) == []
+    assert list(tmp_path.rglob("*.part")) == []
+
+
+def test_the_revision_is_part_of_the_cache_path(tmp_path: Path) -> None:
+    """Two revisions of a benchmark must not share one cache entry.
+
+    Args:
+        tmp_path: Cache directory for this test.
+    """
+    for revision in ("master", "abcdef0"):
+        cached = tmp_path / revision / "random_control" / "ctrl.aig"
+        cached.parent.mkdir(parents=True)
+        cached.write_bytes(b"placeholder")
+
+    assert epfl_path("ctrl", cache_dir=tmp_path).parent.parent.name == "master"
+    assert epfl_path("ctrl", revision="abcdef0", cache_dir=tmp_path).parent.parent.name == "abcdef0"
+
+
+@pytest.mark.benchmarks
+def test_downloading_and_parsing_a_small_benchmark(tmp_path: Path) -> None:
+    """The end-to-end path, against the real repository.
+
+    `ctrl` is the smallest benchmark in the suite, so this stays cheap.
+
+    Args:
+        tmp_path: Cache directory for this test.
+    """
+    ntk = epfl("ctrl", cache_dir=tmp_path)
+
+    assert isinstance(ntk, NamedAig)
+    assert isinstance(ntk, Aig)
+    assert ntk.num_pis == 7
+    assert ntk.num_pos == 26
+    assert ntk.num_gates == 174
+
+
+@pytest.mark.benchmarks
+def test_the_second_call_hits_the_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Downloading twice would make a benchmark sweep needlessly slow.
+
+    Args:
+        tmp_path: Cache directory for this test.
+        monkeypatch: Used to detect a second download attempt.
+    """
+    first = epfl_path("ctrl", cache_dir=tmp_path)
+
+    def _refuse(*_args: object, **_kwargs: object) -> object:
+        msg = "downloaded twice"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr("urllib.request.urlopen", _refuse)
+
+    assert epfl_path("ctrl", cache_dir=tmp_path) == first

--- a/test/benchmarks/test_epfl.py
+++ b/test/benchmarks/test_epfl.py
@@ -136,9 +136,7 @@ def test_a_zero_byte_download_is_rejected(tmp_path: Path, monkeypatch: pytest.Mo
         def read() -> bytes:
             return b""
 
-    monkeypatch.setattr(
-        "urllib.request.urlopen", lambda *_a, **_kw: contextlib.nullcontext(_EmptyResponse())
-    )
+    monkeypatch.setattr("urllib.request.urlopen", lambda *_a, **_kw: contextlib.nullcontext(_EmptyResponse()))
 
     with pytest.raises(OSError, match="downloaded EPFL benchmark 'ctrl' is empty"):
         epfl_path("ctrl", cache_dir=tmp_path)

--- a/test/benchmarks/test_epfl.py
+++ b/test/benchmarks/test_epfl.py
@@ -233,3 +233,36 @@ def test_a_legitimate_revision_is_accepted(revision: str, tmp_path: Path) -> Non
     cached.write_bytes(b"placeholder")
 
     assert epfl_path("adder", revision=revision, cache_dir=tmp_path) == cached
+
+
+@pytest.mark.parametrize(
+    "revision",
+    ["master/", "a//b", "a/./b", "a/.", "./a", "master//"],
+    ids=["trailing-slash", "empty-component", "dot-component", "trailing-dot", "leading-dot", "double-trailing"],
+)
+def test_cache_key_aliases_are_rejected(revision: str, tmp_path: Path) -> None:
+    """Revisions that collapse onto another revision's cache directory are refused.
+
+    The filesystem treats `master/`, `master//` and `master/.` as `master`, so
+    accepting them would serve one revision's circuits under another's name.
+
+    Args:
+        revision: The aliasing revision under test.
+        tmp_path: Cache directory for this test.
+    """
+    with pytest.raises(ValueError, match="invalid revision"):
+        epfl_path("adder", revision=revision, cache_dir=tmp_path)
+
+
+def test_an_alias_cannot_reach_another_revisions_cache(tmp_path: Path) -> None:
+    """Concretely: a trailing slash must not read the pinned revision's circuits.
+
+    Args:
+        tmp_path: Cache directory for this test.
+    """
+    seeded = tmp_path / DEFAULT_REVISION / "arithmetic" / "adder.aig"
+    seeded.parent.mkdir(parents=True)
+    seeded.write_bytes(b"placeholder")
+
+    with pytest.raises(ValueError, match="invalid revision"):
+        epfl_path("adder", revision=DEFAULT_REVISION + "/", cache_dir=tmp_path)

--- a/test/benchmarks/test_epfl.py
+++ b/test/benchmarks/test_epfl.py
@@ -6,6 +6,7 @@ default; the rest runs offline against a fake server or the cache.
 
 from __future__ import annotations
 
+import contextlib
 import re
 from typing import TYPE_CHECKING
 
@@ -116,6 +117,30 @@ def test_a_failed_download_leaves_no_partial_file(tmp_path: Path, monkeypatch: p
     monkeypatch.setattr("urllib.request.urlopen", _fail)
 
     with pytest.raises(OSError, match="could not download the EPFL benchmark 'ctrl'"):
+        epfl_path("ctrl", cache_dir=tmp_path)
+
+    assert list(tmp_path.rglob("*.aig")) == []
+    assert list(tmp_path.rglob("*.part")) == []
+
+
+def test_a_zero_byte_download_is_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty response body must not be published as a cached file.
+
+    Args:
+        tmp_path: Cache directory for this test.
+        monkeypatch: Used to make the download return an empty body.
+    """
+
+    class _EmptyResponse:
+        @staticmethod
+        def read() -> bytes:
+            return b""
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen", lambda *_a, **_kw: contextlib.nullcontext(_EmptyResponse())
+    )
+
+    with pytest.raises(OSError, match="downloaded EPFL benchmark 'ctrl' is empty"):
         epfl_path("ctrl", cache_dir=tmp_path)
 
     assert list(tmp_path.rglob("*.aig")) == []

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,6 +28,8 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
             item.add_marker(pytest.mark.adapters)
         elif "/test/truth_tables/" in test_path:
             item.add_marker(pytest.mark.tts)
+        elif "/test/benchmarks/" in test_path:
+            item.add_marker(pytest.mark.benchmarks)
 
 
 @pytest.fixture


### PR DESCRIPTION
## What

Adds `aigverse.benchmarks`, which fetches standard benchmark suites on demand and caches
them locally. The [EPFL combinational suite](https://github.com/lsils/benchmarks) is
supported out of the box.

```python
from aigverse.benchmarks import epfl, epfl_names

print(epfl_names("arithmetic"))   # ('adder', 'bar', 'div', ...)
aig = epfl("ctrl")                # downloads once, cached thereafter
```

Nothing is bundled with `aigverse` and nothing is downloaded at import time.

## Why

Experiments need circuits, and today every script that wants one carries its own
downloader — URL templates, a category table, a cache directory, retry handling. That is
infrastructure, which is exactly what this library is for.

## Design notes

A few decisions that are not obvious from the diff:

- **Downloads go to a per-user cache directory** (`~/.cache/aigverse/benchmarks` and the
  platform equivalents), deliberately *not* the working directory. A sweep run inside a
  repository checkout must not scatter circuits through it. Overridable per call,
  process-wide via `set_benchmark_cache()`, or through `AIGVERSE_BENCHMARK_CACHE`.
- **The revision is part of the cache path.** The benchmark repository is versioned by
  commit rather than by release and its circuits do change, so `epfl("adder",
  revision="9e5d0ec")` is reproducible and does not collide with the `master` copy.
- **Downloads land in a `.part` file first.** An interrupted transfer must not leave a
  truncated file behind that a later call would happily treat as cached.
- **`epfl()` returns a `NamedAig`.** That is what `read_aiger_into_aig` produces, it is an
  `Aig` everywhere one is expected, and it keeps the AIGER symbol table — so the I/O names
  come along at no cost rather than being thrown away for uniformity.
- **The name tables are `frozenset`s**, so a caller cannot corrupt them for everyone else.

## Testing

Tests that actually download are marked `benchmarks` and skipped by default. That includes
the main CI matrix: a github.com hiccup must not turn every job red over a change that has
nothing to do with the loader. They run in their own path-filtered workflow instead, which
deliberately does not pre-seed the cache, since exercising the real download path is the
point.

The rest runs offline and covers what usually breaks: cache reuse, a zero-byte leftover
not being trusted, a failed download leaving nothing behind, revision isolation, and the
error messages for an unknown benchmark or category.

## Notes

- Independent of the ABC work in #405 — no dependency in either direction.
- `docs/aigs.md` fails to execute on this branch, but it does so on `main` as well; that
  is the bug #407 fixes, surfaced here only because a clean docs build re-executes it
  rather than reading the myst-nb cache. Otherwise this adds zero new docs warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCDkEaZc2dKxHibV5oiMzP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added on-demand access to 20 EPFL combinational benchmarks.
  * Added benchmark listing, loading, revision selection, and cache reuse.
  * Added configurable caching through environment settings or runtime overrides.

* **Documentation**
  * Added a benchmark guide covering loading, reproducibility, inspection, and cache configuration.

* **Tests & CI**
  * Added benchmark-specific coverage and automated tests across major platforms.
  * Updated default test selection to exclude network-dependent tests unless explicitly enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->