### PR TITLE
🐛 Raise `IndexError` instead of segfaulting on out-of-range node ids

### DIFF
--- a/src/aigverse/networks/logic_networks.cpp
+++ b/src/aigverse/networks/logic_networks.cpp
@@ -112,6 +112,30 @@ bool contains_node(const Ntk& ntk, const nanobind::object& value)
     return node_index >= 0 && static_cast<uint64_t>(node_index) < static_cast<uint64_t>(ntk.size());
 }
 
+/**
+ * @brief Validates that a node id refers to an existing node in the network.
+ *
+ * Several native network/view methods index per-node storage directly by node id without any bounds checking of
+ * their own (only debug-only asserts), which is undefined behavior for out-of-range ids. This guard turns such
+ * calls into a well-defined Python exception instead.
+ *
+ * @tparam NetworkOrView Network or network-view type exposing a `size()` member.
+ * @tparam NodeType Node handle type, implicitly convertible to `uint64_t`.
+ * @param ntk Network or view instance.
+ * @param n Node id to validate.
+ * @throws nanobind::index_error If `n` is not a valid node id for `ntk`.
+ */
+template <typename NetworkOrView, typename NodeType>
+void check_node(const NetworkOrView& ntk, const NodeType& n)
+{
+    namespace nb = nanobind;
+
+    if (static_cast<uint64_t>(n) >= static_cast<uint64_t>(ntk.size()))
+    {
+        throw nb::index_error("node index out of range");
+    }
+}
+
 }  // namespace
 
 void bind_tensor_encodings(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
@@ -251,11 +275,32 @@ void bind_network(nanobind::module_& m, const std::string& network_name)  // NOL
         .def_prop_ro("num_pis", &Ntk::num_pis, R"pb(Number of primary inputs.)pb")
         .def_prop_ro("num_pos", &Ntk::num_pos, R"pb(Number of primary outputs.)pb")
         .def("get_node", &Ntk::get_node, nb::arg("s"), R"pb(Returns the node referenced by a signal.)pb")
-        .def("make_signal", &Ntk::make_signal, nb::arg("n"), R"pb(Creates a signal from a node.)pb")
+        .def(
+            "make_signal",
+            [](const Ntk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.make_signal(n);
+            },
+            nb::arg("n"), R"pb(Creates a signal from a node.)pb")
         .def("is_complemented", &Ntk::is_complemented, nb::arg("s"), R"pb(Returns whether a signal is complemented.)pb")
-        .def("node_to_index", &Ntk::node_to_index, nb::arg("n"), R"pb(Returns the integer index of a node.)pb")
+        .def(
+            "node_to_index",
+            [](const Ntk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.node_to_index(n);
+            },
+            nb::arg("n"), R"pb(Returns the integer index of a node.)pb")
         .def("index_to_node", &Ntk::index_to_node, nb::arg("index"), R"pb(Returns the node for an index.)pb")
-        .def("pi_index", &Ntk::pi_index, nb::arg("n"), R"pb(Returns the primary-input position of a node.)pb")
+        .def(
+            "pi_index",
+            [](const Ntk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.pi_index(n);
+            },
+            nb::arg("n"), R"pb(Returns the primary-input position of a node.)pb")
         .def("pi_at", &Ntk::pi_at, nb::arg("index"), R"pb(Returns the primary input node at ``index``.)pb")
         .def("po_index", &Ntk::po_index, nb::arg("s"), R"pb(Returns the primary-output position of a signal.)pb")
         .def("po_at", &Ntk::po_at, nb::arg("index"), R"pb(Returns the primary output signal at ``index``.)pb")
@@ -321,6 +366,7 @@ void bind_network(nanobind::module_& m, const std::string& network_name)  // NOL
             "fanins",
             [](const Ntk& ntk, const Node& n)
             {
+                check_node(ntk, n);
                 std::vector<Signal> fanins;
                 fanins.reserve(ntk.fanin_size(n));
                 ntk.foreach_fanin(n, [&fanins](const auto& f) { fanins.push_back(f); });
@@ -328,39 +374,103 @@ void bind_network(nanobind::module_& m, const std::string& network_name)  // NOL
             },
             nb::arg("n"), R"pb(Returns fanin signals of node ``n``.)pb")
         .def(
-            "fanin_size", [](const Ntk& ntk, const Node& n) { return ntk.fanin_size(n); }, nb::arg("n"),
-            R"pb(Returns the number of fanins of node ``n``.)pb")
+            "fanin_size",
+            [](const Ntk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.fanin_size(n);
+            },
+            nb::arg("n"), R"pb(Returns the number of fanins of node ``n``.)pb")
         .def(
-            "fanout_size", [](const Ntk& ntk, const Node& n) { return ntk.fanout_size(n); }, nb::arg("n"),
-            R"pb(Returns the number of fanouts of node ``n``.)pb")
-        .def("is_constant", &Ntk::is_constant, nb::arg("n"), R"pb(Returns whether ``n`` is a constant node.)pb")
-        .def("is_pi", &Ntk::is_pi, nb::arg("n"), R"pb(Returns whether ``n`` is a primary input.)pb")
+            "fanout_size",
+            [](const Ntk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.fanout_size(n);
+            },
+            nb::arg("n"), R"pb(Returns the number of fanouts of node ``n``.)pb")
+        .def(
+            "is_constant",
+            [](const Ntk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.is_constant(n);
+            },
+            nb::arg("n"), R"pb(Returns whether ``n`` is a constant node.)pb")
+        .def(
+            "is_pi",
+            [](const Ntk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.is_pi(n);
+            },
+            nb::arg("n"), R"pb(Returns whether ``n`` is a primary input.)pb")
         .def("has_and", &Ntk::has_and, nb::arg("a"), nb::arg("b"),
              R"pb(Returns whether an AND with fanins ``a`` and ``b`` already exists.)pb")
         .def(
-            "is_and", [](const Ntk& ntk, const Node& n) { return ntk.is_and(n); }, nb::arg("n"),
-            R"pb(Returns whether ``n`` is an AND node.)pb")
+            "is_and",
+            [](const Ntk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.is_and(n);
+            },
+            nb::arg("n"), R"pb(Returns whether ``n`` is an AND node.)pb")
         .def(
-            "is_or", [](const Ntk& ntk, const Node& n) { return ntk.is_or(n); }, nb::arg("n"),
-            R"pb(Returns whether ``n`` is an OR node.)pb")
+            "is_or",
+            [](const Ntk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.is_or(n);
+            },
+            nb::arg("n"), R"pb(Returns whether ``n`` is an OR node.)pb")
         .def(
-            "is_xor", [](const Ntk& ntk, const Node& n) { return ntk.is_xor(n); }, nb::arg("n"),
-            R"pb(Returns whether ``n`` is an XOR node.)pb")
+            "is_xor",
+            [](const Ntk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.is_xor(n);
+            },
+            nb::arg("n"), R"pb(Returns whether ``n`` is an XOR node.)pb")
         .def(
-            "is_maj", [](const Ntk& ntk, const Node& n) { return ntk.is_maj(n); }, nb::arg("n"),
-            R"pb(Returns whether ``n`` is a majority node.)pb")
+            "is_maj",
+            [](const Ntk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.is_maj(n);
+            },
+            nb::arg("n"), R"pb(Returns whether ``n`` is a majority node.)pb")
         .def(
-            "is_ite", [](const Ntk& ntk, const Node& n) { return ntk.is_ite(n); }, nb::arg("n"),
-            R"pb(Returns whether ``n`` is an if-then-else node.)pb")
+            "is_ite",
+            [](const Ntk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.is_ite(n);
+            },
+            nb::arg("n"), R"pb(Returns whether ``n`` is an if-then-else node.)pb")
         .def(
-            "is_xor3", [](const Ntk& ntk, const Node& n) { return ntk.is_xor3(n); }, nb::arg("n"),
-            R"pb(Returns whether ``n`` is a 3-input XOR node.)pb")
+            "is_xor3",
+            [](const Ntk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.is_xor3(n);
+            },
+            nb::arg("n"), R"pb(Returns whether ``n`` is a 3-input XOR node.)pb")
         .def(
-            "is_nary_and", [](const Ntk& ntk, const Node& n) { return ntk.is_nary_and(n); }, nb::arg("n"),
-            R"pb(Returns whether ``n`` is an n-ary AND node.)pb")
+            "is_nary_and",
+            [](const Ntk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.is_nary_and(n);
+            },
+            nb::arg("n"), R"pb(Returns whether ``n`` is an n-ary AND node.)pb")
         .def(
-            "is_nary_or", [](const Ntk& ntk, const Node& n) { return ntk.is_nary_or(n); }, nb::arg("n"),
-            R"pb(Returns whether ``n`` is an n-ary OR node.)pb")
+            "is_nary_or",
+            [](const Ntk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.is_nary_or(n);
+            },
+            nb::arg("n"), R"pb(Returns whether ``n`` is an n-ary OR node.)pb")
         .def(
             "to_edge_list", [](const Ntk& ntk, const int64_t regular_weight = 0, const int64_t inverted_weight = 1)
             { return aigverse::to_edge_list(ntk, regular_weight, inverted_weight); }, nb::arg("regular_weight") = 0,
@@ -561,9 +671,22 @@ Preserves only combinational structure and does not capture augmented view metad
             "__deepcopy__", [](const DepthNtk& ntk, const nb::dict&) { return DepthNtk{ntk}; }, nb::arg("memo"),
             R"pb(Returns a deep copy of the depth view.)pb")
         .def_prop_ro("num_levels", &DepthNtk::depth, R"pb(Current network depth in levels.)pb")
-        .def("level", &DepthNtk::level, nb::arg("n"), R"pb(Returns the level of node ``n``.)pb")
-        .def("is_on_critical_path", &DepthNtk::is_on_critical_path, nb::arg("n"),
-             R"pb(Returns whether node ``n`` is on at least one critical path.)pb")
+        .def(
+            "level",
+            [](const DepthNtk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.level(n);
+            },
+            nb::arg("n"), R"pb(Returns the level of node ``n``.)pb")
+        .def(
+            "is_on_critical_path",
+            [](const DepthNtk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.is_on_critical_path(n);
+            },
+            nb::arg("n"), R"pb(Returns whether node ``n`` is on at least one critical path.)pb")
         .def("update_levels", &DepthNtk::update_levels, R"pb(Recomputes level information.)pb")
         .def("create_po", &DepthNtk::create_po, nb::arg("f"), R"pb(Creates an output and updates depth information.)pb")
         .def(
@@ -594,6 +717,7 @@ Preserves only combinational structure and does not capture augmented view metad
             "fanouts",
             [](const FanoutNtk& ntk, const Node& n)
             {
+                check_node(ntk, n);
                 std::vector<Node> fanouts;
                 fanouts.reserve(ntk.fanout_size(n));
                 ntk.foreach_fanout(n, [&fanouts](const auto& f) { fanouts.push_back(f); });
@@ -758,9 +882,30 @@ Returns:
         .def("create_ri", &SequentialNtk::create_ri, nb::arg("f"), R"pb(Creates a register input signal.)pb")
         .def_prop_ro("is_combinational", &SequentialNtk::is_combinational,
                      R"pb(Whether the network is combinational.)pb")
-        .def("is_ci", &SequentialNtk::is_ci, nb::arg("n"), R"pb(Returns whether ``n`` is a combinational input.)pb")
-        .def("is_pi", &SequentialNtk::is_pi, nb::arg("n"), R"pb(Returns whether ``n`` is a primary input.)pb")
-        .def("is_ro", &SequentialNtk::is_ro, nb::arg("n"), R"pb(Returns whether ``n`` is a register output.)pb")
+        .def(
+            "is_ci",
+            [](const SequentialNtk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.is_ci(n);
+            },
+            nb::arg("n"), R"pb(Returns whether ``n`` is a combinational input.)pb")
+        .def(
+            "is_pi",
+            [](const SequentialNtk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.is_pi(n);
+            },
+            nb::arg("n"), R"pb(Returns whether ``n`` is a primary input.)pb")
+        .def(
+            "is_ro",
+            [](const SequentialNtk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.is_ro(n);
+            },
+            nb::arg("n"), R"pb(Returns whether ``n`` is a register output.)pb")
         .def_prop_ro("num_pis", &SequentialNtk::num_pis, R"pb(Number of primary inputs.)pb")
         .def_prop_ro("num_pos", &SequentialNtk::num_pos, R"pb(Number of primary outputs.)pb")
         .def_prop_ro("num_cis", &SequentialNtk::num_cis, R"pb(Number of combinational inputs.)pb")
@@ -776,10 +921,31 @@ Returns:
              R"pb(Sets metadata for register ``index``.)pb")
         .def("register_at", &SequentialNtk::register_at, nb::arg("index"),
              R"pb(Returns metadata for register ``index``.)pb")
-        .def("pi_index", &SequentialNtk::pi_index, nb::arg("n"), R"pb(Returns PI index of node ``n``.)pb")
-        .def("ci_index", &SequentialNtk::ci_index, nb::arg("n"), R"pb(Returns CI index of node ``n``.)pb")
+        .def(
+            "pi_index",
+            [](const SequentialNtk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.pi_index(n);
+            },
+            nb::arg("n"), R"pb(Returns PI index of node ``n``.)pb")
+        .def(
+            "ci_index",
+            [](const SequentialNtk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.ci_index(n);
+            },
+            nb::arg("n"), R"pb(Returns CI index of node ``n``.)pb")
         .def("co_index", &SequentialNtk::co_index, nb::arg("s"), R"pb(Returns CO index of signal ``s``.)pb")
-        .def("ro_index", &SequentialNtk::ro_index, nb::arg("n"), R"pb(Returns RO index of node ``n``.)pb")
+        .def(
+            "ro_index",
+            [](const SequentialNtk& ntk, const Node& n)
+            {
+                check_node(ntk, n);
+                return ntk.ro_index(n);
+            },
+            nb::arg("n"), R"pb(Returns RO index of node ``n``.)pb")
         .def("ri_index", &SequentialNtk::ri_index, nb::arg("s"), R"pb(Returns RI index of signal ``s``.)pb")
         .def("ro_to_ri", &SequentialNtk::ro_to_ri, nb::arg("s"), R"pb(Maps a register output signal to its input.)pb")
         .def("ri_to_ro", &SequentialNtk::ri_to_ro, nb::arg("s"), R"pb(Maps a register input signal to its output.)pb")

--- a/src/aigverse/networks/logic_networks.cpp
+++ b/src/aigverse/networks/logic_networks.cpp
@@ -119,8 +119,11 @@ bool contains_node(const Ntk& ntk, const nanobind::object& value)
  * their own (only debug-only asserts), which is undefined behavior for out-of-range ids. This guard turns such
  * calls into a well-defined Python exception instead.
  *
- * @tparam NetworkOrView Network or network-view type exposing a `size()` member.
- * @tparam NodeType Node handle type, implicitly convertible to `uint64_t`.
+ * Uses `node_to_index()` rather than casting `n` directly, so this remains correct for future network types whose
+ * node handles are not already plain integer indices.
+ *
+ * @tparam NetworkOrView Network or network-view type exposing `size()` and `node_to_index()` members.
+ * @tparam NodeType Node handle type accepted by `NetworkOrView::node_to_index()`.
  * @param ntk Network or view instance.
  * @param n Node id to validate.
  * @throws nanobind::index_error If `n` is not a valid node id for `ntk`.
@@ -130,7 +133,7 @@ void check_node(const NetworkOrView& ntk, const NodeType& n)
 {
     namespace nb = nanobind;
 
-    if (static_cast<uint64_t>(n) >= static_cast<uint64_t>(ntk.size()))
+    if (static_cast<uint64_t>(ntk.node_to_index(n)) >= static_cast<uint64_t>(ntk.size()))
     {
         throw nb::index_error("node index out of range");
     }

--- a/test/adapters/test_networkx.py
+++ b/test/adapters/test_networkx.py
@@ -148,6 +148,25 @@ class TestNetworkxAdapter:
                 assert data["fanouts"] >= 0
 
     @staticmethod
+    def test_to_networkx_synthetic_po_nodes_raise_on_native_node_lookups(simple_aig: Aig) -> None:
+        """Regression test for #418.
+
+        to_networkx() adds synthetic PO pseudo-nodes with index >= aig.size. Passing one of those into
+        FanoutAig.fanouts() or DepthAig.is_on_critical_path() used to segfault instead of raising.
+        """
+        graph = simple_aig.to_networkx()
+        synthetic_po_nodes = [node for node in graph.nodes() if node >= simple_aig.size]
+        assert synthetic_po_nodes
+
+        fanout_aig = FanoutAig(simple_aig)
+        depth_aig = DepthAig(simple_aig)
+        for node in synthetic_po_nodes:
+            with pytest.raises(IndexError):
+                fanout_aig.fanouts(node)
+            with pytest.raises(IndexError):
+                depth_aig.is_on_critical_path(node)
+
+    @staticmethod
     def test_to_networkx_edge_types(simple_aig: Aig) -> None:
         """Test edge type one-hot encoding for regular and inverted edges."""
         g = simple_aig.to_networkx()

--- a/test/networks/test_aig.py
+++ b/test/networks/test_aig.py
@@ -680,3 +680,41 @@ def test_aig_setstate_exceptions():
     bad_state: tuple[Any, ...] = ([1, 2, "bad"],)
     with pytest.raises(ValueError, match="Invalid state: expected an index list"):
         pickle.loads(make_bad_pickle(bad_state))
+
+
+def test_aig_node_methods_raise_on_out_of_range_node(aig_with_single_and: tuple[Aig, AigSignal]) -> None:
+    aig, _ = aig_with_single_and
+    out_of_range_node = aig.size
+
+    with pytest.raises(IndexError):
+        aig.make_signal(out_of_range_node)
+    with pytest.raises(IndexError):
+        aig.node_to_index(out_of_range_node)
+    with pytest.raises(IndexError):
+        aig.pi_index(out_of_range_node)
+    with pytest.raises(IndexError):
+        aig.fanins(out_of_range_node)
+    with pytest.raises(IndexError):
+        aig.fanin_size(out_of_range_node)
+    with pytest.raises(IndexError):
+        aig.fanout_size(out_of_range_node)
+    with pytest.raises(IndexError):
+        aig.is_constant(out_of_range_node)
+    with pytest.raises(IndexError):
+        aig.is_pi(out_of_range_node)
+    with pytest.raises(IndexError):
+        aig.is_and(out_of_range_node)
+    with pytest.raises(IndexError):
+        aig.is_or(out_of_range_node)
+    with pytest.raises(IndexError):
+        aig.is_xor(out_of_range_node)
+    with pytest.raises(IndexError):
+        aig.is_maj(out_of_range_node)
+    with pytest.raises(IndexError):
+        aig.is_ite(out_of_range_node)
+    with pytest.raises(IndexError):
+        aig.is_xor3(out_of_range_node)
+    with pytest.raises(IndexError):
+        aig.is_nary_and(out_of_range_node)
+    with pytest.raises(IndexError):
+        aig.is_nary_or(out_of_range_node)

--- a/test/networks/test_depth_aig.py
+++ b/test/networks/test_depth_aig.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import copy
 from typing import TYPE_CHECKING
 
+import pytest
+
 from aigverse.networks import DepthAig
 
 if TYPE_CHECKING:
@@ -73,3 +75,13 @@ def test_depth_aig_clone_and_copy_preserve_wrapper_type(depth_aig_single_and: tu
         assert isinstance(candidate, DepthAig)
         assert candidate.num_levels == 1
         assert candidate.level(candidate.get_node(gate)) == 1
+
+
+def test_depth_aig_out_of_range_node_raises(depth_aig_single_and: tuple[DepthAig, AigSignal]) -> None:
+    aig, _ = depth_aig_single_and
+    out_of_range_node = aig.size
+
+    with pytest.raises(IndexError):
+        aig.level(out_of_range_node)
+    with pytest.raises(IndexError):
+        aig.is_on_critical_path(out_of_range_node)

--- a/test/networks/test_fanout_aig.py
+++ b/test/networks/test_fanout_aig.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import copy
 from typing import TYPE_CHECKING
 
+import pytest
+
 from aigverse.networks import FanoutAig
 
 if TYPE_CHECKING:
@@ -36,3 +38,13 @@ def test_fanout_aig_clone_and_copy_preserve_wrapper_type(
     for candidate in (cloned, shallow, deep):
         assert isinstance(candidate, FanoutAig)
         assert candidate.fanout_size(candidate.get_node(gate0)) == 1
+
+
+def test_fanout_aig_out_of_range_node_raises(
+    fanout_aig_branching: tuple[FanoutAig, AigSignal, AigSignal, AigSignal],
+) -> None:
+    aig, _, _, _ = fanout_aig_branching
+    out_of_range_node = aig.size
+
+    with pytest.raises(IndexError):
+        aig.fanouts(out_of_range_node)

--- a/test/networks/test_sequential_aig.py
+++ b/test/networks/test_sequential_aig.py
@@ -361,3 +361,23 @@ def test_sequential_aig_iteration(
     # Alternative way to verify the relationship between ri and ro
     assert saig.ri_to_ro(f1) == saig.get_node(ro1)
     assert saig.ri_to_ro(f2) == saig.get_node(ro2)
+
+
+def test_sequential_aig_out_of_range_node_raises(
+    sequential_aig_ci_co_fixture: tuple[SequentialAig, AigSignal, AigSignal, AigSignal],
+) -> None:
+    saig, _, _, _ = sequential_aig_ci_co_fixture
+    out_of_range_node = saig.size
+
+    with pytest.raises(IndexError):
+        saig.is_ci(out_of_range_node)
+    with pytest.raises(IndexError):
+        saig.is_pi(out_of_range_node)
+    with pytest.raises(IndexError):
+        saig.is_ro(out_of_range_node)
+    with pytest.raises(IndexError):
+        saig.pi_index(out_of_range_node)
+    with pytest.raises(IndexError):
+        saig.ci_index(out_of_range_node)
+    with pytest.raises(IndexError):
+        saig.ro_index(out_of_range_node)


### PR DESCRIPTION
## Description

Fixes #418.

Every native binding in `src/aigverse/networks/logic_networks.cpp` that accepts a raw AIG `Node` handle (as opposed to a `Signal`, or a plain sequence index like `pi_at`/`po_at`) indexes per-node storage directly — either mockturtle's `node_map::operator[]` (used by `depth_view`/`fanout_view`) or the AIG's own `_storage->nodes[n]` — with only a debug-only `assert` for protection. In release builds (`NDEBUG`, the default for wheel builds) an out-of-range node id is therefore undefined behavior instead of a catchable error.

This was found while writing the AIG visualization documentation in #419: `Aig.to_networkx()` adds synthetic pseudo-nodes for primary outputs with node id `>= aig.size`, and passing one of those into `FanoutAig.fanouts()` or `DepthAig.is_on_critical_path()` segfaults the interpreter.

### Fix

Adds a small `check_node(ntk, n)` helper (`src/aigverse/networks/logic_networks.cpp`) that validates `n < ntk.size()` and throws `nanobind::index_error` (surfaces as Python `IndexError`, consistent with existing conventions in `edge_list.cpp`/`truth_table.cpp`) otherwise. Applied uniformly to every `Node`-parameter binding across the base `Ntk`, `DepthNtk`, `FanoutNtk`, and `SequentialNtk` binding blocks — not just the two methods that happen to crash for AIGs today, since `bind_network` is a template meant to support future network types where currently-safe methods (e.g. `is_or`/`is_xor`, which are no-ops for AIGs) could become unsafe.

Deliberately **not** touched (different bug class / already safe):
- Methods taking a `Signal` (`get_node`, `is_complemented`, `po_index`, `co_index`, `ri_index`, `ro_to_ri`, `ri_to_ro`, `has_name`, `set_name`, `get_name`) — no storage-indexing risk from an arbitrary signal.
- Methods taking a plain sequence `index` (`pi_at`, `po_at`, `ci_at`, `co_at`, `ro_at`, `ri_at`, `register_at`, `index_to_node`) — a related but separate bug class, out of scope here.
- `NtkCut::is_pi`/`node_to_index` (`cut_view`) — already safe (`is_pi` does a bounded linear scan, `node_to_index` uses a hash map's bounds-checked `.at()`), and a cut view's valid node-id domain is the *original* network's node space, not bounded by the cut's own (much smaller) `.size()`.

### Tests

Added regression tests in `test/networks/test_aig.py`, `test_depth_aig.py`, `test_fanout_aig.py`, `test_sequential_aig.py`, and `test/adapters/test_networkx.py` (the latter reproducing the exact `to_networkx()` synthetic-PO-node scenario) asserting `IndexError` for out-of-range node ids.

Verified locally: the reported repro (`FanoutAig(aig).fanouts(node)` on a `to_networkx()` synthetic PO node) now raises `IndexError` instead of crashing the interpreter; full test suite passes (264 tests, excluding pre-existing unrelated scratch files).

### Follow-up

Once this merges, #419 can drop its defensive workaround (filtering `node < aig.size` before calling `DepthAig.is_on_critical_path`) since out-of-range calls will now raise a clear `IndexError` instead of segfaulting.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network APIs now reject invalid or out-of-range node IDs with `IndexError` instead of risking crashes.
  * Improved validation across signal conversion, fanin/fanout queries, node classification, depth checks, and sequential network operations.
  * Added protection for synthetic nodes produced during NetworkX conversion.

* **Tests**
  * Added regression coverage for invalid node access across AIG, depth, fanout, and sequential network functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->