### PR TITLE
🐛 Give each pinned revision its own emoji in Renovate commits

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -111,18 +111,57 @@
       commitMessagePrefix: "⬆\uFE0F\uD83D\uDC0D",
     },
     {
+      // Everything the custom managers above track is a pinned revision of an
+      // external project, so the shared parts live here and the three rules
+      // below only differ where they have to.
       matchManagers: [
         "custom.regex"
       ],
       addLabels: [
-        "dependencies",
+        "dependencies"
+      ],
+      // `:automergeDigest` (inherited from extends) would otherwise merge these
+      // unattended. Each of these pins decides an outcome rather than a version
+      // -- the C++ core we build against, the ABC our results come from, or the
+      // circuits we measure -- so all three get reviewed.
+      automerge: false,
+    },
+    // All three custom managers report as `custom.regex`, so matching on the
+    // manager alone gives them one shared prefix and one shared set of labels --
+    // which is how ABC bumps ended up announcing themselves with mockturtle's
+    // turtle. They are told apart by dependency name, which is unique to each.
+    // A fourth custom manager needs a rule here too, or its commits carry no
+    // emoji prefix at all.
+    {
+      description: "mockturtle is the C++ core aigverse is built on",
+      matchDepNames: [
+        "marcelwa/mockturtle"
+      ],
+      addLabels: [
         "C++",
         "build_system"
       ],
       commitMessagePrefix: "⬆\uFE0F\uD83D\uDC22",
-      // `:automergeDigest` (inherited from extends) would otherwise merge these
-      // unattended. A mockturtle bump changes the C++ core, so it gets reviewed.
-      automerge: false,
+    },
+    {
+      description: "ABC is an external binary the integration tests and the docs build",
+      matchDepNames: [
+        "berkeley-abc/abc"
+      ],
+      addLabels: [
+        "testing"
+      ],
+      commitMessagePrefix: "⬆\uFE0F\uD83C\uDD70\uFE0F",
+    },
+    {
+      description: "The EPFL suite is the circuit data the benchmark loader fetches",
+      matchDepNames: [
+        "lsils/benchmarks"
+      ],
+      addLabels: [
+        "benchmarks"
+      ],
+      commitMessagePrefix: "⬆\uFE0F\uD83D\uDCCA",
     },
     {
       description: "Group and automerge all patch updates",


### PR DESCRIPTION
## Description

[#428](https://github.com/marcelwa/aigverse/pull/428) bumped ABC and announced it as `⬆️🐢 Update berkeley-abc/abc digest`, wearing mockturtle's turtle.

The three custom managers — mockturtle, ABC, and the EPFL suite — all report as `custom.regex`, and the single package rule covering them matched on the manager alone. So all three inherited one commit prefix and one set of labels, both written for mockturtle: the turtle, plus `C++` and `build_system`, which describe neither an external binary the tests build nor a directory of benchmark circuits.

They are now told apart by dependency name, which is unique to each:

| manager tracks | prefix | labels |
|---|---|---|
| `marcelwa/mockturtle` | ⬆️🐢 | `dependencies`, `C++`, `build_system` |
| `berkeley-abc/abc` | ⬆️🅰️ | `dependencies`, `testing` |
| `lsils/benchmarks` | ⬆️📊 | `dependencies`, `benchmarks` |

Each emoji is the one the repository already uses for that thing — 🅰️ from `🅰️ • ABC`, 📊 from `📊 • Benchmarks` — and every label already exists in the repository rather than being invented here.

What is genuinely shared stays on one rule: the `dependencies` label, and `automerge: false`, which stops `:automergeDigest` from merging these unattended. That matters for all three, since each pin decides an outcome rather than a version — the C++ core we build against, the ABC our results come from, or the circuits we measure.

## Testing

- `prek run check-renovate --all-files` passes, so the config still validates against Renovate's schema.
- The escape sequences were decoded back to characters to confirm they render as 🐢, 🅰️, and 📊; the file's existing convention of a literal `⬆` followed by `\uXXXX` escapes is preserved.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBpF9H6mvHQSa24jZ2E44p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update handling for project-specific dependencies.
  * Added clearer categorization and descriptions for dependency update requests.
  * Disabled automatic merging for these updates to support additional review before integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->