### PR TITLE
✨ Expose sequential simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Add `simulate_sequential`, which runs a `SequentialAig` over a number of clock
+  cycles from its reset state and returns the primary output values and the register
+  values per cycle. `simulate` has no notion of a register and never assigns the
+  register outputs at all ([#458]) ([**@marcelwa**])
 - 👷 Run `nox -s minimums` in CI across the full platform matrix, so the declared
   dependency floors are actually installed and tested instead of only claimed
   ([#453]) ([**@marcelwa**])
@@ -165,6 +169,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#010)._
 
 <!-- PR links -->
 
+[#458]: https://github.com/marcelwa/aigverse/pull/458
 [#453]: https://github.com/marcelwa/aigverse/pull/453
 [#448]: https://github.com/marcelwa/aigverse/pull/448
 [#447]: https://github.com/marcelwa/aigverse/pull/447

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -42,7 +42,7 @@ find_package(nanobind CONFIG REQUIRED PATHS "${nanobind_ROOT}" NO_DEFAULT_PATH)
 
 # Fetch mockturtle library
 set(MOCKTURTLE_REV
-    "c5807b7e2be424ec6cb2ea2152882ac3847af19c"
+    "b856d3e0028d3578ed6739d2885c4931db8bb837"
     CACHE STRING "mockturtle identifier (tag, branch or commit hash)")
 set(MOCKTURTLE_REPO_OWNER
     "marcelwa"

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -57,6 +57,93 @@ for node, tt in node_tts.items():
     print(f"  Node {node}: {tt.to_binary()}")
 ```
 
+### Sequential Simulation
+
+{py:func}`~aigverse.algorithms.simulate` evaluates the combinational logic exactly once and has no notion of a
+register. Handed a {py:class}`~aigverse.networks.SequentialAig` it never assigns the register outputs at all, so
+every value downstream of one is meaningless.
+
+{py:func}`~aigverse.algorithms.simulate_sequential` runs the network over a number of clock cycles instead. Every
+register starts at its reset value, the combinational logic is evaluated once per cycle, the primary outputs are
+recorded, and the register inputs are latched into the register outputs for the next cycle.
+
+A design with no primary inputs runs off its reset state alone. A 4-bit linear-feedback shift register seeded with
+`0b0001` walks through all fifteen of its non-zero states before repeating:
+
+```{code-cell} ipython3
+from aigverse.algorithms import simulate_sequential
+from aigverse.networks import AigRegister, SequentialAig
+
+lfsr = SequentialAig()
+
+state = [lfsr.create_ro() for _ in range(4)]
+feedback = lfsr.create_xor(state[3], state[2])
+
+# Primary outputs go in before register inputs: both are combinational outputs of
+# the same network, and `po_at` / `ri_at` slice that one list by position.
+lfsr.create_po(state[3])
+
+lfsr.create_ri(feedback)
+for bit in range(3):
+    lfsr.create_ri(state[bit])
+
+# Seed the register chain with 0b0001
+for bit in range(4):
+    register = AigRegister()
+    register.init = 1 if bit == 0 else 0
+    lfsr.set_register(bit, register)
+
+result = simulate_sequential(lfsr, 15)
+
+print("output: ", "".join(str(int(cycle[0])) for cycle in result.outputs))
+print("cycles: ", result.num_cycles)
+print("reset:  ", result.reset_state)
+print("final:  ", result.final_state)
+```
+
+A full period brings the registers back to their seed, so `final_state` matches `reset_state`.
+
+The result carries two traces, both indexed by clock cycle first: `outputs[cycle][index]` is the value primary
+output `index` took in that cycle, and `states[cycle][index]` the value register `index` held while that cycle was
+evaluated. The state trace is one entry longer than the output trace, because simulating _n_ cycles crosses _n + 1_
+state boundaries:
+
+```{code-cell} ipython3
+for cycle, registers in enumerate(result.states):
+    print(f"  boundary {cycle:2d}: {''.join(str(int(bit)) for bit in registers)}")
+```
+
+Designs with primary inputs are driven by a stimulus, one assignment per cycle. Cycles past the end of it repeat
+the last assignment, so a single assignment holds for the whole run:
+
+```{code-cell} ipython3
+# A three-stage shift register: what goes in comes out three cycles later
+shift = SequentialAig()
+
+data = shift.create_pi()
+stages = [shift.create_ro() for _ in range(3)]
+
+shift.create_po(stages[2])
+
+shift.create_ri(data)
+shift.create_ri(stages[0])
+shift.create_ri(stages[1])
+
+for stage in range(3):
+    register = AigRegister()
+    register.init = 0
+    shift.set_register(stage, register)
+
+# A single pulse on the input, then silence
+pulse = simulate_sequential(shift, 6, [[True], [False]])
+
+print("output:", "".join(str(int(cycle[0])) for cycle in pulse.outputs))
+```
+
+A register may declare no reset value at all, which is what a fresh
+{py:class}`~aigverse.networks.AigRegister` carries and what an AIGER latch with a nondeterministic reset reads back
+as. Simulation needs a concrete value, so `undefined_reset_value` says which one it should use.
+
 ## Optimization
 
 AIG optimization aims to reduce the number of AND gates and inverters in a circuit while maintaining its logical

--- a/python/aigverse/algorithms.pyi
+++ b/python/aigverse/algorithms.pyi
@@ -1,5 +1,6 @@
 """Provides synthesis and optimization algorithms for logic network types."""
 
+from collections.abc import Sequence
 from typing import Literal
 
 import aigverse.networks
@@ -199,4 +200,71 @@ def simulate_nodes(ntk: aigverse.networks.Aig) -> dict[int, aigverse.utils.Truth
 
     Raises:
         MemoryError: If the truth tables cannot be allocated due to memory limits.
+    """
+
+class SequentialSimulationResult:
+    """Represents the outcome of simulating a sequential network over several clock cycles.
+
+    Both traces are indexed by clock cycle first: ``outputs[cycle][index]`` is the value primary
+    output ``index`` took in that cycle, and ``states[cycle][index]`` the value register ``index``
+    held while that cycle was evaluated.
+
+    ``states`` is one entry longer than ``outputs``, because simulating ``n`` cycles crosses
+    ``n + 1`` state boundaries. The first is the reset state the run started from and the last is
+    the state it ended in.
+    """
+
+    @property
+    def outputs(self) -> list[list[bool]]:
+        """Primary output values, one list per clock cycle."""
+
+    @property
+    def states(self) -> list[list[bool]]:
+        """Register values, one list per state boundary."""
+
+    @property
+    def num_cycles(self) -> int:
+        """Number of clock cycles simulated."""
+
+    @property
+    def reset_state(self) -> list[bool]:
+        """The state the registers were reset to."""
+
+    @property
+    def final_state(self) -> list[bool]:
+        """The state the registers held after the last cycle."""
+
+    def __len__(self) -> int: ...
+
+def simulate_sequential(
+    ntk: aigverse.networks.SequentialAig,
+    num_cycles: int,
+    stimulus: Sequence[Sequence[bool]] = [],
+    undefined_reset_value: bool = False,
+) -> SequentialSimulationResult:
+    """Simulates a sequential network over a number of clock cycles.
+
+    Every register starts at its reset value, the combinational logic is evaluated once per
+    cycle, the primary outputs are recorded, and the register inputs are latched into the
+    register outputs for the next cycle.
+
+    This is what distinguishes it from :func:`~aigverse.algorithms.simulate`, which evaluates
+    the combinational logic exactly once and has no notion of a register.
+
+    Args:
+        ntk: The sequential network to simulate.
+        num_cycles: Number of clock cycles to run.
+        stimulus: Primary input assignments, one list of ``ntk.num_pis`` values per clock cycle.
+            Cycles past the end of the stimulus repeat its last assignment, so a single
+            assignment holds for the whole run. Defaults to holding every primary input at
+            ``False``, which is all a design without primary inputs needs.
+        undefined_reset_value: Value a register starts at when its reset value is undefined,
+            which is what a register defaults to and what an AIGER latch with a
+            nondeterministic reset reads back as.
+
+    Returns:
+        The primary output values and the register values, per clock cycle.
+
+    Raises:
+        ValueError: If an assignment in ``stimulus`` does not have one value per primary input.
     """

--- a/src/aigverse/algorithms/CMakeLists.txt
+++ b/src/aigverse/algorithms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_aigverse_python_binding(
   refactoring.cpp
   resubstitution.cpp
   rewriting.cpp
+  sequential_simulation.cpp
   simulation.cpp
   MODULE_NAME
   algorithms

--- a/src/aigverse/algorithms/bindings.cpp
+++ b/src/aigverse/algorithms/bindings.cpp
@@ -9,6 +9,7 @@ void bind_resubstitution(nanobind::module_& m);
 void bind_rewriting(nanobind::module_& m);
 void bind_balancing(nanobind::module_& m);
 void bind_simulation(nanobind::module_& m);
+void bind_sequential_simulation(nanobind::module_& m);
 }  // namespace aigverse
 
 NB_MODULE(algorithms, m)
@@ -23,4 +24,5 @@ NB_MODULE(algorithms, m)
     aigverse::bind_rewriting(m);
     aigverse::bind_balancing(m);
     aigverse::bind_simulation(m);
+    aigverse::bind_sequential_simulation(m);
 }

--- a/src/aigverse/algorithms/sequential_simulation.cpp
+++ b/src/aigverse/algorithms/sequential_simulation.cpp
@@ -1,0 +1,132 @@
+//
+// Created by marcel on 21.08.26.
+//
+
+#include "aigverse/types.hpp"
+
+#include <fmt/format.h>
+#include <mockturtle/algorithms/simulation_sequential.hpp>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>  // NOLINT(misc-include-cleaner)
+#include <nanobind/stl/vector.h>  // NOLINT(misc-include-cleaner)
+
+#include <cstdint>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace aigverse
+{
+
+namespace detail
+{
+
+template <typename Ntk>
+void sequential_simulation(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
+{
+    namespace nb = nanobind;  // NOLINT(misc-unused-alias-decls)
+
+    using result_t = mockturtle::simulate_sequential_result<bool>;
+
+    nb::class_<result_t>(m, "SequentialSimulationResult",
+                         R"pb(Represents the outcome of simulating a sequential network over several clock cycles.
+
+Both traces are indexed by clock cycle first: ``outputs[cycle][index]`` is the value primary
+output ``index`` took in that cycle, and ``states[cycle][index]`` the value register ``index``
+held while that cycle was evaluated.
+
+``states`` is one entry longer than ``outputs``, because simulating ``n`` cycles crosses
+``n + 1`` state boundaries. The first is the reset state the run started from and the last is
+the state it ended in.)pb")
+        .def_ro("outputs", &result_t::outputs, R"pb(Primary output values, one list per clock cycle.)pb")
+        .def_ro("states", &result_t::states, R"pb(Register values, one list per state boundary.)pb")
+        .def_prop_ro(
+            "num_cycles", [](const result_t& self) { return self.num_cycles(); },
+            R"pb(Number of clock cycles simulated.)pb")
+        .def_prop_ro(
+            "reset_state", [](const result_t& self) { return self.reset_state(); },
+            R"pb(The state the registers were reset to.)pb")
+        .def_prop_ro(
+            "final_state", [](const result_t& self) { return self.final_state(); },
+            R"pb(The state the registers held after the last cycle.)pb")
+        .def("__len__", [](const result_t& self) { return self.outputs.size(); })
+        .def("__repr__",
+             [](const result_t& self)
+             {
+                 return fmt::format("SequentialSimulationResult(num_cycles={}, num_pos={}, num_registers={})",
+                                    self.num_cycles(), self.outputs.empty() ? 0UL : self.outputs.front().size(),
+                                    self.states.empty() ? 0UL : self.states.front().size());
+             });
+
+    m.def(
+        "simulate_sequential",
+        [](const Ntk& ntk, const uint32_t num_cycles, std::vector<std::vector<bool>> stimulus,
+           const bool undefined_reset_value) -> result_t
+        {
+            uint32_t cycle = 0;
+            for (const auto& assignment : stimulus)
+            {
+                if (assignment.size() != ntk.num_pis())
+                {
+                    throw std::invalid_argument(fmt::format(
+                        "stimulus for cycle {} assigns {} value(s), but the network has {} primary input(s)", cycle,
+                        assignment.size(), ntk.num_pis()));
+                }
+                ++cycle;
+            }
+
+            // `stimulus_simulator` needs at least one assignment and repeats its last one for
+            // the rest of the run, so holding every primary input low is a single all-false
+            // assignment rather than a special case.
+            if (stimulus.empty())
+            {
+                stimulus.emplace_back(ntk.num_pis(), false);
+            }
+
+            mockturtle::simulate_sequential_params ps{};
+            ps.undefined_reset_value = undefined_reset_value;
+
+            return mockturtle::simulate_sequential<bool>(ntk, num_cycles,
+                                                         mockturtle::stimulus_simulator{std::move(stimulus)}, ps);
+        },
+        nb::arg("ntk"), nb::arg("num_cycles"), nb::arg("stimulus") = std::vector<std::vector<bool>>{},
+        nb::arg("undefined_reset_value") = false,
+        R"pb(Simulates a sequential network over a number of clock cycles.
+
+Every register starts at its reset value, the combinational logic is evaluated once per
+cycle, the primary outputs are recorded, and the register inputs are latched into the
+register outputs for the next cycle.
+
+This is what distinguishes it from :func:`~aigverse.algorithms.simulate`, which evaluates
+the combinational logic exactly once and has no notion of a register.
+
+Args:
+    ntk: The sequential network to simulate.
+    num_cycles: Number of clock cycles to run.
+    stimulus: Primary input assignments, one list of ``ntk.num_pis`` values per clock cycle.
+        Cycles past the end of the stimulus repeat its last assignment, so a single
+        assignment holds for the whole run. Defaults to holding every primary input at
+        ``False``, which is all a design without primary inputs needs.
+    undefined_reset_value: Value a register starts at when its reset value is undefined,
+        which is what a register defaults to and what an AIGER latch with a
+        nondeterministic reset reads back as.
+
+Returns:
+    The primary output values and the register values, per clock cycle.
+
+Raises:
+    ValueError: If an assignment in ``stimulus`` does not have one value per primary input.)pb",
+        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
+}
+
+// Explicit instantiation for the sequential AIG
+template void sequential_simulation<aigverse::sequential_aig>(nanobind::module_& m);
+
+}  // namespace detail
+
+void bind_sequential_simulation(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
+{
+    detail::sequential_simulation<aigverse::sequential_aig>(m);
+}
+
+}  // namespace aigverse

--- a/test/algorithms/test_sequential_simulation.py
+++ b/test/algorithms/test_sequential_simulation.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import pytest
+
+from aigverse.algorithms import simulate_sequential
+from aigverse.networks import AigRegister, SequentialAig
+
+
+def lfsr(width: int = 4, seed: int = 1) -> SequentialAig:
+    """Builds a Fibonacci LFSR with taps on the top two bits.
+
+    It has no primary inputs at all, so it runs off its reset state alone, which
+    makes it a direct test of whether the reset values are honored.
+
+    Args:
+        width: Number of registers.
+        seed: Reset state, as an integer whose bit ``i`` is register ``i``'s reset.
+
+    Returns:
+        The sequential network.
+    """
+    ntk = SequentialAig()
+
+    state = [ntk.create_ro() for _ in range(width)]
+    feedback = ntk.create_xor(state[width - 1], state[width - 2])
+
+    # Primary outputs before register inputs: both are combinational outputs of
+    # the same network, and `po_at` / `ri_at` slice that one list by position.
+    ntk.create_po(state[width - 1])
+
+    ntk.create_ri(feedback)
+    for bit in range(width - 1):
+        ntk.create_ri(state[bit])
+
+    for bit in range(width):
+        register = AigRegister()
+        register.init = (seed >> bit) & 1
+        ntk.set_register(bit, register)
+
+    return ntk
+
+
+def shift_register(depth: int = 3) -> SequentialAig:
+    """Builds a shift register: the input appears at the output ``depth`` cycles later.
+
+    Args:
+        depth: Number of registers in the chain.
+
+    Returns:
+        The sequential network.
+    """
+    ntk = SequentialAig()
+
+    data = ntk.create_pi()
+    state = [ntk.create_ro() for _ in range(depth)]
+
+    ntk.create_po(state[depth - 1])
+
+    ntk.create_ri(data)
+    for stage in range(depth - 1):
+        ntk.create_ri(state[stage])
+
+    for stage in range(depth):
+        register = AigRegister()
+        register.init = 0
+        ntk.set_register(stage, register)
+
+    return ntk
+
+
+def bits(outputs: list[list[bool]]) -> str:
+    """Collects the single primary output of every cycle into a bit string.
+
+    Args:
+        outputs: The per-cycle output trace.
+
+    Returns:
+        One character per cycle.
+    """
+    return "".join(str(int(cycle[0])) for cycle in outputs)
+
+
+def test_lfsr_runs_from_its_reset_state() -> None:
+    result = simulate_sequential(lfsr(), 15)
+
+    assert result.num_cycles == 15
+    assert len(result) == 15
+    # a maximal-length sequence: 15 states before it comes back around
+    assert bits(result.outputs) == "000100110101111"
+
+
+def test_lfsr_returns_to_its_seed() -> None:
+    result = simulate_sequential(lfsr(), 30)
+
+    trace = bits(result.outputs)
+    assert trace[:15] == trace[15:]
+    assert result.final_state == result.reset_state
+
+
+def test_a_different_seed_shifts_the_sequence() -> None:
+    # seeding with the second state of the first LFSR must produce the same
+    # sequence one step ahead, which only holds if the reset values are used
+    from_one = bits(simulate_sequential(lfsr(seed=1), 15).outputs)
+    from_two = bits(simulate_sequential(lfsr(seed=2), 15).outputs)
+
+    assert from_one[1:] == from_two[:14]
+
+
+def test_the_state_trace_is_one_longer_than_the_output_trace() -> None:
+    # simulating n cycles crosses n + 1 state boundaries
+    result = simulate_sequential(lfsr(), 15)
+
+    assert len(result.states) == len(result.outputs) + 1
+    assert result.reset_state == result.states[0]
+    assert result.final_state == result.states[-1]
+    assert result.reset_state == [True, False, False, False]
+
+
+def test_every_lfsr_state_is_distinct_and_non_zero() -> None:
+    result = simulate_sequential(lfsr(), 15)
+
+    seen = [tuple(state) for state in result.states[:-1]]
+
+    assert all(any(state) for state in seen)
+    assert len(set(seen)) == len(seen)
+
+
+def test_simulating_no_cycles_still_reports_the_reset_state() -> None:
+    result = simulate_sequential(lfsr(), 0)
+
+    assert result.num_cycles == 0
+    assert result.outputs == []
+    assert len(result.states) == 1
+    assert result.reset_state == result.final_state == [True, False, False, False]
+
+
+def test_a_pulse_travels_through_a_shift_register() -> None:
+    # a single 1 on the input, then silence
+    result = simulate_sequential(shift_register(), 6, [[True], [False]])
+
+    assert bits(result.outputs) == "000100"
+
+
+def test_a_stimulus_shorter_than_the_run_holds_its_last_assignment() -> None:
+    result = simulate_sequential(shift_register(), 4, [[True]])
+
+    assert bits(result.outputs) == "0001"
+
+
+def test_without_a_stimulus_the_inputs_are_held_low() -> None:
+    result = simulate_sequential(shift_register(), 4)
+
+    assert bits(result.outputs) == "0000"
+
+
+def test_a_register_holds_what_the_previous_cycle_latched() -> None:
+    # one register, driven from the input and read out on the output: the output
+    # of a cycle is the state it started in
+    ntk = SequentialAig()
+    data = ntk.create_pi()
+    state = ntk.create_ro()
+    ntk.create_po(state)
+    ntk.create_ri(data)
+
+    register = AigRegister()
+    register.init = 0
+    ntk.set_register(0, register)
+
+    result = simulate_sequential(ntk, 3, [[True], [False], [True]])
+
+    assert bits(result.outputs) == "010"
+    for cycle in range(result.num_cycles):
+        assert result.states[cycle][0] == result.outputs[cycle][0]
+
+    # the last input latched but never read out
+    assert result.final_state == [True]
+
+
+@pytest.mark.parametrize(("undefined", "expected"), [(False, "000"), (True, "111")])
+def test_an_undefined_reset_follows_the_argument(*, undefined: bool, expected: str) -> None:
+    ntk = SequentialAig()
+    state = ntk.create_ro()
+    ntk.create_po(state)
+    ntk.create_ri(state)
+    ntk.set_register(0, AigRegister())  # a fresh descriptor has no reset value
+
+    assert ntk.register_at(0).init not in {0, 1}
+
+    result = simulate_sequential(ntk, 3, undefined_reset_value=undefined)
+
+    assert bits(result.outputs) == expected
+
+
+def test_a_stimulus_of_the_wrong_width_is_rejected() -> None:
+    ntk = shift_register()
+
+    with pytest.raises(ValueError, match="assigns 2 value"):
+        simulate_sequential(ntk, 3, [[True, False]])
+
+    with pytest.raises(ValueError, match="cycle 1"):
+        simulate_sequential(ntk, 3, [[True], []])
+
+
+def test_repr_names_the_shape_of_the_run() -> None:
+    result = simulate_sequential(lfsr(), 5)
+
+    assert repr(result) == "SequentialSimulationResult(num_cycles=5, num_pos=1, num_registers=4)"


### PR DESCRIPTION
## Why

`simulate` evaluates a network's combinational logic exactly once, so there was no way to ask what a sequential design actually *does* over time — how its registers evolve, or what its outputs emit cycle by cycle.

This came out of reviewing #406: to see the sequential ABC bridge working I had to hand-write a twenty-line simulator in a scratch notebook, because neither `aigverse` nor mockturtle had one. mockturtle has one now (marcelwa/mockturtle#13); this exposes it.

## What

```python
from aigverse.algorithms import simulate_sequential

result = simulate_sequential(lfsr, 15)

result.outputs[cycle][index]   # what primary output `index` emitted that cycle
result.states[cycle][index]    # what register `index` held while it was evaluated
result.num_cycles
result.reset_state             # where the run started
result.final_state             # where it ended up
```

A 4-bit LFSR seeded `0b0001` walks all fifteen of its non-zero states and returns to its seed, driven entirely by the reset values:

```
output:  000100110101111
reset:   [True, False, False, False]
final:   [True, False, False, False]
```

The result is a bound class rather than a list of lists, because the nesting says nothing about which index is the cycle and which the output — that is something a caller would otherwise have to learn from the docs and then remember.

The state trace is deliberately **one entry longer** than the output trace: simulating *n* cycles crosses *n + 1* state boundaries. That is also what lets a zero-cycle run report where the registers started rather than an empty result that cannot answer the question.

Designs with primary inputs take a stimulus, one assignment per cycle:

```python
# a single pulse on the input, then silence, through a 3-stage shift register
simulate_sequential(shift, 6, [[True], [False]])   # -> 000100
```

Cycles past the end of the stimulus repeat its last assignment, so one assignment holds for the whole run. Omitting it holds every primary input low, which is all a design without primary inputs needs. An assignment that does not have exactly one value per primary input is rejected naming the cycle that carries it, rather than read out of bounds:

```
ValueError: stimulus for cycle 1 assigns 2 value(s), but the network has 1 primary input(s)
```

`undefined_reset_value` covers the register that declares no reset value at all — what a fresh `AigRegister` carries, and what an AIGER latch with a nondeterministic reset reads back as.

## Tests

14 cases in `test/algorithms/test_sequential_simulation.py`: the LFSR's maximal-length sequence and its return to seed; a second seed producing the same sequence one step ahead (which only holds if the reset values are honored); every intermediate state distinct and non-zero; the fencepost between the two traces; a zero-cycle run; a pulse through a shift register; a stimulus shorter than the run; no stimulus at all; a register read out one cycle after it is written, where each cycle's output must equal the state it started in; both settings of `undefined_reset_value`; two shapes of malformed stimulus; and `repr`.

`nox -s tests-3.12` is green (410 passed, 80 skipped — the skips are the ABC suite with no binary on this machine), `nox -s lint` is clean, and `clang-tidy` reports nothing on the new binding.

## Notes

- Stubs regenerated; the docs gain a "Sequential Simulation" section whose cells execute at build time, including a state-trace dump that shows the LFSR visiting all fifteen states and boundary 15 landing back on boundary 0.
- The binding uses mockturtle's own `stimulus_simulator`. I had written a local copy first; deleting it in favour of the upstream one removed ten clang-tidy warnings along with it.
- Needs mockturtle at `b856d3e` for `stimulus_simulator`. That bump has since landed on main independently (#459), so it is no longer carried by this branch — it arrives via the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sequential simulation for clocked networks, including cycle-by-cycle outputs, register states, reset state, and final state.
  * Added support for primary-input stimulus sequences and configurable handling of undefined reset values.
  * Added validation for stimulus assignments and a structured simulation result with cycle information.

* **Documentation**
  * Added usage guidance and runnable examples for LFSRs and shift registers.

* **Tests**
  * Added coverage for reset behavior, state and output traces, stimuli, register latching, invalid inputs, and zero-cycle simulations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
