### PR TITLE
👷 Match the release drafter to the v0.1.4 release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,16 +1,8 @@
-name-template: "aigverse $RESOLVED_VERSION Release"
+name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 categories:
-  # Renovate and pre-commit.ci bumps come first on purpose: Release Drafter puts
-  # a PR in the first category it matches, and collapsing them here keeps them
-  # out of the way of the human changes below without hiding them entirely.
-  - title: "⬆️ Dependencies"
-    collapse-after: 5
-    when:
-      labels:
-        - "dependencies"
-        - "github_actions"
-        - "pre-commit"
+  # Categories render in the order they are defined, so the changes a reader
+  # cares about come first and the bot bumps sit at the bottom, collapsed.
   - title: "✨ Features and Enhancements"
     when:
       labels:
@@ -26,12 +18,23 @@ categories:
     when:
       labels:
         - "documentation"
+  # Deliberately matched on `tooling` alone. Renovate's custom managers label
+  # the pinned-revision bumps `build_system` (mockturtle) and `testing` (ABC),
+  # so matching those here would list every such bump twice -- once here and
+  # once under Dependencies. A pull request can match several categories, and
+  # `exclusive` only suppresses *later* ones, which cannot help a category that
+  # renders last. Human build and CI work carries `tooling`.
   - title: "🔧 Tooling, Build & CI"
     when:
       labels:
         - "tooling"
-        - "build_system"
-        - "testing"
+  - title: "⬆️ Dependencies"
+    collapse-after: 5
+    when:
+      labels:
+        - "dependencies"
+        - "github_actions"
+        - "pre-commit"
   - type: "pre-exclude"
     when:
       labels:

--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -546,7 +546,8 @@ The tag is the single source of truth.
 
 1. **Land everything intended for the release on `main`, and label it.**
    Release Drafter (`.github/release-drafter.yml`) sorts pull requests into the release notes by label, so an unlabeled pull request ends up uncategorized.
-   Routine Renovate and pre-commit.ci bumps are collapsed into a single `⬆️ Dependencies` block, so they need no special handling.
+   Build and CI work needs the `tooling` label to show up under `🔧 Tooling, Build & CI`; `build_system` and `testing` alone are not enough, because Renovate applies those to its pinned-revision bumps.
+   Routine Renovate and pre-commit.ci bumps are collapsed into a single `⬆️ Dependencies` block at the bottom, so they need no special handling.
 
 2. **Open a release-preparation pull request**, labeled `release-prep` so that it excludes itself from the notes.
    In `CHANGELOG.md`, rename the `## [Unreleased]` heading to `## [X.Y.Z] - <release date>`, add a fresh, empty `## [Unreleased]` heading above it, and update the link references at the bottom: point `[unreleased]` at `compare/vX.Y.Z...HEAD` and add `[X.Y.Z]` pointing at `releases/tag/vX.Y.Z`.


### PR DESCRIPTION
## Description

The v0.1.4 notes needed hand-editing before they were publishable. This feeds those edits back into `.github/release-drafter.yml` so the next draft comes out right the first time.

**Name the release after its tag.** The draft came out as `aigverse 0.1.4 Release`, and was published as `v0.1.4` — which is what every release since v0.0.1 is called. `name-template` now matches `tag-template`.

**Render the dependency bumps last.** Ordering that category first was a misreading of how Release Drafter matches: a pull request can match several categories, and `exclusive` only suppresses *later* ones. Putting Dependencies first therefore bought nothing, and only pushed 18 collapsed bot bumps ahead of the changes a reader actually opens the notes for.

**Match `🔧 Tooling, Build & CI` on `tooling` alone.** Renovate's custom managers label the pinned-revision bumps `build_system` (mockturtle) and `testing` (ABC), so matching those listed each of them twice — once under Tooling and again under Dependencies. Since the category now renders last, `exclusive: true` cannot fix this, which is why the label set is narrowed instead; the reasoning is recorded in a comment so it does not get "fixed" back. The Development Guide's labeling note says the same thing to contributors: build and CI work needs `tooling`.

Replaying the config over the 25 pull requests in the `v0.1.3..v0.1.4` range reproduces the published notes exactly — same five sections in the same order, same members, 18 bumps collapsed, #451 pre-excluded by its `release-prep` label, nothing uncategorized.

One thing deliberately left alone: #448 appears under both `✨ Features and Enhancements` and `📝 Documentation`, and #425 under both `🐛 Bug Fixes` and `📝 Documentation`, because they carry labels for both. Those duplicates survived into the published notes, so they read as intended rather than as something to suppress. Say the word and `exclusive: true` on the earlier categories removes them.

No changelog entry: this only changes how the GitHub release notes are generated, which is not user-observable.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry for any noteworthy addition, change, fix, or removal.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release guidance to clarify labeling requirements for build, CI, testing, and dependency updates.

* **Chores**
  * Improved automated release categorization and naming.
  * Updated grouping for tooling, build, CI, and dependency-related changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->