### PR TITLE
📝 Add a Visualization documentation page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,8 @@ docs/api/
 docs/example.aig
 docs/example.dot
 docs/example.v
+docs/before.dot
+docs/after.dot
 docs/*.pkl
 docs/aig_pyg_dataset/
 docs/aig_pyg_adj_dataset/

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,7 @@ truth_tables
 algorithms
 generators
 machine_learning
+visualization
 ```
 
 ````{only} not latex

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -16,7 +16,9 @@ mystnb:
 Logic synthesis is inherently structural, and visualizing an AIG is one of the fastest ways to debug a network,
 understand what an optimization pass actually changed, or explain a circuit to someone else. `aigverse` does not
 ship its own plotting library, but it exposes the network structure through standard formats and adapters so that
-mature Python visualization tooling can be used directly.
+mature Python visualization tooling can be used directly. The examples below share a single, non-trivial randomly
+generated AIG (via {py:func}`~aigverse.generators.random_aig`) so that the resulting structures are actually
+interesting to look at.
 
 ## Graphviz (DOT) Export
 
@@ -27,17 +29,11 @@ notebook using the [`graphviz`](https://graphviz.readthedocs.io/) Python package
 ```{code-cell} ipython3
 import graphviz
 
+from aigverse.generators import random_aig
 from aigverse.io import write_dot
-from aigverse.networks import Aig
 
-# Create a sample AIG
-aig = Aig()
-a = aig.create_pi()
-b = aig.create_pi()
-c = aig.create_pi()
-f1 = aig.create_and(a, b)
-f2 = aig.create_or(f1, c)
-aig.create_po(f2)
+# Generate a moderately sized random AIG, reused throughout this page
+aig = random_aig(num_pis=5, num_gates=18, seed=42)
 
 # Write to DOT format
 write_dot(aig, "example.dot")
@@ -57,26 +53,36 @@ The {py:meth}`~aigverse.networks.Aig.to_networkx` adapter converts an AIG into a
 which can be laid out and drawn with [NetworkX](https://networkx.org/) and [Matplotlib](https://matplotlib.org/).
 A full worked example that labels nodes with their level, fanout, type, and function is available in the
 [NetworkX section](machine_learning.md#networkx) of the Machine Learning Integration guide. A minimal version of
-the same workflow:
+the same workflow, using `networkx.multipartite_layout` to place every node on the row that matches its logic
+level (so all primary inputs line up on a single row) and coloring nodes by type:
 
 ```{code-cell} ipython3
 import matplotlib.pyplot as plt
 import networkx as nx
-from networkx.drawing.nx_agraph import graphviz_layout
 
 import aigverse.adapters
 
-# Convert the AIG to a NetworkX graph
-G = aig.to_networkx()
+# Node type one-hot order is [constant, pi, gate, po]
+type_colors = ["black", "#4C72B0", "#DDDDDD", "#55A868"]
 
-# Layer the graph so inputs and outputs are visually separated
-pos = graphviz_layout(G, prog="dot")
-for node, position in pos.items():
-    pos[node] = (position[0], -position[1])
 
-plt.figure(figsize=(6, 4))
-nx.draw(G, pos, with_labels=True, node_color="lightblue", arrows=True, arrowsize=15)
-plt.show()
+def draw_layered(graph, node_colors, node_sizes, *, title):
+    """Draws a NetworkX AIG graph with nodes arranged into rows by logic level."""
+    pos = nx.multipartite_layout(graph, subset_key="level", align="horizontal")
+    plt.figure(figsize=(8, 5))
+    nx.draw(
+        graph, pos, node_color=node_colors, node_size=node_sizes, edgecolors="black", linewidths=0.8,
+        arrows=True, arrowsize=10, width=0.8,
+    )
+    plt.title(title)
+    plt.show()
+
+
+# Convert the AIG to a NetworkX graph, including each node's logic level
+G = aig.to_networkx(levels=True)
+
+node_colors = [type_colors[data["type"].argmax()] for _, data in G.nodes(data=True)]
+draw_layered(G, node_colors, node_sizes=220, title="Random AIG structure")
 ```
 
 ## Highlighting Critical Paths and Fanout
@@ -91,19 +97,11 @@ from aigverse.networks import DepthAig, FanoutAig
 depth_aig = DepthAig(aig)
 fanout_aig = FanoutAig(aig)
 
-G = aig.to_networkx()
-pos = graphviz_layout(G, prog="dot")
-for node, position in pos.items():
-    pos[node] = (position[0], -position[1])
-
 # Synthetic PO nodes (index >= aig.size) represent outputs, not real AIG nodes, so they are excluded here.
-node_colors = ["red" if node < aig.size and depth_aig.is_on_critical_path(node) else "lightgray" for node in G.nodes()]
-node_sizes = [300 + 200 * fanout_aig.fanout_size(node) if node < aig.size else 300 for node in G.nodes()]
+node_colors = ["#C44E52" if node < aig.size and depth_aig.is_on_critical_path(node) else "#DDDDDD" for node in G.nodes()]
+node_sizes = [150 + 60 * fanout_aig.fanout_size(node) if node < aig.size else 150 for node in G.nodes()]
 
-plt.figure(figsize=(6, 4))
-nx.draw(G, pos, with_labels=True, node_color=node_colors, node_size=node_sizes, arrows=True, arrowsize=15)
-plt.title("Critical path (red) and fanout-scaled node size")
-plt.show()
+draw_layered(G, node_colors, node_sizes, title="Critical path (red) and fanout-scaled node size")
 ```
 
 ## Interactive Exploration
@@ -117,7 +115,8 @@ separately.
 ## Before vs. After: Visualizing Optimization
 
 Comparing the DOT (or NetworkX) rendering of a network before and after an optimization pass such as
-{py:func}`~aigverse.algorithms.balancing` visually confirms the effect of the transformation on depth.
+{py:func}`~aigverse.algorithms.balancing` visually confirms the effect of the transformation on depth and gate
+count.
 
 ```{code-cell} ipython3
 from aigverse.algorithms import balancing
@@ -127,8 +126,8 @@ aig_balanced = balancing(aig.clone(), rebalance_function="sop")
 write_dot(aig, "before.dot")
 write_dot(aig_balanced, "after.dot")
 
-print(f"Depth before: {DepthAig(aig).num_levels} levels")
-print(f"Depth after:  {DepthAig(aig_balanced).num_levels} levels")
+print(f"Before: {aig.num_gates} gates, {DepthAig(aig).num_levels} levels")
+print(f"After:  {aig_balanced.num_gates} gates, {DepthAig(aig_balanced).num_levels} levels")
 ```
 
 ```{code-cell} ipython3

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -16,9 +16,8 @@ mystnb:
 Logic synthesis is inherently structural, and visualizing an AIG is one of the fastest ways to debug a network,
 understand what an optimization pass actually changed, or explain a circuit to someone else. `aigverse` does not
 ship its own plotting library, but it exposes the network structure through standard formats and adapters so that
-mature Python visualization tooling can be used directly. The examples below share a single, non-trivial randomly
-generated AIG (via {py:func}`~aigverse.generators.random_aig`) so that the resulting structures are actually
-interesting to look at.
+mature Python visualization tooling can be used directly. The examples below share a single, structured benchmark
+network (see {doc}`generators`) so that the resulting structures are non-trivial and reproducible.
 
 ## Graphviz (DOT) Export
 
@@ -29,11 +28,11 @@ notebook using the [`graphviz`](https://graphviz.readthedocs.io/) Python package
 ```{code-cell} ipython3
 import graphviz
 
-from aigverse.generators import random_aig
+from aigverse.generators import ripple_carry_adder
 from aigverse.io import write_dot
 
-# Generate a moderately sized random AIG, reused throughout this page
-aig = random_aig(num_pis=5, num_gates=18, seed=42)
+# A 4-bit ripple-carry adder, reused throughout this page
+aig = ripple_carry_adder(bitwidth=4)
 
 # Write to DOT format
 write_dot(aig, "example.dot")
@@ -82,7 +81,7 @@ def draw_layered(graph, node_colors, node_sizes, *, title):
 G = aig.to_networkx(levels=True)
 
 node_colors = [type_colors[data["type"].argmax()] for _, data in G.nodes(data=True)]
-draw_layered(G, node_colors, node_sizes=220, title="Random AIG structure")
+draw_layered(G, node_colors, node_sizes=180, title="Ripple-carry adder structure")
 ```
 
 ## Highlighting Critical Paths and Fanout
@@ -114,20 +113,30 @@ separately.
 
 ## Before vs. After: Visualizing Optimization
 
-Comparing the DOT (or NetworkX) rendering of a network before and after an optimization pass such as
-{py:func}`~aigverse.algorithms.balancing` visually confirms the effect of the transformation on depth and gate
-count.
+Comparing the DOT rendering of a network before and after an optimization pipeline visually confirms the effect
+of the transformation on structure, depth, and gate count. A 4-bit carry-lookahead adder makes for a good
+demonstration here, since (unlike the ripple-carry adder above) its structure still leaves room for the
+resubstitution, refactoring, and rewriting passes from the [Algorithms](algorithms.md#optimization) guide to find
+and remove redundant logic.
 
 ```{code-cell} ipython3
-from aigverse.algorithms import balancing
+from aigverse.algorithms import aig_cut_rewriting, aig_resubstitution, balancing, sop_refactoring
+from aigverse.generators import carry_lookahead_adder
+from aigverse.networks import DepthAig
 
-aig_balanced = balancing(aig.clone(), rebalance_function="sop")
+aig_cla = carry_lookahead_adder(bitwidth=4)
 
-write_dot(aig, "before.dot")
-write_dot(aig_balanced, "after.dot")
+aig_optimized = aig_cla.clone()
+aig_optimized = aig_resubstitution(aig_optimized)
+aig_optimized = sop_refactoring(aig_optimized)
+aig_optimized = aig_cut_rewriting(aig_optimized)
+aig_optimized = balancing(aig_optimized, rebalance_function="sop")
 
-print(f"Before: {aig.num_gates} gates, {DepthAig(aig).num_levels} levels")
-print(f"After:  {aig_balanced.num_gates} gates, {DepthAig(aig_balanced).num_levels} levels")
+write_dot(aig_cla, "before.dot")
+write_dot(aig_optimized, "after.dot")
+
+print(f"Before: {aig_cla.num_gates} gates, {DepthAig(aig_cla).num_levels} levels")
+print(f"After:  {aig_optimized.num_gates} gates, {DepthAig(aig_optimized).num_levels} levels")
 ```
 
 ```{code-cell} ipython3

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -1,0 +1,151 @@
+---
+file_format: mystnb
+kernelspec:
+  name: python3
+mystnb:
+  number_source_lines: true
+---
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+%config InlineBackend.figure_formats = ['svg']
+```
+
+# Visualization
+
+Logic synthesis is inherently structural, and visualizing an AIG is one of the fastest ways to debug a network,
+understand what an optimization pass actually changed, or explain a circuit to someone else. `aigverse` does not
+ship its own plotting library, but it exposes the network structure through standard formats and adapters so that
+mature Python visualization tooling can be used directly.
+
+## Graphviz (DOT) Export
+
+The {py:func}`~aigverse.io.write_dot` function writes a network to a
+[Graphviz](https://graphviz.org/) DOT file. Once written, the file can be rendered directly inside a script or
+notebook using the [`graphviz`](https://graphviz.readthedocs.io/) Python package.
+
+```{code-cell} ipython3
+import graphviz
+
+from aigverse.io import write_dot
+from aigverse.networks import Aig
+
+# Create a sample AIG
+aig = Aig()
+a = aig.create_pi()
+b = aig.create_pi()
+c = aig.create_pi()
+f1 = aig.create_and(a, b)
+f2 = aig.create_or(f1, c)
+aig.create_po(f2)
+
+# Write to DOT format
+write_dot(aig, "example.dot")
+
+# Render the DOT file inline
+graphviz.Source.from_file("example.dot")
+```
+
+:::{note}
+Rendering DOT files requires a local Graphviz installation (the `dot` executable) in addition to the `graphviz`
+Python package.
+:::
+
+## NetworkX and Matplotlib
+
+The {py:meth}`~aigverse.networks.Aig.to_networkx` adapter converts an AIG into a {py:class}`~networkx.DiGraph`,
+which can be laid out and drawn with [NetworkX](https://networkx.org/) and [Matplotlib](https://matplotlib.org/).
+A full worked example that labels nodes with their level, fanout, type, and function is available in the
+[NetworkX section](machine_learning.md#networkx) of the Machine Learning Integration guide. A minimal version of
+the same workflow:
+
+```{code-cell} ipython3
+import matplotlib.pyplot as plt
+import networkx as nx
+from networkx.drawing.nx_agraph import graphviz_layout
+
+import aigverse.adapters
+
+# Convert the AIG to a NetworkX graph
+G = aig.to_networkx()
+
+# Layer the graph so inputs and outputs are visually separated
+pos = graphviz_layout(G, prog="dot")
+for node, position in pos.items():
+    pos[node] = (position[0], -position[1])
+
+plt.figure(figsize=(6, 4))
+nx.draw(G, pos, with_labels=True, node_color="lightblue", arrows=True, arrowsize=15)
+plt.show()
+```
+
+## Highlighting Critical Paths and Fanout
+
+Wrapping an AIG in {py:class}`~aigverse.networks.DepthAig` exposes per-node critical-path information, and passing
+`fanouts=True` to {py:meth}`~aigverse.networks.Aig.to_networkx` attaches each node's fanout count directly as a
+graph attribute. Combined, these can be used to color-code a plot, making bottlenecks and high-congestion nodes
+immediately visible.
+
+```{code-cell} ipython3
+from aigverse.networks import DepthAig
+
+depth_aig = DepthAig(aig)
+
+# Request fanout counts as a node attribute
+G = aig.to_networkx(fanouts=True)
+pos = graphviz_layout(G, prog="dot")
+for node, position in pos.items():
+    pos[node] = (position[0], -position[1])
+
+# Color critical-path nodes red, all others gray.
+# Synthetic PO nodes (index >= aig.size) are not real AIG nodes, so they are excluded here.
+node_colors = ["red" if node < aig.size and depth_aig.is_on_critical_path(node) else "lightgray" for node in G.nodes()]
+
+# Size nodes by their fanout count
+node_sizes = [300 + 200 * data["fanouts"] for _, data in G.nodes(data=True)]
+
+plt.figure(figsize=(6, 4))
+nx.draw(G, pos, with_labels=True, node_color=node_colors, node_size=node_sizes, arrows=True, arrowsize=15)
+plt.title("Critical path (red) and fanout-scaled node size")
+plt.show()
+```
+
+:::{note}
+{py:meth}`~aigverse.networks.Aig.to_networkx` adds one synthetic node per primary output (index `>= aig.size`) to
+represent the network's outputs. These synthetic nodes are not valid arguments for
+{py:class}`~aigverse.networks.DepthAig` or {py:class}`~aigverse.networks.FanoutAig` methods, which only operate on
+real AIG nodes.
+:::
+
+## Interactive Exploration
+
+For larger AIGs, a static plot quickly becomes hard to read. Interactive graph-drawing libraries such as
+[pyvis](https://pyvis.readthedocs.io/) or [ipycytoscape](https://ipycytoscape.readthedocs.io/) can render the same
+{py:class}`~networkx.DiGraph` produced by {py:meth}`~aigverse.networks.Aig.to_networkx` as a zoomable, draggable
+graph with hover tooltips for node attributes. These are not dependencies of `aigverse` and must be installed
+separately.
+
+## Before vs. After: Visualizing Optimization
+
+Comparing the DOT (or NetworkX) rendering of a network before and after an optimization pass such as
+{py:func}`~aigverse.algorithms.balancing` visually confirms the effect of the transformation on depth.
+
+```{code-cell} ipython3
+from aigverse.algorithms import balancing
+
+aig_balanced = balancing(aig.clone(), rebalance_function="sop")
+
+write_dot(aig, "before.dot")
+write_dot(aig_balanced, "after.dot")
+
+print(f"Depth before: {DepthAig(aig).num_levels} levels")
+print(f"Depth after:  {DepthAig(aig_balanced).num_levels} levels")
+```
+
+```{code-cell} ipython3
+graphviz.Source.from_file("before.dot")
+```
+
+```{code-cell} ipython3
+graphviz.Source.from_file("after.dot")
+```

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -16,8 +16,10 @@ mystnb:
 Logic synthesis is inherently structural, and visualizing an AIG is one of the fastest ways to debug a network,
 understand what an optimization pass actually changed, or explain a circuit to someone else. `aigverse` does not
 ship its own plotting library, but it exposes the network structure through standard formats and adapters so that
-mature Python visualization tooling can be used directly. The examples below share a single, structured benchmark
-network (see {doc}`generators`) so that the resulting structures are non-trivial and reproducible.
+mature Python visualization tooling can be used directly. The examples below use structured benchmark networks
+(see {doc}`generators`) rather than arbitrary toy circuits, so the resulting structures are non-trivial and
+reproducible: the Graphviz, NetworkX, and highlighting examples share a single ripple-carry adder, while the
+optimization comparison at the end uses a separate carry-lookahead adder.
 
 ## Graphviz (DOT) Export
 
@@ -98,7 +100,7 @@ fanout_aig = FanoutAig(aig)
 
 # Synthetic PO nodes (index >= aig.size) represent outputs, not real AIG nodes, so they are excluded here.
 node_colors = ["#C44E52" if node < aig.size and depth_aig.is_on_critical_path(node) else "#DDDDDD" for node in G.nodes()]
-node_sizes = [150 + 60 * fanout_aig.fanout_size(node) if node < aig.size else 150 for node in G.nodes()]
+node_sizes = [100 + 300 * fanout_aig.fanout_size(node) if node < aig.size else 100 for node in G.nodes()]
 
 draw_layered(G, node_colors, node_sizes, title="Critical path (red) and fanout-scaled node size")
 ```

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -120,11 +120,12 @@ resubstitution, refactoring, and rewriting passes from the [Algorithms](algorith
 and remove redundant logic.
 
 ```{code-cell} ipython3
-from aigverse.algorithms import aig_cut_rewriting, aig_resubstitution, balancing, sop_refactoring
+from aigverse.algorithms import aig_cut_rewriting, aig_resubstitution, balancing, cleanup_dangling, sop_refactoring
 from aigverse.generators import carry_lookahead_adder
 from aigverse.networks import DepthAig
 
-aig_cla = carry_lookahead_adder(bitwidth=4)
+# Generators can leave behind a handful of dead gates; clean those up first for a fair baseline
+aig_cla = cleanup_dangling(carry_lookahead_adder(bitwidth=4))
 
 aig_optimized = aig_cla.clone()
 aig_optimized = aig_resubstitution(aig_optimized)

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -81,41 +81,30 @@ plt.show()
 
 ## Highlighting Critical Paths and Fanout
 
-Wrapping an AIG in {py:class}`~aigverse.networks.DepthAig` exposes per-node critical-path information, and passing
-`fanouts=True` to {py:meth}`~aigverse.networks.Aig.to_networkx` attaches each node's fanout count directly as a
-graph attribute. Combined, these can be used to color-code a plot, making bottlenecks and high-congestion nodes
-immediately visible.
+Wrapping an AIG in {py:class}`~aigverse.networks.DepthAig` or {py:class}`~aigverse.networks.FanoutAig` exposes
+per-node critical-path and fanout information, which can be used to color-code a plot, making bottlenecks and
+high-congestion nodes immediately visible.
 
 ```{code-cell} ipython3
-from aigverse.networks import DepthAig
+from aigverse.networks import DepthAig, FanoutAig
 
 depth_aig = DepthAig(aig)
+fanout_aig = FanoutAig(aig)
 
-# Request fanout counts as a node attribute
-G = aig.to_networkx(fanouts=True)
+G = aig.to_networkx()
 pos = graphviz_layout(G, prog="dot")
 for node, position in pos.items():
     pos[node] = (position[0], -position[1])
 
-# Color critical-path nodes red, all others gray.
-# Synthetic PO nodes (index >= aig.size) are not real AIG nodes, so they are excluded here.
+# Synthetic PO nodes (index >= aig.size) represent outputs, not real AIG nodes, so they are excluded here.
 node_colors = ["red" if node < aig.size and depth_aig.is_on_critical_path(node) else "lightgray" for node in G.nodes()]
-
-# Size nodes by their fanout count
-node_sizes = [300 + 200 * data["fanouts"] for _, data in G.nodes(data=True)]
+node_sizes = [300 + 200 * fanout_aig.fanout_size(node) if node < aig.size else 300 for node in G.nodes()]
 
 plt.figure(figsize=(6, 4))
 nx.draw(G, pos, with_labels=True, node_color=node_colors, node_size=node_sizes, arrows=True, arrowsize=15)
 plt.title("Critical path (red) and fanout-scaled node size")
 plt.show()
 ```
-
-:::{note}
-{py:meth}`~aigverse.networks.Aig.to_networkx` adds one synthetic node per primary output (index `>= aig.size`) to
-represent the network's outputs. These synthetic nodes are not valid arguments for
-{py:class}`~aigverse.networks.DepthAig` or {py:class}`~aigverse.networks.FanoutAig` methods, which only operate on
-real AIG nodes.
-:::
 
 ## Interactive Exploration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,6 +244,7 @@ docs = [
     "sphinx>=8.2.3; python_version >= '3.11'",
     "matplotlib>=3.0.0",
     "pygraphviz>=1.9.0",
+    "graphviz>=0.20",
 ]
 test = [
     { include-group = "adapters" },

--- a/uv.lock
+++ b/uv.lock
@@ -61,6 +61,7 @@ dev = [
 ]
 docs = [
     { name = "furo" },
+    { name = "graphviz" },
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "matplotlib", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "myst-nb" },
@@ -126,6 +127,7 @@ dev = [
 ]
 docs = [
     { name = "furo", specifier = ">=2024.8.6" },
+    { name = "graphviz", specifier = ">=0.20" },
     { name = "matplotlib", specifier = ">=3.0.0" },
     { name = "myst-nb", specifier = ">=1.1.2" },
     { name = "networkx", specifier = ">=3.0.0" },
@@ -937,6 +939,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ec/20/5f5ad4da6a5a27c80f2ed2ee9aee3f9e36c66e56e21c00fde467b2f8f88f/furo-2025.12.19.tar.gz", hash = "sha256:188d1f942037d8b37cd3985b955839fea62baa1730087dc29d157677c857e2a7", size = 1661473, upload-time = "2025-12-19T17:34:40.889Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/b2/50e9b292b5cac13e9e81272c7171301abc753a60460d21505b606e15cf21/furo-2025.12.19-py3-none-any.whl", hash = "sha256:bb0ead5309f9500130665a26bee87693c41ce4dbdff864dbfb6b0dae4673d24f", size = 339262, upload-time = "2025-12-19T17:34:38.905Z" },
+]
+
+[[package]]
+name = "graphviz"
+version = "0.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b3/3ac91e9be6b761a4b30d66ff165e54439dcd48b83f4e20d644867215f6ca/graphviz-0.21.tar.gz", hash = "sha256:20743e7183be82aaaa8ad6c93f8893c923bd6658a04c32ee115edb3c8a835f78", size = 200434, upload-time = "2025-06-15T09:35:05.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/4c/e0ce1ef95d4000ebc1c11801f9b944fa5910ecc15b5e351865763d8657f8/graphviz-0.21-py3-none-any.whl", hash = "sha256:54f33de9f4f911d7e84e4191749cac8cc5653f815b06738c54db9a15ab8b1e42", size = 47300, upload-time = "2025-06-15T09:35:04.433Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Adds a dedicated **Visualization** page to the documentation, centralizing the various ways to visualize AIGs that were previously scattered (a one-line `write_dot` example buried in the "File I/O" section of `aigs.md`) or ML-framed (`to_networkx` documented only under "Machine Learning Integration").

Fixes #309

New `docs/visualization.md` page covers, in order:
- **Graphviz (DOT) export** — `write_dot` + rendering with the `graphviz` Python package.
- **NetworkX + Matplotlib** — a minimal standalone example using `to_networkx`, cross-referencing the full worked example already in `machine_learning.md` rather than duplicating it.
- **Highlighting critical paths and fanout** — color/size nodes using `DepthAig.is_on_critical_path` and `to_networkx(fanouts=True)`, reusing existing APIs (no new bindings needed).
- **Interactive exploration** — a prose-only pointer to `pyvis`/`ipycytoscape` for large graphs, without adding them as dependencies.
- **Before vs. after** — visualizing the effect of `balancing` on network depth.

Registered in the User Guide toctree (`docs/index.md`) after "Machine Learning Integration".

Added `graphviz>=0.20` to the `docs` dependency group in `pyproject.toml`/`uv.lock` (the `graphviz` Python package, distinct from the already-present `pygraphviz`), since the system `dot` binary is already a required build dependency for the docs (via `pygraphviz`).

While writing the highlighting example, I found a real segfault: `to_networkx()` adds synthetic PO pseudo-nodes (index `>= aig.size`) to the returned graph, and passing one of those into `FanoutAig.fanouts()` or `DepthAig.is_on_critical_path()` crashes the native code instead of raising a Python exception. Filed as #418; the doc example works around it by filtering to real AIG nodes and using `to_networkx(fanouts=True)`'s safe, precomputed `fanouts` attribute instead of calling `FanoutAig.fanouts()` directly.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive visualization guide covering Graphviz exports, NetworkX and Matplotlib rendering, critical paths, fanout highlighting, interactive exploration, and before/after optimization comparisons.
  * Added the visualization guide to the User Guide table of contents.

* **Chores**
  * Added Graphviz support for documentation workflows.
  * Excluded generated visualization artifacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->