### PR TITLE
📝 Suppress stderr in the NetworkX doc's graphviz cell

### DIFF
--- a/docs/machine_learning.md
+++ b/docs/machine_learning.md
@@ -59,6 +59,8 @@ extract node and edge features, visualize the structure (e.g., with [Matplotlib]
 the graph into downstream model pipelines.
 
 ```{code-cell} ipython3
+:tags: [remove-stderr]
+
 import matplotlib.pyplot as plt
 import networkx as nx
 from networkx.drawing.nx_agraph import graphviz_layout


### PR DESCRIPTION
## Description

Fixes #423

The `Fontconfig warning: ... unknown element "reset-dirs"` rendered in the docs comes from `dot` (invoked via `graphviz_layout` in the NetworkX example) printing to stderr on the ReadTheDocs build image (Ubuntu 24.04's fontconfig doesn't understand the `<reset-dirs>` element used by `/usr/share/fontconfig/conf.avail/05-reset-dirs-sample.conf`). MyST-NB captures and renders that stderr as cell output, which is how it ends up embedded in the built page — it's a docs-rendering issue, not something wrong with aigverse's code or the fontconfig file itself.

This alternative to #424 fixes it at the doc-tooling level instead of patching the OS's fontconfig files during the RTD build: MyST-NB has a built-in `remove-stderr` cell tag for exactly this (https://myst-nb.readthedocs.io/en/latest/render/format_code_cells.html), and the codebase already uses the same `:tags: [...]` convention elsewhere (e.g. `remove-cell`, `skip-execution`). This suppresses stderr output for just that one cell — no environment-specific system-file patching required — and I verified locally that without the tag the fontconfig warning is embedded verbatim in `docs/_build/html/machine_learning.html`, and with it, it's gone.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the NetworkX example to hide standard-error output when the notebook is executed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->