### PR TITLE
🏷️ Fix the one-hot encoding annotations in the NetworkX adapter

### DIFF
--- a/python/aigverse/adapters/networkx.py
+++ b/python/aigverse/adapters/networkx.py
@@ -80,15 +80,17 @@ def to_networkx(
         - name (str, optional): Signal name or primary output name for edges to synthetic
             PO nodes (only for :class:`~aigverse.NamedAig`).
     """
-    # one-hot encodings for node types: [const, pi, gate, po]
-    node_type_const: Final[np.ndarray[Any, np.dtype[np.int8]]] = np.array([1, 0, 0, 0], dtype=dtype)
-    node_type_pi: Final[np.ndarray[Any, np.dtype[np.int8]]] = np.array([0, 1, 0, 0], dtype=dtype)
-    node_type_gate: Final[np.ndarray[Any, np.dtype[np.int8]]] = np.array([0, 0, 1, 0], dtype=dtype)
-    node_type_po: Final[np.ndarray[Any, np.dtype[np.int8]]] = np.array([0, 0, 0, 1], dtype=dtype)
+    # one-hot encodings for node types: [const, pi, gate, po]. The element type
+    # follows the `dtype` argument, so it is not `np.int8` unless that is what the
+    # caller asked for.
+    node_type_const: Final[np.ndarray[Any, np.dtype[np.generic]]] = np.array([1, 0, 0, 0], dtype=dtype)
+    node_type_pi: Final[np.ndarray[Any, np.dtype[np.generic]]] = np.array([0, 1, 0, 0], dtype=dtype)
+    node_type_gate: Final[np.ndarray[Any, np.dtype[np.generic]]] = np.array([0, 0, 1, 0], dtype=dtype)
+    node_type_po: Final[np.ndarray[Any, np.dtype[np.generic]]] = np.array([0, 0, 0, 1], dtype=dtype)
 
     # one-hot encodings for edge types: [regular, inverted]
-    edge_type_regular: Final[np.ndarray[Any, np.dtype[np.int8]]] = np.array([1, 0], dtype=dtype)
-    edge_type_inverted: Final[np.ndarray[Any, np.dtype[np.int8]]] = np.array([0, 1], dtype=dtype)
+    edge_type_regular: Final[np.ndarray[Any, np.dtype[np.generic]]] = np.array([1, 0], dtype=dtype)
+    edge_type_inverted: Final[np.ndarray[Any, np.dtype[np.generic]]] = np.array([0, 1], dtype=dtype)
 
     # Check if this is a NamedAig
     self_named = self if isinstance(self, NamedAig) else None


### PR DESCRIPTION
## Description

`nox -s lint` currently fails on a clean `main` with six `invalid-assignment` errors from `ty`, all in `python/aigverse/adapters/networkx.py`:

```
error[invalid-assignment]: Object of type `NDArray[generic[Any]]` is not assignable to `ndarray[Any, dtype[signedinteger[_8Bit]]]`
  --> python/aigverse/adapters/networkx.py:84:66
```

`to_networkx` takes a `dtype: type[np.generic] = np.int8` and builds its one-hot encodings with `np.array(..., dtype=dtype)`, so their element type follows whatever the caller passed. The six locals were nonetheless annotated `np.ndarray[Any, np.dtype[np.int8]]`, which is correct only for the default — and contradicts the docstring right above them, which already says *"The data type is determined by the `dtype` argument, defaulting to `numpy.int8`."*

The annotations were therefore always wrong; `ty` used to infer `Any` for these calls and let it pass, and now infers `NDArray[generic[Any]]` and reports it. Widening them to `np.dtype[np.generic]` matches both the inferred type and the documented behavior.

This is not a latent runtime bug — the values were always built from `dtype` correctly, only the annotations disagreed. Confirmed empirically that the element type does follow the argument:

```
requested int8     -> one-hot vectors are int8
requested float32  -> one-hot vectors are float32
requested int64    -> one-hot vectors are int64
requested bool     -> one-hot vectors are bool
```

Branched from `main` rather than folded into #410, since it is unrelated to that PR and is what turns its lint job red.

Fixes no tracked issue.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

<details>
<summary>Notes on the checklist</summary>

**Tests and documentation:** no new tests. Annotations on local variables are never evaluated by CPython, so there is no observable behavior to pin — the module's compiled opcode stream is identical before and after the change (verified by diffing normalized `dis` output: 647 instructions, streams equal). The existing 46 adapter tests cover the runtime behavior and pass; the full default suite is 396 passed, 80 skipped (all ABC, no binary installed locally). The docstring already documented the correct behavior, so it needed no change.

**Warnings:** `prek run --all-files` is now fully green on this branch, `ty` included.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fDo8rC2BN6gRqqgXmyqQo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that node and edge one-hot encoding values use the requested data type.
* **Bug Fixes**
  * Improved type handling so encoding metadata accurately reflects the selected NumPy data type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->