### PR TITLE
🐛 Remove ineffective `cp313t-*` cibuildwheel skip selector

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ testpaths = ["test/"]
 
 [tool.cibuildwheel]
 build = "cp3*"
-skip = ["*-musllinux_*", "cp313t-*"]
+skip = ["*-musllinux_*"]
 archs = "auto64"
 build-frontend = "build[uv]"
 test-groups = ["test", "torch"]


### PR DESCRIPTION
## Summary
- cibuildwheel CI jobs emit a warning: `Invalid skip selector: 'cp313t-*'. This selector matches a group that wasn't enabled.`
- The `cp313t` (free-threaded Python 3.13) group is opt-in in cibuildwheel and this project never enables it via `enable = [...]`, so the skip entry is a no-op.
- Removes the dead `"cp313t-*"` entry from `skip` in `pyproject.toml`.

## Test plan
- [x] `grep -n cp313t pyproject.toml` returns nothing
- [ ] Confirm the warning no longer appears in the next cibuildwheel CI run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building free-threaded CPython 3.13 wheels.

* **Build Improvements**
  * Continued excluding musllinux wheel builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->