### PR TITLE
📝 Add a changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,5 +12,6 @@ This checklist serves as a reminder of a couple of things that ensure your pull 
 
 - [ ] The pull request only contains commits that are related to it.
 - [ ] I have added appropriate tests and documentation.
+- [ ] I have added a changelog entry for any noteworthy addition, change, fix, or removal.
 - [ ] I have made sure that all CI jobs on GitHub pass.
 - [ ] The pull request introduces no new warnings and follows the project's style guidelines.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,11 @@ Prefix every commit subject and PR title with a plain [gitmoji](https://gitmoji.
 `🐛`, `📝`) — not the `:shortcode:` text form. See [gitmoji.dev](https://gitmoji.dev) for the full list; a few
 common ones: `✨` new feature, `🐛` bug fix, `📝` docs, `♻️` refactor, `⬆️` dependency bump.
 
+A changelog entry carries the same gitmoji, one sentence, and closes with the pull request reference and every
+contributing author — `- ✨ Add cut enumeration over AIGs ([#368]) ([**@wjrforcyber**])`. Define the two links at
+the bottom of `CHANGELOG.md`, in the `PR links` and `Contributor` blocks. Within a category the newest entry goes
+first.
+
 ## Boundaries
 
 - **Always:** run `uvx nox -s lint` and `uvx nox -s tests-3.12` before considering a change complete; regenerate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,9 +143,9 @@ Prefix every commit subject and PR title with a plain [gitmoji](https://gitmoji.
 common ones: `✨` new feature, `🐛` bug fix, `📝` docs, `♻️` refactor, `⬆️` dependency bump.
 
 A changelog entry carries the same gitmoji, one sentence, and closes with the pull request reference and every
-contributing author — `- ✨ Add cut enumeration over AIGs ([#368]) ([**@wjrforcyber**])`. Define the two links at
-the bottom of `CHANGELOG.md`, in the `PR links` and `Contributor` blocks. Within a category the newest entry goes
-first.
+contributing author — `- 📝 Add a visualization page to the documentation ([#419]) ([**@marcelwa**])`. Define the
+two links at the bottom of `CHANGELOG.md`, in the `PR links` and `Contributor` blocks. Within a category the newest
+entry goes first.
 
 ## Boundaries
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,9 @@ common ones: `✨` new feature, `🐛` bug fix, `📝` docs, `♻️` refactor, 
 A changelog entry carries the same gitmoji, one sentence, and closes with the pull request reference and every
 contributing author — `- 📝 Add a visualization page to the documentation ([#419]) ([**@marcelwa**])`. Define the
 two links at the bottom of `CHANGELOG.md`, in the `PR links` and `Contributor` blocks. Within a category the newest
-entry goes first.
+entry goes first. Routine Renovate and pre-commit.ci bumps are left out entirely; a user-observable dependency
+change from one of those bots (e.g. a runtime dependency version bump) still gets an entry, but without a
+contributor link, since the bot isn't one.
 
 ## Boundaries
 
@@ -154,7 +156,7 @@ entry goes first.
   update `CHANGELOG.md` for user-facing changes. Only touch `UPGRADING.md` for **breaking** changes — i.e. ones that
   require users to change their own code to keep working (renamed/removed APIs, changed defaults, moved modules).
   A user-facing but non-breaking addition (a new function, an added optional parameter) belongs in `CHANGELOG.md`
-  only, not `UPGRADING.md`. Prefix commit messages and PR titles with a gitmoji shortcode (see
+  only, not `UPGRADING.md`. Prefix commit messages and PR titles with a plain gitmoji character (see
   [Commit & PR Conventions](#commit--pr-conventions)).
 - **Ask first:** before adding new dependencies to `pyproject.toml`; before major architectural changes to the C++
   core; before modifying CI workflows in `.github/workflows/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,168 @@
+<!-- Entries in each category are sorted by merge time, with the latest PRs appearing first. -->
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on a mixture of [Keep a Changelog] and [Common Changelog].
+This project adheres to [Semantic Versioning], with the exception that minor
+releases may include breaking changes.
+
+## [Unreleased]
+
+### Added
+
+- ✨ Add the `aigverse.abc` module, a bridge that runs the optimization scripts
+  and commands of an externally installed ABC ([#405]) ([**@marcelwa**])
+
+### Changed
+
+- ⬆️ Update `nanobind` to version 2.14.0 ([#430])
+
+### Fixed
+
+- 🏷️ Fix the one-hot encoding annotations in the NetworkX adapter, which pinned
+  `int8` regardless of the `dtype` the caller passed ([#435]) ([**@marcelwa**])
+
+## [0.1.3] - 2026-08-04
+
+### Added
+
+- ✨ Add a benchmark loader that fetches and caches the EPFL suite on demand
+  ([#409]) ([**@marcelwa**])
+- ✨ Emit `llms.txt` and `llms-full.txt` from the documentation build, so agents
+  read the docs as markdown instead of scraping HTML ([#417]) ([**@marcelwa**])
+- 📝 Add a visualization page to the documentation ([#419]) ([**@marcelwa**])
+
+### Changed
+
+- 👷 Track the pinned `mockturtle` revision with a Renovate custom manager
+  ([#404]) ([**@marcelwa**])
+
+### Fixed
+
+- 🐛 Raise `IndexError` instead of segfaulting on an out-of-range node ID
+  ([#420]) ([**@marcelwa**])
+- 🐛 Fix the named AIG example in the AIG documentation ([#407])
+  ([**@marcelwa**])
+- 👷 Drop the `cp313t-*` `cibuildwheel` skip selector, which matched a group the
+  project never enables and made every wheel job warn ([#421]) ([**@marcelwa**])
+
+## [0.1.2] - 2026-07-24
+
+### Added
+
+- ✨ Add cut enumeration over AIGs ([#368]) ([**@wjrforcyber**])
+- ✨ Add `to_graph_tensors`, which exports an AIG as DLPack sparse tensors for
+  zero-copy interop with PyTorch, JAX, and TensorFlow ([#308]) ([**@marcelwa**])
+- 👷 Add a Zizmor workflow that scans the GitHub Actions workflows and uploads
+  its findings to code scanning ([#392]) ([**@marcelwa**])
+- 📝 Add `AGENTS.md` and `WORKFLOW.md` to steer agentic coding tools ([#382])
+  ([**@marcelwa**])
+- 📝 Document edge lists in the AIG guide ([#389]) ([**@marcelwa**])
+- 📝 Document the gitmoji convention for commit messages and pull request titles
+  ([#390]) ([**@marcelwa**])
+
+### Changed
+
+- ⬆️ Update `mockturtle` to the latest `mnt` revision ([#388]) ([**@marcelwa**])
+- ⬆️ Update `nanobind` to version 2.13.0 ([#369])
+
+### Fixed
+
+- 🐛 Fix ASCII AIGER parsing for constant outputs ([#394]) ([**@marcelwa**])
+- 📝 Fix role rendering and broken links in the documentation, and the PyTorch
+  sparse tensor warning it raised ([#395]) ([**@marcelwa**])
+
+## [0.1.1] - 2026-05-18
+
+### Fixed
+
+- 🐛 Stop `to_edge_list` from collapsing duplicate primary outputs ([#358])
+  ([**@marcelwa**])
+
+## [0.1.0] - 2026-05-09
+
+_If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#010)._
+
+### Added
+
+- ✨ Expose the network generators through the new `aigverse.generators` module
+  ([#305]) ([**@marcelwa**])
+- 📝 Add docstrings to every module and symbol ([#303]) ([**@marcelwa**])
+
+### Changed
+
+- 💥 Split the monolithic package into the `networks`, `algorithms`, `io`, and
+  `utils` extension modules ([#285]) ([**@marcelwa**])
+- 💥 Rework the API to be Pythonic: the optimization passes return a new cleaned
+  `Aig` by default and take `inplace`, and `cleanup_dangling` moves to
+  `aigverse.algorithms` ([#298]) ([**@marcelwa**])
+- 💥 Make every optimization parameter except the input network keyword-only
+  ([#306]) ([**@marcelwa**])
+- ♻️ Migrate the bindings from `pybind11` to `nanobind` ([#297])
+  ([**@marcelwa**])
+- 🔧 Modernize the tooling and adopt the Scientific Python repo review ([#314],
+  [#335]) ([**@marcelwa**])
+- ✅ Restructure the test suite around markers and shared fixtures ([#313])
+  ([**@marcelwa**])
+- 📝 Streamline the README and the documentation ([#334]) ([**@marcelwa**])
+
+### Fixed
+
+- 🐛 Fix the `stubgen` pattern file so the generated stubs come out as intended
+  ([#336]) ([**@marcelwa**])
+
+<!-- Version links -->
+
+[unreleased]: https://github.com/marcelwa/aigverse/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/marcelwa/aigverse/releases/tag/v0.1.3
+[0.1.2]: https://github.com/marcelwa/aigverse/releases/tag/v0.1.2
+[0.1.1]: https://github.com/marcelwa/aigverse/releases/tag/v0.1.1
+[0.1.0]: https://github.com/marcelwa/aigverse/releases/tag/v0.1.0
+
+<!-- PR links -->
+
+[#435]: https://github.com/marcelwa/aigverse/pull/435
+[#430]: https://github.com/marcelwa/aigverse/pull/430
+[#421]: https://github.com/marcelwa/aigverse/pull/421
+[#420]: https://github.com/marcelwa/aigverse/pull/420
+[#419]: https://github.com/marcelwa/aigverse/pull/419
+[#417]: https://github.com/marcelwa/aigverse/pull/417
+[#409]: https://github.com/marcelwa/aigverse/pull/409
+[#407]: https://github.com/marcelwa/aigverse/pull/407
+[#405]: https://github.com/marcelwa/aigverse/pull/405
+[#404]: https://github.com/marcelwa/aigverse/pull/404
+[#395]: https://github.com/marcelwa/aigverse/pull/395
+[#394]: https://github.com/marcelwa/aigverse/pull/394
+[#392]: https://github.com/marcelwa/aigverse/pull/392
+[#390]: https://github.com/marcelwa/aigverse/pull/390
+[#389]: https://github.com/marcelwa/aigverse/pull/389
+[#388]: https://github.com/marcelwa/aigverse/pull/388
+[#382]: https://github.com/marcelwa/aigverse/pull/382
+[#369]: https://github.com/marcelwa/aigverse/pull/369
+[#368]: https://github.com/marcelwa/aigverse/pull/368
+[#358]: https://github.com/marcelwa/aigverse/pull/358
+[#336]: https://github.com/marcelwa/aigverse/pull/336
+[#335]: https://github.com/marcelwa/aigverse/pull/335
+[#334]: https://github.com/marcelwa/aigverse/pull/334
+[#314]: https://github.com/marcelwa/aigverse/pull/314
+[#313]: https://github.com/marcelwa/aigverse/pull/313
+[#308]: https://github.com/marcelwa/aigverse/pull/308
+[#306]: https://github.com/marcelwa/aigverse/pull/306
+[#305]: https://github.com/marcelwa/aigverse/pull/305
+[#303]: https://github.com/marcelwa/aigverse/pull/303
+[#298]: https://github.com/marcelwa/aigverse/pull/298
+[#297]: https://github.com/marcelwa/aigverse/pull/297
+[#285]: https://github.com/marcelwa/aigverse/pull/285
+
+<!-- Contributor -->
+
+[**@marcelwa**]: https://github.com/marcelwa
+[**@wjrforcyber**]: https://github.com/wjrforcyber
+
+<!-- General links -->
+
+[Keep a Changelog]: https://keepachangelog.com/en/1.1.0/
+[Common Changelog]: https://common-changelog.org
+[Semantic Versioning]: https://semver.org/spec/v2.0.0.html

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,3 @@
+```{include} ../CHANGELOG.md
+
+```

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,0 +1,3 @@
+```{include} ../UPGRADING.md
+
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,8 @@ benchmarks
 abc
 machine_learning
 visualization
+CHANGELOG
+UPGRADING
 ```
 
 ````{only} not latex


### PR DESCRIPTION
## Description

`AGENTS.md` has told every contributor and every agent to "update `CHANGELOG.md` for user-facing changes" while no such file existed. What a release actually changed was recoverable only from the auto-generated GitHub release notes, where a handful of real entries sit buried under forty dependency bumps — v0.1.2 lists ten substantive pull requests among thirty-seven.

This adds `CHANGELOG.md`, following [Keep a Changelog] and [Common Changelog]: one section per release, `Added`/`Changed`/`Removed`/`Fixed` within it, newest entry first, and one sentence per entry closing with its pull request and authors — `([#419]) ([**@marcelwa**])` — with the link definitions collected at the bottom of the file.

### Backfill

Populated from the git history back to **0.1.0**, the release that split the package into the `networks`/`algorithms`/`io`/`utils` extension modules. 0.0.x predates the current API and would document a library nobody is running, so it is left to the git history.

Routine Renovate and pre-commit.ci bumps are out. Dependency changes that a user can observe are in, without a contributor link, matching what the bots would sign.

The three breaking entries under 0.1.0 carry `💥`, and the section links to `UPGRADING.md#010`, which already documents the migration.

### Docs

`docs/CHANGELOG.md` and `docs/UPGRADING.md` include the two root files, and both join the User Guide toctree. That makes the upgrade link resolve inside the rendered docs as well as on GitHub — `myst_heading_anchors = 3` already generates the `#010` anchor.

### Keeping it current

The pull request template gains a changelog checkbox, and `AGENTS.md` states the entry format, so the instruction it already carried now has something to point at.

### Verification

- `nox -s lint` passes; prettier reformats nothing.
- `nox -s docs` builds clean. Both new pages render, and the eight warnings are the pre-existing `py:class reference target not found` ones from the API reference, unchanged by this PR.

### Note

#447 is open against `main` and adds four entries' worth of user-facing change. Whichever of the two merges second gets its entries added to `Unreleased` in that same branch.

[Keep a Changelog]: https://keepachangelog.com/en/1.1.0/
[Common Changelog]: https://common-changelog.org

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry for any noteworthy addition, change, fix, or removal.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive changelog covering project releases, updates, improvements, and fixes.
  - Added upgrade guidance and changelog pages to the User Guide.
  - Linked documentation pages to the central changelog and upgrade information.

- **Chores**
  - Added pull request guidance requiring changelog entries for noteworthy changes.
  - Documented changelog formatting and organization requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->