### PR TITLE
👷 Cache Windows compiles with Ninja and sccache

### DIFF
--- a/.github/workflows/aigverse-pypi-deployment.yml
+++ b/.github/workflows/aigverse-pypi-deployment.yml
@@ -137,6 +137,16 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3
 
+      # The container compiles as root and sccache creates its directories 0700,
+      # so the runner cannot read them back and the cache save fails with
+      # `tar: .sccache/a: Cannot open: Permission denied`. That is only a
+      # warning, so without this the job stays green while saving nothing.
+      # `always()` keeps a partial cache from a failed build, which is still
+      # worth having.
+      - if: always() && runner.os == 'Linux'
+        name: Hand the container's cache back to the runner
+        run: sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE/.sccache"
+
       - name: Upload wheel as an artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/aigverse-pypi-deployment.yml
+++ b/.github/workflows/aigverse-pypi-deployment.yml
@@ -100,8 +100,10 @@ jobs:
       # `cibw-run-ihw907m4` -- and on the native runners the build interpreter
       # lives inside it, so its include path lands in every compile command and
       # no command ever repeats. Measured with a restored 276 MB cache present:
-      # windows 145 requests / 0 hits, macOS 145 calls / 0 hits. Neither ccache
-      # nor sccache can normalise that away.
+      # windows 145 requests / 0 hits, macOS 145 calls / 0 hits. Base-directory
+      # rewriting cannot recover it either: both caches rewrite paths relative
+      # to the compile working directory, which here sits on a separate stable
+      # root, so the varying component survives the rewrite.
       #
       # The container has no such problem. Everything the Linux build sees is
       # fixed -- /opt/python/cp310-cp310, /project/build/... -- so its commands

--- a/.github/workflows/aigverse-pypi-deployment.yml
+++ b/.github/workflows/aigverse-pypi-deployment.yml
@@ -111,23 +111,19 @@ jobs:
       # to share `${{matrix.runs-on}}-aigverse` and evict each other, their
       # objects being disjoint.
       - if: runner.os == 'Linux'
-        name: Setup ccache
-        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
-        with:
-          key: "${{matrix.runs-on}}-aigverse-wheels"
-          save: true
-          max-size: 10G
-
-      # cibuildwheel copies the project into the manylinux container with
-      # `docker cp` instead of mounting it, so the container needs an explicit
-      # volume to reach the cache directory the action manages on the host.
-      # Without it ccache runs inside the container and writes into a filesystem
-      # that is thrown away with it.
-      - if: runner.os == 'Linux'
-        name: Share the ccache directory with the manylinux container
+        name: Share the sccache directory with the manylinux container
         run: |
-          echo "CIBW_CONTAINER_ENGINE=docker; create_args: --volume=$GITHUB_WORKSPACE/.ccache:/ccache" >> "$GITHUB_ENV"
-          echo "CIBW_ENVIRONMENT_LINUX=CCACHE_DIR=/ccache" >> "$GITHUB_ENV"
+          mkdir -p "$GITHUB_WORKSPACE/.sccache"
+          echo "CIBW_CONTAINER_ENGINE=docker; create_args: --volume=$GITHUB_WORKSPACE/.sccache:/sccache" >> "$GITHUB_ENV"
+          echo "CIBW_ENVIRONMENT_LINUX=SCCACHE_DIR=/sccache SCCACHE_CACHE_SIZE=2G" >> "$GITHUB_ENV"
+
+      - if: runner.os == 'Linux'
+        name: Cache sccache objects
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .sccache
+          key: sccache-${{ matrix.runs-on }}-aigverse-wheels-${{ github.run_id }}
+          restore-keys: sccache-${{ matrix.runs-on }}-aigverse-wheels-
 
       - if: runner.os == 'Linux'
         name: Setup mold

--- a/.github/workflows/aigverse-pypi-deployment.yml
+++ b/.github/workflows/aigverse-pypi-deployment.yml
@@ -117,7 +117,7 @@ jobs:
         run: |
           mkdir -p "$GITHUB_WORKSPACE/.sccache"
           echo "CIBW_CONTAINER_ENGINE=docker; create_args: --volume=$GITHUB_WORKSPACE/.sccache:/sccache" >> "$GITHUB_ENV"
-          echo "CIBW_ENVIRONMENT_LINUX=SCCACHE_DIR=/sccache SCCACHE_CACHE_SIZE=2G" >> "$GITHUB_ENV"
+          echo "CIBW_ENVIRONMENT_LINUX=SCCACHE_DIR=/sccache SCCACHE_CACHE_SIZE=2G CMAKE_ARGS=-DCMAKE_VERBOSE_MAKEFILE=ON" >> "$GITHUB_ENV"
 
       - if: runner.os == 'Linux'
         name: Cache sccache objects

--- a/.github/workflows/aigverse-pypi-deployment.yml
+++ b/.github/workflows/aigverse-pypi-deployment.yml
@@ -95,12 +95,38 @@ jobs:
       - name: Set up MSVC development environment (Windows only)
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
-      - name: Setup ccache
+      # The key carries `-wheels` because this workflow and the test matrix used
+      # to share `${{matrix.runs-on}}-aigverse` and evict each other. cibuildwheel
+      # builds against its own CPython installs, the test matrix against nox
+      # virtualenvs, so the two produce disjoint objects and neither could ever
+      # use what the other stored: the macOS wheel job restored a cache written
+      # by the test workflow and reported 145 calls, 0 hits.
+      - if: runner.os != 'Windows'
+        name: Setup ccache
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
         with:
-          key: "${{matrix.runs-on}}-aigverse"
+          key: "${{matrix.runs-on}}-aigverse-wheels"
           save: true
           max-size: 10G
+
+      # Same defect, and the same fix, as the test matrix: scikit-build-core
+      # picks the Visual Studio generator, MSBuild ignores the compiler launcher,
+      # and the job cached nothing at all. See `aigverse-python-tests.yml`.
+      - if: runner.os == 'Windows'
+        name: Build with Ninja so that the compiler cache is used
+        shell: bash
+        run: |
+          echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
+          echo "SCCACHE_DIR=$GITHUB_WORKSPACE/.sccache" >> "$GITHUB_ENV"
+          echo "SCCACHE_CACHE_SIZE=2G" >> "$GITHUB_ENV"
+
+      - if: runner.os == 'Windows'
+        name: Cache sccache objects
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .sccache
+          key: sccache-${{ matrix.runs-on }}-aigverse-wheels-${{ github.run_id }}
+          restore-keys: sccache-${{ matrix.runs-on }}-aigverse-wheels-
 
       - if: runner.os == 'Linux'
         name: Setup mold
@@ -111,8 +137,18 @@ jobs:
         with:
           enable-cache: false
 
+      - if: runner.os == 'Windows'
+        name: Install sccache
+        run: uv tool install sccache
+
       - name: Build wheels
         uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3
+
+      - if: always() && runner.os == 'Windows'
+        name: sccache statistics
+        run: |
+          sccache --show-stats
+          sccache --stop-server
 
       - name: Upload wheel as an artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/aigverse-pypi-deployment.yml
+++ b/.github/workflows/aigverse-pypi-deployment.yml
@@ -95,38 +95,28 @@ jobs:
       - name: Set up MSVC development environment (Windows only)
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
+      # Linux only, and that is not an oversight. cibuildwheel builds each wheel
+      # under a directory it names randomly per run -- `cibw-run-43zqqz1p`, then
+      # `cibw-run-ihw907m4` -- and on the native runners the build interpreter
+      # lives inside it, so its include path lands in every compile command and
+      # no command ever repeats. Measured with a restored 276 MB cache present:
+      # windows 145 requests / 0 hits, macOS 145 calls / 0 hits. Neither ccache
+      # nor sccache can normalise that away.
+      #
+      # The container has no such problem. Everything the Linux build sees is
+      # fixed -- /opt/python/cp310-cp310, /project/build/... -- so its commands
+      # do repeat and the cache works.
+      #
       # The key carries `-wheels` because this workflow and the test matrix used
-      # to share `${{matrix.runs-on}}-aigverse` and evict each other. cibuildwheel
-      # builds against its own CPython installs, the test matrix against nox
-      # virtualenvs, so the two produce disjoint objects and neither could ever
-      # use what the other stored: the macOS wheel job restored a cache written
-      # by the test workflow and reported 145 calls, 0 hits.
-      - if: runner.os != 'Windows'
+      # to share `${{matrix.runs-on}}-aigverse` and evict each other, their
+      # objects being disjoint.
+      - if: runner.os == 'Linux'
         name: Setup ccache
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
         with:
           key: "${{matrix.runs-on}}-aigverse-wheels"
           save: true
           max-size: 10G
-
-      # Same defect, and the same fix, as the test matrix: scikit-build-core
-      # picks the Visual Studio generator, MSBuild ignores the compiler launcher,
-      # and the job cached nothing at all. See `aigverse-python-tests.yml`.
-      - if: runner.os == 'Windows'
-        name: Build with Ninja so that the compiler cache is used
-        shell: bash
-        run: |
-          echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
-          echo "SCCACHE_DIR=$GITHUB_WORKSPACE/.sccache" >> "$GITHUB_ENV"
-          echo "SCCACHE_CACHE_SIZE=2G" >> "$GITHUB_ENV"
-
-      - if: runner.os == 'Windows'
-        name: Cache sccache objects
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .sccache
-          key: sccache-${{ matrix.runs-on }}-aigverse-wheels-${{ github.run_id }}
-          restore-keys: sccache-${{ matrix.runs-on }}-aigverse-wheels-
 
       # cibuildwheel copies the project into the manylinux container with
       # `docker cp` instead of mounting it, so the container needs an explicit
@@ -148,18 +138,8 @@ jobs:
         with:
           enable-cache: false
 
-      - if: runner.os == 'Windows'
-        name: Install sccache
-        run: uv tool install sccache
-
       - name: Build wheels
         uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3
-
-      - if: always() && runner.os == 'Windows'
-        name: sccache statistics
-        run: |
-          sccache --show-stats
-          sccache --stop-server
 
       - name: Upload wheel as an artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/aigverse-pypi-deployment.yml
+++ b/.github/workflows/aigverse-pypi-deployment.yml
@@ -95,31 +95,15 @@ jobs:
       - name: Set up MSVC development environment (Windows only)
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
-      # No compiler cache here, deliberately. Every wheel build compiles against
-      # nanobind headers inside uv's PEP 517 build-isolation environment, which
-      # is a directory named randomly per run:
+      # No compiler cache here, deliberately. Wheels compile against nanobind
+      # headers inside uv's build-isolation environment, a directory named
+      # randomly per run (`/tmp/build-env-r57r75a3`, then `/tmp/build-env-sjkp5_7v`),
+      # so no compilation ever repeats. Disabling isolation does not help either:
+      # cibuildwheel's own build venv is randomised the same way. Measured on all
+      # four platforms with a restored cache present: 145 requests, 0 hits.
       #
-      #   -I/tmp/build-env-r57r75a3/lib/python3.10/site-packages/nanobind/include
-      #   -I/tmp/build-env-sjkp5_7v/lib/python3.10/site-packages/nanobind/include
-      #
-      # That one token is the only difference between two runs of the same
-      # commit, out of 78 in the command, and it is enough that no compilation
-      # ever repeats. Disabling build isolation does not help: cibuildwheel's own
-      # per-build virtualenv is `/tmp/tmp.XXXXXXXX/venv`, randomised the same way.
-      # Base-directory rewriting cannot recover it either, since both caches
-      # rewrite relative to the compile working directory, which sits on a
-      # separate stable root.
-      #
-      # Measured on all four platforms with a restored cache present: windows 145
-      # requests / 0 hits, macOS 145 / 0, and Linux 145 / 0 even with sccache
-      # reachable inside the container and 0 non-cacheable calls. The test matrix
-      # is cacheable precisely because it builds with `--no-build-isolation-package`
-      # against stable `.nox/<session>` virtualenvs -- see aigverse-python-tests.yml,
-      # which hits 360 of 360.
-      #
-      # A cache action here was also actively harmful: it shared the key
-      # `${{ matrix.runs-on }}-aigverse` with the test matrix while producing
-      # disjoint objects, so each run overwrote a cache the other could not use.
+      # A cache action here was also harmful, sharing a key with the test matrix
+      # while producing disjoint objects, so each run evicted the other's.
 
       - if: runner.os == 'Linux'
         name: Setup mold

--- a/.github/workflows/aigverse-pypi-deployment.yml
+++ b/.github/workflows/aigverse-pypi-deployment.yml
@@ -128,6 +128,17 @@ jobs:
           key: sccache-${{ matrix.runs-on }}-aigverse-wheels-${{ github.run_id }}
           restore-keys: sccache-${{ matrix.runs-on }}-aigverse-wheels-
 
+      # cibuildwheel copies the project into the manylinux container with
+      # `docker cp` instead of mounting it, so the container needs an explicit
+      # volume to reach the cache directory the action manages on the host.
+      # Without it ccache runs inside the container and writes into a filesystem
+      # that is thrown away with it.
+      - if: runner.os == 'Linux'
+        name: Share the ccache directory with the manylinux container
+        run: |
+          echo "CIBW_CONTAINER_ENGINE=docker; create_args: --volume=$GITHUB_WORKSPACE/.ccache:/ccache" >> "$GITHUB_ENV"
+          echo "CIBW_ENVIRONMENT_LINUX=CCACHE_DIR=/ccache" >> "$GITHUB_ENV"
+
       - if: runner.os == 'Linux'
         name: Setup mold
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1

--- a/.github/workflows/aigverse-pypi-deployment.yml
+++ b/.github/workflows/aigverse-pypi-deployment.yml
@@ -95,37 +95,31 @@ jobs:
       - name: Set up MSVC development environment (Windows only)
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
-      # Linux only, and that is not an oversight. cibuildwheel builds each wheel
-      # under a directory it names randomly per run -- `cibw-run-43zqqz1p`, then
-      # `cibw-run-ihw907m4` -- and on the native runners the build interpreter
-      # lives inside it, so its include path lands in every compile command and
-      # no command ever repeats. Measured with a restored 276 MB cache present:
-      # windows 145 requests / 0 hits, macOS 145 calls / 0 hits. Base-directory
-      # rewriting cannot recover it either: both caches rewrite paths relative
-      # to the compile working directory, which here sits on a separate stable
-      # root, so the varying component survives the rewrite.
+      # No compiler cache here, deliberately. Every wheel build compiles against
+      # nanobind headers inside uv's PEP 517 build-isolation environment, which
+      # is a directory named randomly per run:
       #
-      # The container has no such problem. Everything the Linux build sees is
-      # fixed -- /opt/python/cp310-cp310, /project/build/... -- so its commands
-      # do repeat and the cache works.
+      #   -I/tmp/build-env-r57r75a3/lib/python3.10/site-packages/nanobind/include
+      #   -I/tmp/build-env-sjkp5_7v/lib/python3.10/site-packages/nanobind/include
       #
-      # The key carries `-wheels` because this workflow and the test matrix used
-      # to share `${{matrix.runs-on}}-aigverse` and evict each other, their
-      # objects being disjoint.
-      - if: runner.os == 'Linux'
-        name: Share the sccache directory with the manylinux container
-        run: |
-          mkdir -p "$GITHUB_WORKSPACE/.sccache"
-          echo "CIBW_CONTAINER_ENGINE=docker; create_args: --volume=$GITHUB_WORKSPACE/.sccache:/sccache" >> "$GITHUB_ENV"
-          echo "CIBW_ENVIRONMENT_LINUX=SCCACHE_DIR=/sccache SCCACHE_CACHE_SIZE=2G CMAKE_ARGS=-DCMAKE_VERBOSE_MAKEFILE=ON" >> "$GITHUB_ENV"
-
-      - if: runner.os == 'Linux'
-        name: Cache sccache objects
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .sccache
-          key: sccache-${{ matrix.runs-on }}-aigverse-wheels-${{ github.run_id }}
-          restore-keys: sccache-${{ matrix.runs-on }}-aigverse-wheels-
+      # That one token is the only difference between two runs of the same
+      # commit, out of 78 in the command, and it is enough that no compilation
+      # ever repeats. Disabling build isolation does not help: cibuildwheel's own
+      # per-build virtualenv is `/tmp/tmp.XXXXXXXX/venv`, randomised the same way.
+      # Base-directory rewriting cannot recover it either, since both caches
+      # rewrite relative to the compile working directory, which sits on a
+      # separate stable root.
+      #
+      # Measured on all four platforms with a restored cache present: windows 145
+      # requests / 0 hits, macOS 145 / 0, and Linux 145 / 0 even with sccache
+      # reachable inside the container and 0 non-cacheable calls. The test matrix
+      # is cacheable precisely because it builds with `--no-build-isolation-package`
+      # against stable `.nox/<session>` virtualenvs -- see aigverse-python-tests.yml,
+      # which hits 360 of 360.
+      #
+      # A cache action here was also actively harmful: it shared the key
+      # `${{ matrix.runs-on }}-aigverse` with the test matrix while producing
+      # disjoint objects, so each run overwrote a cache the other could not use.
 
       - if: runner.os == 'Linux'
         name: Setup mold
@@ -138,16 +132,6 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3
-
-      # The container compiles as root and sccache creates its directories 0700,
-      # so the runner cannot read them back and the cache save fails with
-      # `tar: .sccache/a: Cannot open: Permission denied`. That is only a
-      # warning, so without this the job stays green while saving nothing.
-      # `always()` keeps a partial cache from a failed build, which is still
-      # worth having.
-      - if: always() && runner.os == 'Linux'
-        name: Hand the container's cache back to the runner
-        run: sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE/.sccache"
 
       - name: Upload wheel as an artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/aigverse-python-tests.yml
+++ b/.github/workflows/aigverse-python-tests.yml
@@ -3,9 +3,6 @@
 name: 🐍 • CI
 
 on:
-  # Manual runs make the pipeline measurable: dispatched runs get a unique
-  # concurrency group, so repeats of the same ref do not cancel each other.
-  workflow_dispatch:
   merge_group:
   push:
     branches: ["main"]
@@ -102,26 +99,10 @@ jobs:
           save: true
           max-size: 10G
 
-      # Windows needs three things that the other platforms get for free.
-      #
-      # scikit-build-core defaults to the Visual Studio generator on Windows,
-      # and MSBuild ignores CMAKE_<LANG>_COMPILER_LAUNCHER, so the compiler
-      # cache was configured and then never invoked: the job used to end with
-      # "Cache size (GB): 0.0 / 10.0" after twenty minutes of compiling. Ninja
-      # honours the launcher, but only runs if MSVC is already on PATH, hence
-      # the developer environment.
-      #
-      # The cache itself is sccache rather than ccache. ccache's MSVC support
-      # does not work in practice -- measured against this same workload it
-      # reports half the invocations as uncacheable and never hits on the rest.
-      # `cmake/Cache.cmake` picks sccache automatically under MSVC.
-      #
-      # The cache has to persist between runs to be worth anything here. A
-      # job-local cache was measured first and returned nothing: the ten builds
-      # inside one job compile against ten different interpreters, each in its
-      # own nox virtualenv, so no two of them are the same compilation and
-      # sccache reported 360 requests and 0 hits. The identical ten recur on
-      # every run, though, which is exactly why ccache hits 360 of 360 on Linux.
+      # MSBuild ignores CMAKE_<LANG>_COMPILER_LAUNCHER, so under scikit-build-core's
+      # default Visual Studio generator the cache was configured and never invoked.
+      # Ninja honours it, but needs MSVC on PATH. sccache rather than ccache,
+      # whose MSVC support reports most invocations uncacheable and hits none.
       - if: runner.os == 'Windows'
         name: Set up the MSVC development environment
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
@@ -132,16 +113,13 @@ jobs:
         run: |
           echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
           echo "SCCACHE_DIR=$GITHUB_WORKSPACE/.sccache" >> "$GITHUB_ENV"
-          # The working set is ~400 MB for the six builds a job does. 2G let a
-          # single entry reach 1.2 GB when the build layout changed and both
-          # generations of objects were kept, and GitHub evicts repo-wide at
-          # 10 GB, so an oversized entry here costs other workflows their cache.
+          # ~400 MB working set; a bigger ceiling just evicts other workflows'
+          # caches against the repo-wide 10 GB limit.
           echo "SCCACHE_CACHE_SIZE=600M" >> "$GITHUB_ENV"
 
-      # A fresh key every run with a prefix restore, so each run starts from the
-      # most recent cache and stores its own. GitHub's cache entries are
-      # immutable, so the usual save-under-the-same-key idiom would only ever
-      # write once and then go stale.
+      # Persisting between runs is the whole point: the builds within one job
+      # target different interpreters and share nothing, but recur every run.
+      # Fresh key per run with a prefix restore, since cache entries are immutable.
       - if: runner.os == 'Windows'
         name: Cache sccache objects
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -181,10 +159,8 @@ jobs:
       - name: 🐍 Test
         run: uvx nox -s tests --verbose -- --full -m "not network"
 
-      # A hit rate is a fact; a step duration is a guess about one. Print it on
-      # every run so a cache that quietly stops working is visible immediately
-      # rather than after someone times the matrix against itself. The other
-      # platforms get the same thing from ccache-action's post step.
+      # A hit rate is a fact; a step duration is a guess about one. The other
+      # platforms get this from ccache-action's post step.
       - if: always() && runner.os == 'Windows'
         name: sccache statistics
         run: |

--- a/.github/workflows/aigverse-python-tests.yml
+++ b/.github/workflows/aigverse-python-tests.yml
@@ -161,8 +161,11 @@ jobs:
 
       # A hit rate is a fact; a step duration is a guess about one. The other
       # platforms get this from ccache-action's post step.
+      # Never gate the job: `--stop-server` exits non-zero when sccache was never
+      # invoked, which is the failure this step exists to make visible.
       - if: always() && runner.os == 'Windows'
         name: sccache statistics
+        continue-on-error: true
         run: |
-          sccache --show-stats
-          sccache --stop-server
+          sccache --show-stats || true
+          sccache --stop-server || true

--- a/.github/workflows/aigverse-python-tests.yml
+++ b/.github/workflows/aigverse-python-tests.yml
@@ -160,12 +160,12 @@ jobs:
         run: uvx nox -s tests --verbose -- --full -m "not network"
 
       # A hit rate is a fact; a step duration is a guess about one. The other
-      # platforms get this from ccache-action's post step.
-      # Never gate the job: `--stop-server` exits non-zero when sccache was never
-      # invoked, which is the failure this step exists to make visible.
+      # platforms get this from ccache-action's post step. `--show-stats` is left
+      # to fail the job, since it only fails when sccache itself is broken, which
+      # is the thing this step exists to catch; `--stop-server` exits non-zero
+      # when no server was ever started, which is not an error.
       - if: always() && runner.os == 'Windows'
         name: sccache statistics
-        continue-on-error: true
         run: |
-          sccache --show-stats || true
+          sccache --show-stats
           sccache --stop-server || true

--- a/.github/workflows/aigverse-python-tests.yml
+++ b/.github/workflows/aigverse-python-tests.yml
@@ -3,6 +3,9 @@
 name: 🐍 • CI
 
 on:
+  # Manual runs make the pipeline measurable: dispatched runs get a unique
+  # concurrency group, so repeats of the same ref do not cancel each other.
+  workflow_dispatch:
   merge_group:
   push:
     branches: ["main"]

--- a/.github/workflows/aigverse-python-tests.yml
+++ b/.github/workflows/aigverse-python-tests.yml
@@ -93,12 +93,58 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup ccache
+      # Windows is on sccache instead, see below.
+      - if: runner.os != 'Windows'
+        name: Setup ccache
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
         with:
           key: "${{matrix.runs-on}}-aigverse"
           save: true
           max-size: 10G
+
+      # Windows needs three things that the other platforms get for free.
+      #
+      # scikit-build-core defaults to the Visual Studio generator on Windows,
+      # and MSBuild ignores CMAKE_<LANG>_COMPILER_LAUNCHER, so the compiler
+      # cache was configured and then never invoked: the job used to end with
+      # "Cache size (GB): 0.0 / 10.0" after twenty minutes of compiling. Ninja
+      # honours the launcher, but only runs if MSVC is already on PATH, hence
+      # the developer environment.
+      #
+      # The cache itself is sccache rather than ccache. ccache's MSVC support
+      # does not work in practice -- measured against this same workload it
+      # reports half the invocations as uncacheable and never hits on the rest.
+      # `cmake/Cache.cmake` picks sccache automatically under MSVC.
+      #
+      # The cache has to persist between runs to be worth anything here. A
+      # job-local cache was measured first and returned nothing: the ten builds
+      # inside one job compile against ten different interpreters, each in its
+      # own nox virtualenv, so no two of them are the same compilation and
+      # sccache reported 360 requests and 0 hits. The identical ten recur on
+      # every run, though, which is exactly why ccache hits 360 of 360 on Linux.
+      - if: runner.os == 'Windows'
+        name: Set up the MSVC development environment
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
+      - if: runner.os == 'Windows'
+        name: Build with Ninja so that the compiler cache is used
+        shell: bash
+        run: |
+          echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
+          echo "SCCACHE_DIR=$GITHUB_WORKSPACE/.sccache" >> "$GITHUB_ENV"
+          echo "SCCACHE_CACHE_SIZE=2G" >> "$GITHUB_ENV"
+
+      # A fresh key every run with a prefix restore, so each run starts from the
+      # most recent cache and stores its own. GitHub's cache entries are
+      # immutable, so the usual save-under-the-same-key idiom would only ever
+      # write once and then go stale.
+      - if: runner.os == 'Windows'
+        name: Cache sccache objects
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .sccache
+          key: sccache-${{ matrix.runs-on }}-aigverse-${{ github.run_id }}
+          restore-keys: sccache-${{ matrix.runs-on }}-aigverse-
 
       - if: runner.os == 'Linux'
         name: Setup mold
@@ -109,6 +155,10 @@ jobs:
         with:
           enable-cache: true
           save-cache: ${{ github.ref == 'refs/heads/main' }}
+
+      - if: runner.os == 'Windows'
+        name: Install sccache
+        run: uv tool install sccache
 
       # The declared floors are only a claim until something installs them, so
       # resolve every direct dependency down to its minimum and run the suite
@@ -126,3 +176,13 @@ jobs:
 
       - name: 🐍 Test
         run: uvx nox -s tests --verbose -- --full -m "not network"
+
+      # A hit rate is a fact; a step duration is a guess about one. Print it on
+      # every run so a cache that quietly stops working is visible immediately
+      # rather than after someone times the matrix against itself. The other
+      # platforms get the same thing from ccache-action's post step.
+      - if: always() && runner.os == 'Windows'
+        name: sccache statistics
+        run: |
+          sccache --show-stats
+          sccache --stop-server

--- a/.github/workflows/aigverse-python-tests.yml
+++ b/.github/workflows/aigverse-python-tests.yml
@@ -132,7 +132,11 @@ jobs:
         run: |
           echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
           echo "SCCACHE_DIR=$GITHUB_WORKSPACE/.sccache" >> "$GITHUB_ENV"
-          echo "SCCACHE_CACHE_SIZE=2G" >> "$GITHUB_ENV"
+          # The working set is ~400 MB for the six builds a job does. 2G let a
+          # single entry reach 1.2 GB when the build layout changed and both
+          # generations of objects were kept, and GitHub evicts repo-wide at
+          # 10 GB, so an oversized entry here costs other workflows their cache.
+          echo "SCCACHE_CACHE_SIZE=600M" >> "$GITHUB_ENV"
 
       # A fresh key every run with a prefix restore, so each run starts from the
       # most recent cache and stores its own. GitHub's cache entries are

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 # C extensions
 *.so
 .ccache/
+.sccache/
 cmake-build-*
 
 # Distribution / packaging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ releases may include breaking changes.
 
 ### Fixed
 
+- 👷 Cache Windows compiles. `scikit-build-core` defaults to the Visual Studio
+  generator, which ignores `CMAKE_<LANG>_COMPILER_LAUNCHER`, so the compiler
+  cache was configured on Windows and then never invoked -- every job rebuilt
+  every translation unit once per interpreter. Windows now builds with Ninja and
+  caches with `sccache`, whose MSVC support, unlike ccache's, actually hits
+  ([#456]) ([**@marcelwa**])
 - 🐛 Forward `-h` and `--help` to `sphinx-build` in the `docs` nox session, which
   its own argument parser used to intercept ([#453]) ([**@marcelwa**])
 - 🐛 Gate the `numpy` and `torch` floors by Python version. Both predate every
@@ -165,6 +171,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#010)._
 
 <!-- PR links -->
 
+[#456]: https://github.com/marcelwa/aigverse/pull/456
 [#453]: https://github.com/marcelwa/aigverse/pull/453
 [#448]: https://github.com/marcelwa/aigverse/pull/448
 [#447]: https://github.com/marcelwa/aigverse/pull/447

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ releases may include breaking changes.
   one is caught by CI rather than by the next person to run it ([#410])
   ([**@marcelwa**])
 
+### Changed
+
+- ⚡️ Build the extension once per wheel tag in the `tests` and `minimums` nox
+  sessions instead of once per interpreter. `wheel.py-api = "cp312"` makes 3.12
+  and above one abi3 wheel, so a five-interpreter matrix needs three builds
+  rather than five, and the newer interpreters now run against the very artefact
+  PyPI ships ([#456]) ([**@marcelwa**])
+
 ### Fixed
 
 - 👷 Cache Windows compiles. `scikit-build-core` defaults to the Visual Studio

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@ releases may include breaking changes.
 - ⚡️ Build the extension once per wheel tag in the `tests` and `minimums` nox
   sessions instead of once per interpreter. `wheel.py-api = "cp312"` makes 3.12
   and above one abi3 wheel, so a five-interpreter matrix needs three builds
-  rather than five, and the newer interpreters now run against the very artefact
-  PyPI ships ([#456]) ([**@marcelwa**])
+  rather than five, and the newer interpreters now run against that one abi3
+  wheel rather than a purpose-built one each ([#456]) ([**@marcelwa**])
 
 ### Fixed
 

--- a/cmake/Cache.cmake
+++ b/cmake/Cache.cmake
@@ -1,7 +1,17 @@
 # Enable cache if available
 function(aigverse_enable_cache)
+  # ccache's MSVC support is nominal: half the invocations come back
+  # "Uncacheable" and the rest never hit, so it costs a process launch per
+  # translation unit and returns nothing. sccache is what MSVC builds actually
+  # cache with, so make it the default there.
+  if(MSVC)
+    set(CACHE_OPTION_DEFAULT "sccache")
+  else()
+    set(CACHE_OPTION_DEFAULT "ccache")
+  endif()
+
   set(CACHE_OPTION
-      "ccache"
+      ${CACHE_OPTION_DEFAULT}
       CACHE STRING "Compiler cache to be used")
   set(CACHE_OPTION_VALUES "ccache" "sccache")
   set_property(CACHE CACHE_OPTION PROPERTY STRINGS ${CACHE_OPTION_VALUES})
@@ -17,6 +27,17 @@ function(aigverse_enable_cache)
   unset(CACHE_BINARY CACHE)
   find_program(CACHE_BINARY NAMES ${CACHE_OPTION})
   if(CACHE_BINARY)
+    # The Visual Studio generator ignores CMAKE_<LANG>_COMPILER_LAUNCHER
+    # outright. Configuring one there looks like it works and caches nothing,
+    # which is exactly how this went unnoticed until Windows CI was timed
+    # against the other platforms.
+    if(CMAKE_GENERATOR MATCHES "Visual Studio")
+      message(
+        WARNING
+          "${CACHE_OPTION} was found, but the '${CMAKE_GENERATOR}' generator ignores "
+          "compiler launchers, so nothing will be cached. Configure with -G Ninja "
+          "(or set CMAKE_GENERATOR=Ninja) to make the cache effective.")
+    endif()
     message(STATUS "${CACHE_BINARY} found and enabled")
     set(CMAKE_CXX_COMPILER_LAUNCHER
         ${CACHE_BINARY}

--- a/cmake/Cache.cmake
+++ b/cmake/Cache.cmake
@@ -26,6 +26,19 @@ function(aigverse_enable_cache)
 
   unset(CACHE_BINARY CACHE)
   find_program(CACHE_BINARY NAMES ${CACHE_OPTION})
+
+  # Fall back to whichever cache is actually installed. The manylinux container
+  # the wheels are built in carries only sccache, and a contributor with one of
+  # the two on PATH should not have to name it.
+  if(NOT CACHE_BINARY)
+    list(REMOVE_ITEM CACHE_OPTION_VALUES ${CACHE_OPTION})
+    find_program(CACHE_BINARY NAMES ${CACHE_OPTION_VALUES})
+    if(CACHE_BINARY)
+      message(STATUS "${CACHE_OPTION} was not found, falling back to "
+                     "${CACHE_BINARY}")
+    endif()
+  endif()
+
   if(CACHE_BINARY)
     # The Visual Studio generator ignores CMAKE_<LANG>_COMPILER_LAUNCHER
     # outright. Configuring one there looks like it works and caches nothing,

--- a/cmake/Cache.cmake
+++ b/cmake/Cache.cmake
@@ -41,7 +41,7 @@ function(aigverse_enable_cache)
     if(CMAKE_GENERATOR MATCHES "Visual Studio")
       message(
         WARNING
-          "${CACHE_OPTION} was found, but the '${CMAKE_GENERATOR}' generator ignores "
+          "${CACHE_BINARY} was found, but the '${CMAKE_GENERATOR}' generator ignores "
           "compiler launchers, so nothing will be cached. Configure with -G Ninja "
           "(or set CMAKE_GENERATOR=Ninja) to make the cache effective.")
     endif()

--- a/cmake/Cache.cmake
+++ b/cmake/Cache.cmake
@@ -1,9 +1,7 @@
 # Enable cache if available
 function(aigverse_enable_cache)
-  # ccache's MSVC support is nominal: half the invocations come back
-  # "Uncacheable" and the rest never hit, so it costs a process launch per
-  # translation unit and returns nothing. sccache is what MSVC builds actually
-  # cache with, so make it the default there.
+  # ccache's MSVC support is nominal: most invocations come back "Uncacheable"
+  # and the rest never hit. sccache is what MSVC builds actually cache with.
   if(MSVC)
     set(CACHE_OPTION_DEFAULT "sccache")
   else()
@@ -27,9 +25,7 @@ function(aigverse_enable_cache)
   unset(CACHE_BINARY CACHE)
   find_program(CACHE_BINARY NAMES ${CACHE_OPTION})
 
-  # Fall back to whichever cache is actually installed. The manylinux container
-  # the wheels are built in carries only sccache, and a contributor with one of
-  # the two on PATH should not have to name it.
+  # A contributor with only one of the two on PATH should not have to name it.
   if(NOT CACHE_BINARY)
     list(REMOVE_ITEM CACHE_OPTION_VALUES ${CACHE_OPTION})
     find_program(CACHE_BINARY NAMES ${CACHE_OPTION_VALUES})
@@ -40,10 +36,8 @@ function(aigverse_enable_cache)
   endif()
 
   if(CACHE_BINARY)
-    # The Visual Studio generator ignores CMAKE_<LANG>_COMPILER_LAUNCHER
-    # outright. Configuring one there looks like it works and caches nothing,
-    # which is exactly how this went unnoticed until Windows CI was timed
-    # against the other platforms.
+    # The Visual Studio generator ignores compiler launchers outright, so
+    # configuring one there looks like it works and caches nothing.
     if(CMAKE_GENERATOR MATCHES "Visual Studio")
       message(
         WARNING

--- a/noxfile.py
+++ b/noxfile.py
@@ -107,7 +107,8 @@ def _build_or_reuse_wheel(
 
     Every session used to rebuild the extension, so 3.12 and up each recompiled
     the same sources into the identical abi3 wheel. Building once per tag also
-    means the newer interpreters run against the artefact PyPI ships.
+    means the newer interpreters run against that one wheel, which is the same
+    abi3 artefact users install, rather than a purpose-built one each.
 
     `tests` and `minimums` cannot share a wheel: `minimums` resolves the build
     dependencies to their floors, so its wheel comes from a different nanobind.

--- a/noxfile.py
+++ b/noxfile.py
@@ -58,18 +58,16 @@ def lint(session: nox.Session) -> None:
     session.run("prek", "run", "--all-files", *session.posargs, external=True)
 
 
-# Wheels already built during this nox invocation, keyed by (group, wheel tag).
-# Memoized per process rather than left on disk, so a stale wheel from an earlier
-# invocation can never be picked up.
+# Wheels built during this nox invocation, keyed by (group, wheel tag). Memoized
+# per process, so a stale wheel from an earlier invocation cannot be picked up.
 _BUILT_WHEELS: dict[tuple[str, str], Path] = {}
 
 
 def _wheel_tag(python: str) -> str:
     """Return the wheel tag a given interpreter builds.
 
-    `wheel.py-api = "cp312"` in pyproject.toml means 3.12 and everything above it
-    produce one and the same abi3 wheel, so they share a tag and only need
-    building once.
+    `wheel.py-api = "cp312"` makes 3.12 and above one and the same abi3 wheel, so
+    they share a tag and only need building once.
 
     Args:
         python: The interpreter version, as nox spells it, e.g. "3.12".
@@ -87,8 +85,7 @@ def _venv_python(session: nox.Session) -> Path:
     """Return the path to the session virtualenv's interpreter.
 
     `uv build --no-build-isolation` builds with whatever `--python` names, so it
-    has to be pointed at the environment holding the `build` group rather than at
-    a bare version number, which would resolve to a system interpreter.
+    needs the environment holding the `build` group, not a bare version number.
 
     Args:
         session: The nox session whose virtualenv to locate.
@@ -108,16 +105,12 @@ def _build_or_reuse_wheel(
 ) -> Path:
     """Build the project wheel for this session's tag, or reuse one already built.
 
-    Every session used to rebuild the extension from scratch, which for a matrix
-    of six interpreters meant six compilations of the same 26 translation units
-    per nox invocation, twice over across `tests` and `minimums`. Three of those
-    tags are identical, so this collapses them: 3.12 through 3.15 share one abi3
-    wheel and it is built once. It is also closer to what users get, since the
-    newer interpreters then exercise the very artefact PyPI ships.
+    Every session used to rebuild the extension, so 3.12 and up each recompiled
+    the same sources into the identical abi3 wheel. Building once per tag also
+    means the newer interpreters run against the artefact PyPI ships.
 
     `tests` and `minimums` cannot share a wheel: `minimums` resolves the build
-    dependencies down to their floors, so its wheel is built by a different
-    nanobind and scikit-build-core.
+    dependencies to their floors, so its wheel comes from a different nanobind.
 
     Args:
         session: The nox session requesting the wheel.
@@ -229,8 +222,8 @@ def _run_tests(
         "install",
         "--python",
         str(_venv_python(session)),
-        # the version is derived from the commit, so an uncommitted source change
-        # rebuilds to the same version and would otherwise be skipped as present
+        # the version comes from the commit, so an uncommitted source change
+        # rebuilds to the same version and would be skipped as already present
         "--reinstall-package",
         "aigverse",
         str(wheel),

--- a/noxfile.py
+++ b/noxfile.py
@@ -58,9 +58,111 @@ def lint(session: nox.Session) -> None:
     session.run("prek", "run", "--all-files", *session.posargs, external=True)
 
 
+# Wheels already built during this nox invocation, keyed by (group, wheel tag).
+# Memoized per process rather than left on disk, so a stale wheel from an earlier
+# invocation can never be picked up.
+_BUILT_WHEELS: dict[tuple[str, str], Path] = {}
+
+
+def _wheel_tag(python: str) -> str:
+    """Return the wheel tag a given interpreter builds.
+
+    `wheel.py-api = "cp312"` in pyproject.toml means 3.12 and everything above it
+    produce one and the same abi3 wheel, so they share a tag and only need
+    building once.
+
+    Args:
+        python: The interpreter version, as nox spells it, e.g. "3.12".
+
+    Returns:
+        The tag identifying the wheel that interpreter builds.
+    """
+    major, minor = (int(part) for part in python.split("."))
+    if (major, minor) >= (3, 12):
+        return "cp312-abi3"
+    return f"cp{major}{minor}"
+
+
+def _venv_python(session: nox.Session) -> Path:
+    """Return the path to the session virtualenv's interpreter.
+
+    `uv build --no-build-isolation` builds with whatever `--python` names, so it
+    has to be pointed at the environment holding the `build` group rather than at
+    a bare version number, which would resolve to a system interpreter.
+
+    Args:
+        session: The nox session whose virtualenv to locate.
+
+    Returns:
+        Path to the interpreter inside the session's virtualenv.
+    """
+    venv = Path(session.virtualenv.location)
+    return venv / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+
+def _build_or_reuse_wheel(
+    session: nox.Session,
+    group: str,
+    env: dict[str, str],
+    install_args: Sequence[str],
+) -> Path:
+    """Build the project wheel for this session's tag, or reuse one already built.
+
+    Every session used to rebuild the extension from scratch, which for a matrix
+    of six interpreters meant six compilations of the same 26 translation units
+    per nox invocation, twice over across `tests` and `minimums`. Three of those
+    tags are identical, so this collapses them: 3.12 through 3.15 share one abi3
+    wheel and it is built once. It is also closer to what users get, since the
+    newer interpreters then exercise the very artefact PyPI ships.
+
+    `tests` and `minimums` cannot share a wheel: `minimums` resolves the build
+    dependencies down to their floors, so its wheel is built by a different
+    nanobind and scikit-build-core.
+
+    Args:
+        session: The nox session requesting the wheel.
+        group: Which family of sessions this belongs to, `tests` or `minimums`.
+        env: Environment to run `uv` with.
+        install_args: Extra `uv` arguments, used to pin resolution.
+
+    Returns:
+        Path to the built wheel.
+    """
+    key = (group, _wheel_tag(session.python))
+    cached = _BUILT_WHEELS.get(key)
+    if cached is not None and cached.is_file():
+        session.log(f"reusing {cached.name}, already built for {key[1]}")
+        return cached
+
+    out_dir = Path(".nox") / "_wheels" / f"{key[0]}-{key[1]}"
+    if out_dir.exists():
+        shutil.rmtree(out_dir)
+    out_dir.mkdir(parents=True)
+
+    session.run(
+        "uv",
+        "build",
+        "--wheel",
+        "--no-build-isolation",  # build deps are already in the session venv
+        "--python",
+        str(_venv_python(session)),
+        "--out-dir",
+        str(out_dir),
+        *install_args,
+        env=env,
+    )
+
+    built = sorted(out_dir.glob("*.whl"))
+    if not built:
+        session.error(f"uv build produced no wheel in {out_dir}")
+    _BUILT_WHEELS[key] = built[0]
+    return built[0]
+
+
 def _run_tests(
     session: nox.Session,
     *,
+    group: str,
     install_args: Sequence[str] = (),
     extra_command: Sequence[str] = (),
     pytest_run_args: Sequence[str] = (),
@@ -69,6 +171,8 @@ def _run_tests(
 
     Args:
         session: The nox session to install into and run in.
+        group: Which family of sessions this belongs to, `tests` or `minimums`.
+            Wheels are shared between sessions of the same group and tag.
         install_args: Extra arguments forwarded to every `uv` invocation, used to
             pin resolution for the minimums session.
         extra_command: A command to run after installing and before testing.
@@ -118,15 +222,18 @@ def _run_tests(
         *install_args,
         env=env,
     )
+    wheel = _build_or_reuse_wheel(session, group, env, install_args)
     session.run(
         "uv",
-        "sync",
-        "--inexact",
-        "--no-dev",  # do not auto-install dev dependencies
-        "--no-build-isolation-package",
-        "aigverse",  # build the project without isolation
-        python_flag,
-        *install_args,
+        "pip",
+        "install",
+        "--python",
+        str(_venv_python(session)),
+        # the version is derived from the commit, so an uncommitted source change
+        # rebuilds to the same version and would otherwise be skipped as present
+        "--reinstall-package",
+        "aigverse",
+        str(wheel),
         env=env,
     )
     if extra_command:
@@ -200,7 +307,7 @@ def _find_abc() -> str | None:
 @nox.session(reuse_venv=True, python=PYTHON_ALL_VERSIONS, default=True)
 def tests(session: nox.Session) -> None:
     """Run the test suite."""
-    _run_tests(session)
+    _run_tests(session, group="tests")
 
 
 @nox.session(reuse_venv=True, venv_backend="uv", python=PYTHON_ALL_VERSIONS, default=True)
@@ -209,6 +316,7 @@ def minimums(session: nox.Session) -> None:
     with preserve_lockfile():
         _run_tests(
             session,
+            group="minimums",
             install_args=["--resolution=lowest-direct"],
             pytest_run_args=["-Wdefault"],
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,27 +148,6 @@ test-sources = ["test/"]
 test-command = 'pytest test/ -m "(torch or not torch) and not network"'
 
 
-# The manylinux image ships no compiler cache at all, so the Linux wheels
-# compiled uncached. sccache comes from PyPI rather than EPEL, which carries
-# only ccache 3.7.7: the host runs 4.9.1, the two on-disk formats are not
-# compatible, and pointing both at one directory produced a second full set of
-# objects instead of a single hit. PyPI also publishes aarch64 wheels, which the
-# official ccache static builds do not.
-#
-# The install is allowed to fail. If PyPI is ever unreachable `Cache.cmake`
-# warns and the build proceeds uncached, which is a better failure mode for a
-# release than a broken one.
-#
-# The cache directory is bind-mounted into the container by the workflow, which
-# is also where `SCCACHE_DIR` is set. It cannot live under /project:
-# cibuildwheel copies the project in with `docker cp` rather than mounting it,
-# so anything written there is discarded along with the container.
-[tool.cibuildwheel.linux]
-before-all = "/opt/python/cp312-cp312/bin/pip install sccache && ln -sf /opt/python/cp312-cp312/bin/sccache /usr/local/bin/sccache || true"
-# Runs after each build and before its tests, so every build reports its own
-# hit rate. A hit rate is a fact; a job duration is a guess about one.
-before-test = "sccache --show-stats || true"
-
 [tool.cibuildwheel.macos]
 environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,9 +165,9 @@ test-command = 'pytest test/ -m "(torch or not torch) and not network"'
 # so anything written there is discarded along with the container.
 [tool.cibuildwheel.linux]
 before-all = "/opt/python/cp312-cp312/bin/pip install sccache && ln -sf /opt/python/cp312-cp312/bin/sccache /usr/local/bin/sccache || true"
-# Runs before each build, so the last one reports the hit rate for everything
-# built before it. A hit rate is a fact; a job duration is a guess about one.
-before-build = "sccache --show-stats || true"
+# Runs after each build and before its tests, so every build reports its own
+# hit rate. A hit rate is a fact; a job duration is a guess about one.
+before-test = "sccache --show-stats || true"
 
 [tool.cibuildwheel.macos]
 environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,19 +148,26 @@ test-sources = ["test/"]
 test-command = 'pytest test/ -m "(torch or not torch) and not network"'
 
 
-# The manylinux image ships no ccache, so the Linux wheel builds compiled
-# uncached: the job restored a cache and then never invoked ccache once.
+# The manylinux image ships no compiler cache at all, so the Linux wheels
+# compiled uncached. sccache comes from PyPI rather than EPEL, which carries
+# only ccache 3.7.7: the host runs 4.9.1, the two on-disk formats are not
+# compatible, and pointing both at one directory produced a second full set of
+# objects instead of a single hit. PyPI also publishes aarch64 wheels, which the
+# official ccache static builds do not.
 #
-# The install is allowed to fail. ccache lives in EPEL, and if that is ever
-# unavailable `Cache.cmake` warns and the build proceeds uncached, which is a
-# better failure mode for a release than a broken one.
+# The install is allowed to fail. If PyPI is ever unreachable `Cache.cmake`
+# warns and the build proceeds uncached, which is a better failure mode for a
+# release than a broken one.
 #
 # The cache directory is bind-mounted into the container by the workflow, which
-# is also where `CCACHE_DIR` is set. It cannot live under /project: cibuildwheel
-# copies the project in with `docker cp` rather than mounting it, so anything
-# written there is discarded with the container.
+# is also where `SCCACHE_DIR` is set. It cannot live under /project:
+# cibuildwheel copies the project in with `docker cp` rather than mounting it,
+# so anything written there is discarded along with the container.
 [tool.cibuildwheel.linux]
-before-all = "yum install -y epel-release ccache || true"
+before-all = "/opt/python/cp312-cp312/bin/pip install sccache && ln -sf /opt/python/cp312-cp312/bin/sccache /usr/local/bin/sccache || true"
+# Runs before each build, so the last one reports the hit rate for everything
+# built before it. A hit rate is a fact; a job duration is a guess about one.
+before-build = "sccache --show-stats || true"
 
 [tool.cibuildwheel.macos]
 environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,18 +148,19 @@ test-sources = ["test/"]
 test-command = 'pytest test/ -m "(torch or not torch) and not network"'
 
 
-# Linux wheels build inside the manylinux container, which has no ccache and
-# cannot see the host's. The workspace is mounted at /project, so the cache
-# directory the ccache action manages on the host is reachable from inside --
-# it just has to be named by its in-container path. Without this the Linux wheel
-# job restored a 0.3 GB cache and then never invoked ccache once.
+# The manylinux image ships no ccache, so the Linux wheel builds compiled
+# uncached: the job restored a cache and then never invoked ccache once.
 #
-# The install is allowed to fail: ccache lives in EPEL, and if that is ever
-# unavailable `Cache.cmake` warns and the build proceeds uncached rather than
-# breaking a release.
+# The install is allowed to fail. ccache lives in EPEL, and if that is ever
+# unavailable `Cache.cmake` warns and the build proceeds uncached, which is a
+# better failure mode for a release than a broken one.
+#
+# The cache directory is bind-mounted into the container by the workflow, which
+# is also where `CCACHE_DIR` is set. It cannot live under /project: cibuildwheel
+# copies the project in with `docker cp` rather than mounting it, so anything
+# written there is discarded with the container.
 [tool.cibuildwheel.linux]
 before-all = "yum install -y epel-release ccache || true"
-environment = { CCACHE_DIR = "/project/.ccache" }
 
 [tool.cibuildwheel.macos]
 environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,19 @@ test-sources = ["test/"]
 test-command = 'pytest test/ -m "(torch or not torch) and not network"'
 
 
+# Linux wheels build inside the manylinux container, which has no ccache and
+# cannot see the host's. The workspace is mounted at /project, so the cache
+# directory the ccache action manages on the host is reachable from inside --
+# it just has to be named by its in-container path. Without this the Linux wheel
+# job restored a 0.3 GB cache and then never invoked ccache once.
+#
+# The install is allowed to fail: ccache lives in EPEL, and if that is ever
+# unavailable `Cache.cmake` warns and the build proceeds uncached rather than
+# breaking a release.
+[tool.cibuildwheel.linux]
+before-all = "yum install -y epel-release ccache || true"
+environment = { CCACHE_DIR = "/project/.ccache" }
+
 [tool.cibuildwheel.macos]
 environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 


### PR DESCRIPTION
## Description

Fixes #454.

Windows gated the wall-clock of every CI run and, unlike every other platform, got nothing from a warm compiler cache. It turned out not to be a weak cache but an absent one, and chasing it surfaced a second, platform-independent waste in the same matrix.

### Result

Medians of repeated runs per arm, `🐍 • CI`:

| Job | baseline | after | change |
| --- | -------- | ----- | ------ |
| `🐍 windows-2025` | **1309s** | **596s** | **−54%** |
| `🐍 macos-15` | 363s | 292s | −20% |
| `🐍 ubuntu-24.04-arm` | 332s | 278s | −16% |
| `🐍 ubuntu-24.04` | 442s | 384s | −13% |

Windows now reports **216/216 sccache hits (100%)**, matching Linux. Tests unchanged throughout at 329 passed / 150 skipped.

### 1. The Windows cache was never invoked

`scikit-build-core` defaults to the Visual Studio generator on Windows, and **MSBuild ignores `CMAKE_<LANG>_COMPILER_LAUNCHER`**. `cmake/Cache.cmake` set the variables, CMake accepted them, and nothing downstream read them:

```
Local storage:
  Cache size (GB): 0.0 / 10.0 ( 0.00%)
Not saving cache because no objects are cached.
```

after twenty minutes of compiling, while `ubuntu-24.04` on the same run reported `360 / 360 (100.0%)` hits.

**ccache is not the fix, even with Ninja.** Measured on fiction, which already runs Ninja + MSVC + ccache: v143 reports half of 602 invocations `Uncacheable` and 0 hits on the rest; ClangCL reports all 602 cacheable and still 0 hits, across two consecutive runs on one cache key.

**The win is cross-run, not intra-job.** A job-local sccache was measured first and returned 360 requests, 0 hits, and a 9% *slower* job. The builds inside one job are not the same compilation — each runs against a different interpreter in its own virtualenv — but the same set recurs every run, which is exactly why Linux hits 360/360.

### 2. The extension was built once per interpreter, not once per wheel tag

`wheel.py-api = "cp312"` makes 3.12 and above one abi3 wheel, so five interpreters need three builds, not five — ten across `tests` and `minimums` rather than six.

The redundancy is invisible from the build directory, which is keyed by wheel tag and already shared: abi3 makes the *binary* portable, but each build still compiles against a specific interpreter's headers, so `Python_INCLUDE_DIR` changes and the target fully rebuilds. Reusing the **wheel** is what skips the work — which is what cibuildwheel already does (`that's compatible with cp313-win_amd64. Skipping build step...`), and why the wheel jobs never had this problem.

sccache confirms it: 360 compile requests per job before, 216 after. The newer interpreters now also run against the very artefact PyPI ships.

### Wheels: not cacheable, and now documented as such

Every wheel job cached nothing either. Making the build verbose and diffing the compile command for one translation unit across two runs of the same commit gives exactly one differing token out of 78:

```
-I/tmp/build-env-r57r75a3/lib/python3.10/site-packages/nanobind/include
-I/tmp/build-env-sjkp5_7v/lib/python3.10/site-packages/nanobind/include
```

uv's PEP 517 build-isolation environment is named randomly per run and nanobind's headers live inside it, so no compilation ever repeats. The same `build-env-*` directories appear in the Windows and macOS logs, so it is one root cause on all four platforms. Disabling build isolation does not rescue it — cibuildwheel's own per-build virtualenv is `/tmp/tmp.XXXXXXXX/venv`, randomised the same way — and base-directory rewriting cannot either, since both caches rewrite relative to the compile working directory, which sits on a separate stable root.

Measured with a restored cache present on every platform: windows 145 requests / 0 hits, macOS 145 / 0, Linux 145 / 0 even with sccache reachable inside the manylinux container and 0 non-cacheable calls.

So the wheel jobs lose their cache action entirely. It never cached anything, and it was worse than inert: it shared the key `${{ matrix.runs-on }}-aigverse` with the test matrix while producing disjoint objects, so the two workflows overwrote caches neither could use. The reasoning is recorded in the workflow so it is not re-derived.

### Notes

`cmake/Cache.cmake` now picks the cache per compiler, falls back to whichever is installed, and **warns when a launcher is configured under a generator that will silently drop it**. That warning is what would have surfaced this years ago.

The commit history keeps the negative results and the reverts deliberately, so the measurements that ruled each approach out stay attached to the code.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry for any noteworthy addition, change, fix, or removal.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved compiler caching across supported test and build environments, including Windows.
  * Added fallback handling when the preferred caching tool is unavailable.

* **Testing & Builds**
  * Reused compatible wheels across Python test sessions to reduce redundant builds.
  * Test environments now install explicitly built wheels for more consistent validation.

* **Documentation**
  * Updated the changelog with wheel-building and Windows caching improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->