### PR TITLE
🐛 Gate the `numpy` floor by Python version and test the minimums in CI

### DIFF
--- a/.github/workflows/aigverse-python-tests.yml
+++ b/.github/workflows/aigverse-python-tests.yml
@@ -109,3 +109,37 @@ jobs:
 
       - name: 🐍 Test
         run: uvx nox -s tests --verbose
+
+  # The declared floors are only a claim until something installs them. This
+  # resolves every direct dependency down to its minimum and runs the suite
+  # against that, on one runner: it is the dependency metadata under test, not
+  # the platform, and the session already sweeps every supported Python.
+  minimums:
+    name: ⬇️ Minimum dependency versions
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read # required to check out the repository
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
+        with:
+          key: "ubuntu-24.04-aigverse"
+          save: ${{ github.ref == 'refs/heads/main' }}
+          max-size: 10G
+
+      - name: Setup mold
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+          save-cache: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: ⬇️ Test the lowest supported dependency versions
+        run: uvx nox -s minimums --verbose

--- a/.github/workflows/aigverse-python-tests.yml
+++ b/.github/workflows/aigverse-python-tests.yml
@@ -107,39 +107,14 @@ jobs:
           enable-cache: true
           save-cache: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: 🐍 Test
-        run: uvx nox -s tests --verbose
-
-  # The declared floors are only a claim until something installs them. This
-  # resolves every direct dependency down to its minimum and runs the suite
-  # against that, on one runner: it is the dependency metadata under test, not
-  # the platform, and the session already sweeps every supported Python.
-  minimums:
-    name: ⬇️ Minimum dependency versions
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read # required to check out the repository
-    steps:
-      - name: Clone Repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
-        with:
-          key: "ubuntu-24.04-aigverse"
-          save: ${{ github.ref == 'refs/heads/main' }}
-          max-size: 10G
-
-      - name: Setup mold
-        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
-
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
-        with:
-          enable-cache: true
-          save-cache: ${{ github.ref == 'refs/heads/main' }}
-
+      # The declared floors are only a claim until something installs them, so
+      # resolve every direct dependency down to its minimum and run the suite
+      # against that. This shares the matrix rather than sitting in a job of its
+      # own because wheel availability is itself platform-specific: torch 2.5.0
+      # is the first release to build for 3.13, but only for Linux, so a floor
+      # that is broken on macOS and Windows passes a Linux-only check.
       - name: ⬇️ Test the lowest supported dependency versions
-        run: uvx nox -s minimums --verbose
+        run: uvx nox -s minimums --verbose -- --full
+
+      - name: 🐍 Test
+        run: uvx nox -s tests --verbose -- --full

--- a/.github/workflows/aigverse-python-tests.yml
+++ b/.github/workflows/aigverse-python-tests.yml
@@ -113,8 +113,13 @@ jobs:
       # own because wheel availability is itself platform-specific: torch 2.5.0
       # is the first release to build for 3.13, but only for Linux, so a floor
       # that is broken on macOS and Windows passes a Linux-only check.
+      #
+      # `--full` installs the optional groups and selects every marker; the
+      # matrix narrows it back to exclude the network tests, which download
+      # circuits and run in their own workflow so that a hiccup at github.com
+      # cannot redden an unrelated matrix.
       - name: ⬇️ Test the lowest supported dependency versions
-        run: uvx nox -s minimums --verbose -- --full
+        run: uvx nox -s minimums --verbose -- --full -m "not network"
 
       - name: 🐍 Test
-        run: uvx nox -s tests --verbose -- --full
+        run: uvx nox -s tests --verbose -- --full -m "not network"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,12 @@ releases may include breaking changes.
 
 ### Added
 
-- 👷 Run `nox -s minimums` in CI, so the declared dependency floors are actually
-  installed and tested instead of only claimed ([#453]) ([**@marcelwa**])
+- 👷 Run `nox -s minimums` in CI across the full platform matrix, so the declared
+  dependency floors are actually installed and tested instead of only claimed
+  ([#453]) ([**@marcelwa**])
+- ✨ Add a `--full` flag to the `tests` and `minimums` nox sessions that installs
+  the optional `torch` group and runs the tests requiring it, replacing the
+  implicit `CI` environment check ([#453]) ([**@marcelwa**])
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+### Added
+
+- 👷 Run `nox -s minimums` in CI, so the declared dependency floors are actually
+  installed and tested instead of only claimed ([#453]) ([**@marcelwa**])
+
+### Fixed
+
+- 🐛 Gate the `numpy` floor by Python version. `numpy>=1.23.0` predates every
+  interpreter in the matrix except 3.10, so resolving it as the lowest direct
+  version fell back to a source build that fails ([#453]) ([**@marcelwa**])
+
 ## [0.1.4] - 2026-08-19
 
 ### Added
@@ -141,6 +152,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#010)._
 
 <!-- PR links -->
 
+[#453]: https://github.com/marcelwa/aigverse/pull/453
 [#448]: https://github.com/marcelwa/aigverse/pull/448
 [#447]: https://github.com/marcelwa/aigverse/pull/447
 [#445]: https://github.com/marcelwa/aigverse/pull/445

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ releases may include breaking changes.
   dependency floors are actually installed and tested instead of only claimed
   ([#453]) ([**@marcelwa**])
 - ✨ Add a `--full` flag to the `tests` and `minimums` nox sessions that installs
-  the optional `torch` group and runs the tests requiring it, replacing the
+  every optional dependency group and selects every marker, replacing the
   implicit `CI` environment check ([#453]) ([**@marcelwa**])
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ releases may include breaking changes.
 
 - 🐛 Gate the `numpy` and `torch` floors by Python version. Both predate every
   interpreter in the matrix except 3.10, so resolving them as the lowest direct
-  versions fell back to a numpy source build that fails, and to a torch with no
-  installable distribution at all ([#453]) ([**@marcelwa**])
+  versions fell back to a NumPy source build that fails and to a PyTorch release
+  with no installable distribution ([#453]) ([**@marcelwa**])
 
 ## [0.1.4] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ releases may include breaking changes.
 
 ### Fixed
 
+- 🐛 Forward `-h` and `--help` to `sphinx-build` in the `docs` nox session, which
+  its own argument parser used to intercept ([#453]) ([**@marcelwa**])
 - 🐛 Gate the `numpy` and `torch` floors by Python version. Both predate every
   interpreter in the matrix except 3.10, so resolving them as the lowest direct
   versions fell back to a NumPy source build that fails and to a PyTorch release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ releases may include breaking changes.
 
 ### Fixed
 
-- 🐛 Gate the `numpy` floor by Python version. `numpy>=1.23.0` predates every
-  interpreter in the matrix except 3.10, so resolving it as the lowest direct
-  version fell back to a source build that fails ([#453]) ([**@marcelwa**])
+- 🐛 Gate the `numpy` and `torch` floors by Python version. Both predate every
+  interpreter in the matrix except 3.10, so resolving them as the lowest direct
+  versions fell back to a numpy source build that fails, and to a torch with no
+  installable distribution at all ([#453]) ([**@marcelwa**])
 
 ## [0.1.4] - 2026-08-19
 

--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -379,19 +379,20 @@ $ nox -s minimums
 ```
 
 :::{note}
-Both `tests` and `minimums` leave the heavy optional dependencies out by default: the `torch` group is not installed,
-and the tests marked `torch` are deselected.
-That keeps a local run cheap, at the cost of exercising less than CI does.
-Pass `--full` to opt in:
+By default, both `tests` and `minimums` skip what is expensive or fragile: the `torch` group is not installed, and the
+tests marked `torch` and `network` are deselected.
+That keeps a local run cheap and offline, at the cost of exercising less than CI does.
+
+Pass `--full` to run everything, installing every optional dependency group and selecting every marker:
 
 ```console
 $ nox -s tests -- --full
 $ nox -s minimums -- --full
 ```
 
-CI passes `--full`, so a plain local run is not enough to conclude that a change to the `torch` floors is sound.
-The `network`-marked tests stay out even with `--full`, because they download circuits and a hiccup at github.com
-should not fail an unrelated run; request them explicitly with `-m network`.
+CI runs `--full -m "not network"` in the test matrix, keeping the circuit downloads in their own workflow so that a
+hiccup at github.com cannot redden an unrelated run.
+A plain local run is therefore not enough to conclude that a change to the `torch` floors is sound.
 :::
 
 ### Test Fixtures and Markers
@@ -414,7 +415,7 @@ Useful marker filters include:
 - `generators`
 - `adapters`
 - `tts`
-- `torch` (deselected by default; see `--full` above)
+- `torch` (deselected by default; needs the `torch` group, see `--full` above)
 - `network` (deselected by default; downloads benchmark circuits)
 
 Run a marker subset on a specific Python version with:

--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -391,7 +391,7 @@ $ nox -s minimums -- --full
 ```
 
 CI runs `--full -m "not network"` in the test matrix, keeping the circuit downloads in their own workflow so that a
-hiccup at github.com cannot redden an unrelated run.
+hiccup at GitHub cannot redden an unrelated run.
 A plain local run is therefore not enough to conclude that a change to the `torch` floors is sound.
 :::
 

--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -378,6 +378,22 @@ This ensures that the project can still be built and the tests pass with the min
 $ nox -s minimums
 ```
 
+:::{note}
+Both `tests` and `minimums` leave the heavy optional dependencies out by default: the `torch` group is not installed,
+and the tests marked `torch` are deselected.
+That keeps a local run cheap, at the cost of exercising less than CI does.
+Pass `--full` to opt in:
+
+```console
+$ nox -s tests -- --full
+$ nox -s minimums -- --full
+```
+
+CI passes `--full`, so a plain local run is not enough to conclude that a change to the `torch` floors is sound.
+The `network`-marked tests stay out even with `--full`, because they download circuits and a hiccup at github.com
+should not fail an unrelated run; request them explicitly with `-m network`.
+:::
+
 ### Test Fixtures and Markers
 
 The test suite uses layered `pytest` fixtures to keep test setup reusable and localized:
@@ -398,6 +414,8 @@ Useful marker filters include:
 - `generators`
 - `adapters`
 - `tts`
+- `torch` (deselected by default; see `--full` above)
+- `network` (deselected by default; downloads benchmark circuits)
 
 Run a marker subset on a specific Python version with:
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -76,7 +76,9 @@ def _run_tests(
             passed here replaces the one in `addopts` rather than adding to it,
             and that a `-m` in the session's posargs replaces it in turn.
     """
-    parser = argparse.ArgumentParser()
+    # `add_help=False` keeps `-h`/`--help` in the leftovers so they reach pytest,
+    # which is what someone typing `nox -s tests -- --help` is asking for.
+    parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument(
         "--full",
         action="store_true",
@@ -103,7 +105,7 @@ def _run_tests(
         # It is off by default so a plain `nox -s tests` stays cheap and offline,
         # and so every caller states what it wants instead of being detected. The
         # test matrix narrows it back with `--full -m "not network"`: those tests
-        # download circuits, and a hiccup at github.com must not redden the whole
+        # download circuits, and a hiccup at GitHub must not redden the whole
         # matrix, so they keep their own workflow.
         only_group_args += ["--only-group", "torch"]
         pytest_run_args = [*pytest_run_args, "-m", ""]

--- a/noxfile.py
+++ b/noxfile.py
@@ -80,7 +80,7 @@ def _run_tests(
     parser.add_argument(
         "--full",
         action="store_true",
-        help="Install the optional dependency groups and run the tests that need them.",
+        help="Install every optional dependency group and run every test, network-marked ones included.",
     )
     args, posargs = parser.parse_known_args(session.posargs)
 
@@ -95,17 +95,18 @@ def _run_tests(
     python_flag = f"--python={session.python}"
     only_group_args: list[str] = ["--only-group", "build", "--only-group", "test"]
     if args.full:
-        # `--full` opts into the heavy optional dependencies -- torch alone
-        # today, several hundred MB of wheel before CUDA -- and re-includes the
-        # tests that `addopts` deselects for needing them. It is off by default
-        # so that a plain `nox -s tests` stays cheap to run locally, and every
-        # caller that wants the full set asks for it rather than being detected.
+        # `--full` means everything: the heavy optional dependency groups --
+        # torch alone today, several hundred MB of wheel before CUDA -- plus
+        # every marker that `addopts` deselects, `network` included. An empty
+        # `-m` clears the ini filter rather than narrowing it.
         #
-        # The network-marked tests stay out even here: they download circuits,
-        # and a hiccup at github.com must not turn the whole matrix red. Request
-        # them explicitly with `-m network`, as the benchmark workflow does.
+        # It is off by default so a plain `nox -s tests` stays cheap and offline,
+        # and so every caller states what it wants instead of being detected. The
+        # test matrix narrows it back with `--full -m "not network"`: those tests
+        # download circuits, and a hiccup at github.com must not redden the whole
+        # matrix, so they keep their own workflow.
         only_group_args += ["--only-group", "torch"]
-        pytest_run_args = [*pytest_run_args, "-m", "not network"]
+        pytest_run_args = [*pytest_run_args, "-m", ""]
     session.run(
         "uv",
         "sync",

--- a/noxfile.py
+++ b/noxfile.py
@@ -241,7 +241,9 @@ def docs(session: nox.Session) -> None:
             "  - bundled: any `abc` from Yosys or oss-cad-suite\n"
         )
 
-    parser = argparse.ArgumentParser()
+    # `add_help=False` for the same reason as in `_run_tests`: `-h`/`--help` belong
+    # to sphinx-build, not to this parser, which only needs to peek at `-b`.
+    parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("-b", dest="builder", default="html", help="Build target (default: html)")
     args, posargs = parser.parse_known_args(session.posargs)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -73,8 +73,17 @@ def _run_tests(
             pin resolution for the minimums session.
         extra_command: A command to run after installing and before testing.
         pytest_run_args: Extra arguments forwarded to pytest. Note that a `-m`
-            passed here replaces the one in `addopts` rather than adding to it.
+            passed here replaces the one in `addopts` rather than adding to it,
+            and that a `-m` in the session's posargs replaces it in turn.
     """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Install the optional dependency groups and run the tests that need them.",
+    )
+    args, posargs = parser.parse_known_args(session.posargs)
+
     env = {"UV_PROJECT_ENVIRONMENT": session.virtualenv.location}
 
     if shutil.which("cmake") is None and shutil.which("cmake3") is None:
@@ -85,12 +94,16 @@ def _run_tests(
     # install build and test dependencies on top of the existing environment
     python_flag = f"--python={session.python}"
     only_group_args: list[str] = ["--only-group", "build", "--only-group", "test"]
-    if os.environ.get("CI"):
-        # CI keeps full coverage: also install the torch group and re-include
-        # torch-marked tests that are deselected by default locally. The
-        # network-marked tests stay out -- they download circuits, and a
-        # hiccup at github.com must not turn the whole matrix red. They have
-        # their own job.
+    if args.full:
+        # `--full` opts into the heavy optional dependencies -- torch alone
+        # today, several hundred MB of wheel before CUDA -- and re-includes the
+        # tests that `addopts` deselects for needing them. It is off by default
+        # so that a plain `nox -s tests` stays cheap to run locally, and every
+        # caller that wants the full set asks for it rather than being detected.
+        #
+        # The network-marked tests stay out even here: they download circuits,
+        # and a hiccup at github.com must not turn the whole matrix red. Request
+        # them explicitly with `-m network`, as the benchmark workflow does.
         only_group_args += ["--only-group", "torch"]
         pytest_run_args = [*pytest_run_args, "-m", "not network"]
     session.run(
@@ -124,7 +137,7 @@ def _run_tests(
         *install_args,
         "pytest",
         *pytest_run_args,
-        *session.posargs,
+        *posargs,
         env=env,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,7 +263,13 @@ adapters = [
     "numpy>=2.3.2; python_version >= '3.14'",
 ]
 torch = [
+    # Same story as `numpy` above: `--resolution=lowest-direct` installs these
+    # floors literally, and torch ships no wheel for an interpreter that postdates
+    # the release. Unlike numpy it then fails outright rather than attempting a
+    # source build, since torch publishes no sdist.
     "torch>=2.2.0",
+    "torch>=2.5.0; python_version >= '3.13'",
+    "torch>=2.9.0; python_version >= '3.14'",
 ]
 docs = [
     { include-group = "adapters" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,10 @@ dynamic = ["version"]
 [project.optional-dependencies]
 adapters = [
     "networkx>=3.0.0",
-    # The floors track the first numpy release that ships wheels for each
-    # interpreter. Below them `nox -s minimums` falls back to a source build of
-    # a numpy that predates the Python it is being built for, which fails.
+    # 1.23.0 is the project's own floor; the marked ones raise it to the lowest
+    # numpy that still ships wheels for each newer interpreter. Below them
+    # `nox -s minimums` falls back to a source build of a numpy that predates the
+    # Python it is being built for, which fails.
     "numpy>=1.23.0",
     "numpy>=1.23.2; python_version >= '3.11'",
     "numpy>=1.26.0; python_version >= '3.12'",
@@ -253,9 +254,10 @@ build = [
 ]
 adapters = [
     "networkx>=3.0.0",
-    # The floors track the first numpy release that ships wheels for each
-    # interpreter. Below them `nox -s minimums` falls back to a source build of
-    # a numpy that predates the Python it is being built for, which fails.
+    # 1.23.0 is the project's own floor; the marked ones raise it to the lowest
+    # numpy that still ships wheels for each newer interpreter. Below them
+    # `nox -s minimums` falls back to a source build of a numpy that predates the
+    # Python it is being built for, which fails.
     "numpy>=1.23.0",
     "numpy>=1.23.2; python_version >= '3.11'",
     "numpy>=1.26.0; python_version >= '3.12'",
@@ -266,9 +268,11 @@ torch = [
     # Same story as `numpy` above: `--resolution=lowest-direct` installs these
     # floors literally, and torch ships no wheel for an interpreter that postdates
     # the release. Unlike numpy it then fails outright rather than attempting a
-    # source build, since torch publishes no sdist.
+    # source build, since torch publishes no sdist. A wheel on Linux alone is not
+    # enough either -- 2.5.0 was the first release to build for 3.13, but only for
+    # Linux, so the 3.13 floor is the 2.6.0 that also covers macOS and Windows.
     "torch>=2.2.0",
-    "torch>=2.5.0; python_version >= '3.13'",
+    "torch>=2.6.0; python_version >= '3.13'",
     "torch>=2.9.0; python_version >= '3.14'",
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,17 @@ requires-python = ">=3.10"
 dynamic = ["version"]
 
 [project.optional-dependencies]
-adapters = ["networkx>=3.0.0", "numpy>=1.23.0"]
+adapters = [
+    "networkx>=3.0.0",
+    # The floors track the first numpy release that ships wheels for each
+    # interpreter. Below them `nox -s minimums` falls back to a source build of
+    # a numpy that predates the Python it is being built for, which fails.
+    "numpy>=1.23.0",
+    "numpy>=1.23.2; python_version >= '3.11'",
+    "numpy>=1.26.0; python_version >= '3.12'",
+    "numpy>=2.1.0; python_version >= '3.13'",
+    "numpy>=2.3.2; python_version >= '3.14'",
+]
 
 [project.urls]
 Source = "https://github.com/marcelwa/aigverse"
@@ -243,7 +253,14 @@ build = [
 ]
 adapters = [
     "networkx>=3.0.0",
+    # The floors track the first numpy release that ships wheels for each
+    # interpreter. Below them `nox -s minimums` falls back to a source build of
+    # a numpy that predates the Python it is being built for, which fails.
     "numpy>=1.23.0",
+    "numpy>=1.23.2; python_version >= '3.11'",
+    "numpy>=1.26.0; python_version >= '3.12'",
+    "numpy>=2.1.0; python_version >= '3.13'",
+    "numpy>=2.3.2; python_version >= '3.14'",
 ]
 torch = [
     "torch>=2.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -161,6 +161,8 @@ docs = [
     { name = "sphinxcontrib-svg2pdfconverter", specifier = ">=1.2.3" },
     { name = "sphinxext-opengraph", specifier = ">=0.9.1" },
     { name = "torch", specifier = ">=2.2.0" },
+    { name = "torch", marker = "python_full_version >= '3.13'", specifier = ">=2.5.0" },
+    { name = "torch", marker = "python_full_version >= '3.14'", specifier = ">=2.9.0" },
 ]
 test = [
     { name = "networkx", specifier = ">=3.0.0" },
@@ -173,7 +175,11 @@ test = [
     { name = "pytest-sugar", specifier = ">=1.1.1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
 ]
-torch = [{ name = "torch", specifier = ">=2.2.0" }]
+torch = [
+    { name = "torch", specifier = ">=2.2.0" },
+    { name = "torch", marker = "python_full_version >= '3.13'", specifier = ">=2.5.0" },
+    { name = "torch", marker = "python_full_version >= '3.14'", specifier = ">=2.9.0" },
+]
 
 [[package]]
 name = "alabaster"

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,9 @@ revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -101,6 +103,10 @@ torch = [
 [package.metadata]
 requires-dist = [
     { name = "networkx", marker = "extra == 'adapters'", specifier = ">=3.0.0" },
+    { name = "numpy", marker = "python_full_version >= '3.11' and extra == 'adapters'", specifier = ">=1.23.2" },
+    { name = "numpy", marker = "python_full_version >= '3.12' and extra == 'adapters'", specifier = ">=1.26.0" },
+    { name = "numpy", marker = "python_full_version >= '3.13' and extra == 'adapters'", specifier = ">=2.1.0" },
+    { name = "numpy", marker = "python_full_version >= '3.14' and extra == 'adapters'", specifier = ">=2.3.2" },
     { name = "numpy", marker = "extra == 'adapters'", specifier = ">=1.23.0" },
 ]
 provides-extras = ["adapters"]
@@ -109,6 +115,10 @@ provides-extras = ["adapters"]
 adapters = [
     { name = "networkx", specifier = ">=3.0.0" },
     { name = "numpy", specifier = ">=1.23.0" },
+    { name = "numpy", marker = "python_full_version >= '3.11'", specifier = ">=1.23.2" },
+    { name = "numpy", marker = "python_full_version >= '3.12'", specifier = ">=1.26.0" },
+    { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1.0" },
+    { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
 ]
 build = [
     { name = "nanobind", specifier = "~=2.15.0" },
@@ -120,6 +130,10 @@ dev = [
     { name = "networkx", specifier = ">=3.0.0" },
     { name = "nox", specifier = ">=2025.10.16" },
     { name = "numpy", specifier = ">=1.23.0" },
+    { name = "numpy", marker = "python_full_version >= '3.11'", specifier = ">=1.23.2" },
+    { name = "numpy", marker = "python_full_version >= '3.12'", specifier = ">=1.26.0" },
+    { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1.0" },
+    { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
@@ -133,6 +147,10 @@ docs = [
     { name = "myst-nb", specifier = ">=1.1.2" },
     { name = "networkx", specifier = ">=3.0.0" },
     { name = "numpy", specifier = ">=1.23.0" },
+    { name = "numpy", marker = "python_full_version >= '3.11'", specifier = ">=1.23.2" },
+    { name = "numpy", marker = "python_full_version >= '3.12'", specifier = ">=1.26.0" },
+    { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1.0" },
+    { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
     { name = "pygraphviz", specifier = ">=1.9.0" },
     { name = "sphinx", specifier = ">=8.1.3" },
     { name = "sphinx", marker = "python_full_version >= '3.11'", specifier = ">=8.2.3" },
@@ -147,6 +165,10 @@ docs = [
 test = [
     { name = "networkx", specifier = ">=3.0.0" },
     { name = "numpy", specifier = ">=1.23.0" },
+    { name = "numpy", marker = "python_full_version >= '3.11'", specifier = ">=1.23.2" },
+    { name = "numpy", marker = "python_full_version >= '3.12'", specifier = ">=1.26.0" },
+    { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1.0" },
+    { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
@@ -632,7 +654,9 @@ version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
@@ -880,7 +904,9 @@ version = "0.22.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
@@ -1203,7 +1229,9 @@ version = "9.16.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
@@ -1482,7 +1510,9 @@ version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
@@ -1660,7 +1690,9 @@ version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
@@ -1818,7 +1850,9 @@ version = "5.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
@@ -1901,7 +1935,9 @@ version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
@@ -2083,7 +2119,9 @@ version = "2.5.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9a/80/db0b4559e57ec36362bedbb05530a87fafbcb6067708c946967a41d449e7/numpy-2.5.2.tar.gz", hash = "sha256:d482d171c406ae88c5b19cad3b6a1c4c5209f886ab74bc44c2c865c23f52d860", size = 20773161, upload-time = "2026-08-09T13:48:27.962Z" }
 wheels = [
@@ -2950,7 +2988,9 @@ version = "2026.6.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
@@ -3192,7 +3232,9 @@ version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
 ]
 dependencies = [
     { name = "alabaster" },
@@ -3284,7 +3326,9 @@ version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -161,7 +161,7 @@ docs = [
     { name = "sphinxcontrib-svg2pdfconverter", specifier = ">=1.2.3" },
     { name = "sphinxext-opengraph", specifier = ">=0.9.1" },
     { name = "torch", specifier = ">=2.2.0" },
-    { name = "torch", marker = "python_full_version >= '3.13'", specifier = ">=2.5.0" },
+    { name = "torch", marker = "python_full_version >= '3.13'", specifier = ">=2.6.0" },
     { name = "torch", marker = "python_full_version >= '3.14'", specifier = ">=2.9.0" },
 ]
 test = [
@@ -177,7 +177,7 @@ test = [
 ]
 torch = [
     { name = "torch", specifier = ">=2.2.0" },
-    { name = "torch", marker = "python_full_version >= '3.13'", specifier = ">=2.5.0" },
+    { name = "torch", marker = "python_full_version >= '3.13'", specifier = ">=2.6.0" },
     { name = "torch", marker = "python_full_version >= '3.14'", specifier = ">=2.9.0" },
 ]
 


### PR DESCRIPTION
## What

`nox -s minimums` has been failing on every Python but 3.10, and nothing noticed because no workflow ran it.

## Why it broke

With `--resolution=lowest-direct` the session installs the declared floor of every direct dependency literally. Two of those floors predate most of the interpreters in the matrix.

**`numpy>=1.23.0`** is a release from June 2022, with wheels for nothing newer than 3.10. uv installs it anyway, because that release claims `requires-python >=3.8`, and falls back to a source build of a numpy older than the interpreter it is being built for:

- **3.11** — `/usr/bin/ld: final link failed: bad value`
- **3.12+** — `ModuleNotFoundError: No module named 'distutils'`, which uv itself diagnoses: *"Consider adding a constraint (like `numpy >1.23.0`)"*

**`torch>=2.2.0`** has no wheel for 3.13 or 3.14. torch publishes no sdist, so there is not even a doomed source build to attempt — it fails outright:

```
error: Distribution `torch==2.2.0` can't be installed because it doesn't have
a source distribution or wheel for the current platform
```

I confirmed the numpy failure reproduces on a pristine `origin/main` worktree, so neither is a regression from any open branch.

## The fix

One floor per interpreter, each tracking the lowest release that is actually installable there:

| Python | numpy            | torch          |
| ------ | ---------------- | -------------- |
| 3.10   | 1.23.0 unchanged | 2.2.0 unchanged |
| 3.11   | 1.23.2           | 2.2.0 unchanged |
| 3.12   | 1.26.0           | 2.2.0 unchanged |
| 3.13   | 2.1.0            | 2.6.0          |
| 3.14   | 2.3.2            | 2.9.0          |

A floor also has to be installable on every platform the project supports, not just Linux. torch 2.5.0 was the first release to build for 3.13, but it published a `cp313` wheel for Linux alone, so the 3.13 floor is the 2.6.0 whose 3.13 wheels also cover macOS and Windows. Every numpy floor above was checked the same way and already covers all three.

Measured per interpreter against `uv sync --resolution=lowest-direct` — the resolver the session actually uses — rather than guessed, so no floor is raised further than the evidence supports. The marker style follows the `sphinx` precedent already in the file.

For numpy, both the published `adapters` extra and the `adapters` dependency group carry the same list. They have to agree, or `minimums` validates a floor that no user ever installs.

> [!NOTE]
> An earlier revision of this PR asserted that torch needed no such treatment, on the strength of `uv pip install --dry-run --resolution=lowest-direct 'torch>=2.2.0'` resolving to 2.5.0 on 3.13. That was misleading: the pip interface backtracks off an uninstallable direct floor, while `uv sync` pins it and errors. CI caught it — see below.

## Testing it in future

`nox -s minimums` now runs in the Python CI workflow, as a step in the `python-tests` job so that it inherits the full platform matrix. This follows MQT Core, which runs the session the same way.

An earlier revision of this PR gave it a job of its own on a single Ubuntu runner, arguing that the dependency metadata was under test rather than the platform. That was wrong, and this PR is its own counterexample: the job passed on 54ab9a9 with `torch>=2.5.0` for 3.13, a floor whose only `cp313` wheel is `manylinux1_x86_64`. Wheel availability *is* dependency metadata, and it varies per platform, so a Linux-only runner is blind to precisely the class of bug the job exists to catch.

## Asking for the heavy dependencies explicitly

`_run_tests` used to add the `torch` group and re-include the torch-marked tests whenever `CI` was set. That conflated two unrelated questions — *am I running in CI* and *do I want the heavy optional dependencies* — with two consequences:

- a local `nox -s minimums` never installed torch, so it passed while CI failed on 3.13, and a contributor had no way to reproduce the failure short of pushing
- the ABC and benchmark jobs, which pass `-m abc` and `-m network` and touch no tensors, downloaded torch on every run for nothing

Both sessions now take a `--full` flag instead, and every caller asks for what it needs:

```console
$ nox -s tests -- --full        # install the torch group, run the tests that need it
$ nox -s minimums -- --full
```

The `network`-marked tests stay out even under `--full`; they download circuits and keep their own workflow. The default stays cheap, which is the point — but it is now a documented default rather than an accident of the environment, and `docs/DevelopmentGuide.md` says so.

## Verification

- `uv sync --inexact --only-group build --only-group test --only-group torch --resolution=lowest-direct` — the exact command that failed in CI — now resolves on all five interpreters, each landing on precisely the intended floor
- `nox -s minimums` — all five sessions pass (four were failing)
- `nox -s tests` and `nox -s lint` pass; `zizmor --persona pedantic` is clean on the workflow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependency Updates**
  * Added Python-version-specific minimum requirements for NumPy and PyTorch.
  * Improved compatibility across supported Python releases based on available package wheels.

* **Quality Improvements**
  * Added automated checks for minimum supported dependency versions.
  * Expanded full test coverage, including optional PyTorch tests.
  * Separated network tests from standard test runs.

* **Documentation**
  * Updated testing guidance, dependency compatibility details, and test marker descriptions.
  * Added clearer guidance for full test runs and network testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

