### PR TITLE
⬆️🪝 Unpin validate-pyproject-schema-store now that the [tool.uv] crash is fixed upstream

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -171,13 +171,6 @@
         "patch"
       ],
       automerge: true
-    },
-    {
-      description: "2026.07.20 crashes validate-pyproject with UnboundLocalError on any [tool.uv] table; unpin once fixed upstream (see GalacticDynamics/quax-blocks#55)",
-      matchPackageNames: [
-        "henryiii/validate-pyproject-schema-store"
-      ],
-      allowedVersions: "<= 2026.07.17"
     }
   ]
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -159,7 +159,7 @@ repos:
 
   # Check the pyproject.toml file
   - repo: https://github.com/henryiii/validate-pyproject-schema-store
-    rev: 2026.07.17
+    rev: 2026.08.15
     hooks:
       - id: validate-pyproject
         priority: 0


### PR DESCRIPTION
Fixes #401.

`henryiii/validate-pyproject-schema-store` 2026.08.15 no longer crashes with `UnboundLocalError: cannot access local variable 'data_keys'` on `pyproject.toml` files containing a `[tool.uv]` table — verified locally by running `validate-pyproject` with that version against this repo's `pyproject.toml`, which now validates cleanly.

- Removes the temporary Renovate `packageRule` (added in #399) that capped `henryiii/validate-pyproject-schema-store` at `<= 2026.07.17`.
- Bumps the `.pre-commit-config.yaml` pin from `2026.07.17` to `2026.08.15`.

`uvx nox -s lint` passes, including the `Validate pyproject.toml` hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Python 3.15 to the supported testing range.
  * Improved test and documentation command handling, including help options and custom test selections.

* **Tests**
  * Adjusted Python 3.15 test execution for platform-specific limitations.

* **Documentation**
  * Updated development, versioning, release, and changelog guidance.

* **Chores**
  * Refreshed project validation tooling to the latest configured revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->