### PR TITLE
✨ Batch and parallel execution for the ABC bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,31 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+### Added
+
+- ✨ Add `run_many` to the `aigverse.abc` bridge, which runs one ABC script over many
+  networks at once, one process per network across all cores, and with
+  `return_exceptions=True` hands back each failure in its network's place instead of
+  losing the batch to the first bad design ([#467]) ([**@marcelwa**])
+
 ### Changed
 
+- ⚡️ Run `examples/abc_recipe_study.py`'s sweep as one batch per recipe rather than one
+  ABC call at a time, and give it a `--jobs` flag. Its 400 runs over the default design
+  set drop from 44 s to 11 s on sixteen cores, with identical measurements ([#467])
+  ([**@marcelwa**])
 - ⚡️ Release the GIL in the `generators` bindings, so random and structured
   network construction overlaps across threads instead of blocking every other
   worker ([#478]) ([**@marcelwa**])
 - ⚡️ Release the GIL in the `io` bindings, so reading and writing networks
   overlaps across threads instead of serializing against every other worker
   ([#477]) ([**@marcelwa**])
+
+### Fixed
+
+- 🐛 Resolve the ABC executable once per `run_script` call instead of twice. The second
+  lookup ran after ABC had already finished, purely to name the binary in an error, so a
+  binary that disappeared mid-run discarded a successful result ([#467]) ([**@marcelwa**])
 
 ## [0.1.5] - 2026-08-24
 
@@ -210,6 +227,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#010)._
 
 <!-- PR links -->
 
+[#467]: https://github.com/marcelwa/aigverse/pull/467
 [#478]: https://github.com/marcelwa/aigverse/pull/478
 [#477]: https://github.com/marcelwa/aigverse/pull/477
 [#463]: https://github.com/marcelwa/aigverse/pull/463

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,9 @@ releases may include breaking changes.
 
 - ⚡️ Run `examples/abc_recipe_study.py`'s sweep as one batch per recipe rather than one
   ABC call at a time, and give it a `--jobs` flag. Its 400 runs over the default design
-  set drop from 20 s to 8 s on sixteen cores, with every measurement unchanged. Its CSV
-  loses the `seconds` column, which a concurrent run cannot measure per item ([#467])
-  ([**@marcelwa**])
+  set drop from about 24 s to under 9 s on sixteen cores, with every measurement
+  unchanged. Its CSV loses the `seconds` column, which a concurrent run cannot measure
+  per item ([#467]) ([**@marcelwa**])
 - ⚡️ Release the GIL in the `generators` bindings, so random and structured
   network construction overlaps across threads instead of blocking every other
   worker ([#478]) ([**@marcelwa**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ releases may include breaking changes.
 
 - ⚡️ Run `examples/abc_recipe_study.py`'s sweep as one batch per recipe rather than one
   ABC call at a time, and give it a `--jobs` flag. Its 400 runs over the default design
-  set drop from 44 s to 11 s on sixteen cores, with identical measurements ([#467])
+  set drop from 20 s to 8 s on sixteen cores, with every measurement unchanged. Its CSV
+  loses the `seconds` column, which a concurrent run cannot measure per item ([#467])
   ([**@marcelwa**])
 - ⚡️ Release the GIL in the `generators` bindings, so random and structured
   network construction overlaps across threads instead of blocking every other
@@ -32,9 +33,10 @@ releases may include breaking changes.
 
 ### Fixed
 
-- 🐛 Resolve the ABC executable once per `run_script` call instead of twice. The second
-  lookup ran after ABC had already finished, purely to name the binary in an error, so a
-  binary that disappeared mid-run discarded a successful result ([#467]) ([**@marcelwa**])
+- 🐛 Look the ABC executable up on `PATH` once per `run_script` call instead of twice. The
+  second lookup ran after ABC had already finished, purely to name the binary in an error,
+  so a binary that disappeared mid-run discarded a successful result ([#467])
+  ([**@marcelwa**])
 
 ## [0.1.5] - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,18 +12,15 @@ releases may include breaking changes.
 
 ### Added
 
-- ✨ Add `run_many` to the `aigverse.abc` bridge, which runs one ABC script over many
-  networks at once, one process per network across all cores, and with
-  `return_exceptions=True` hands back each failure in its network's place instead of
-  losing the batch to the first bad design ([#467]) ([**@marcelwa**])
+- ✨ Add `run_many` to the `aigverse.abc` bridge, running one ABC script over many
+  networks in parallel and reporting each failure in place instead of losing the
+  batch to the first bad design ([#467]) ([**@marcelwa**])
 
 ### Changed
 
-- ⚡️ Run `examples/abc_recipe_study.py`'s sweep as one batch per recipe rather than one
-  ABC call at a time, and give it a `--jobs` flag. Its 400 runs over the default design
-  set drop from about 24 s to under 9 s on sixteen cores, with every measurement
-  unchanged. Its CSV loses the `seconds` column, which a concurrent run cannot measure
-  per item ([#467]) ([**@marcelwa**])
+- ⚡️ Run `examples/abc_recipe_study.py`'s sweep as one batch per recipe instead of one
+  ABC call at a time, with a new `--jobs` flag. Its CSV loses the `seconds` column,
+  which a concurrent run cannot measure per item ([#467]) ([**@marcelwa**])
 - ⚡️ Release the GIL in the `generators` bindings, so random and structured
   network construction overlaps across threads instead of blocking every other
   worker ([#478]) ([**@marcelwa**])
@@ -33,9 +30,9 @@ releases may include breaking changes.
 
 ### Fixed
 
-- 🐛 Look the ABC executable up on `PATH` once per `run_script` call instead of twice. The
-  second lookup ran after ABC had already finished, purely to name the binary in an error,
-  so a binary that disappeared mid-run discarded a successful result ([#467])
+- 🐛 Look the ABC executable up on `PATH` once per `run_script` call instead of twice.
+  The second lookup ran after ABC finished purely to name the binary in an error, so a
+  binary that disappeared mid-run discarded a successful result ([#467])
   ([**@marcelwa**])
 
 ## [0.1.5] - 2026-08-24

--- a/docs/abc.md
+++ b/docs/abc.md
@@ -238,9 +238,9 @@ every call already gets its own temporary directory, its own working directory a
 cores, and hands the results back in input order:
 
 ```{code-cell} ipython3
-from aigverse.generators import carry_lookahead_adder, ripple_carry_adder
+from aigverse.generators import carry_lookahead_adder
 
-designs = [ripple_carry_adder(8), carry_lookahead_adder(8), ripple_carry_adder(12)]
+designs = [carry_lookahead_adder(width) for width in (4, 8, 16)]
 optimized = abc.run_many(designs, abc.expand_script("resyn2"))
 
 for before, after in zip(designs, optimized):

--- a/docs/abc.md
+++ b/docs/abc.md
@@ -263,8 +263,8 @@ transfer.
 
 Expect a speedup below the number of cores. A batch is only as fast as its slowest network,
 and the AIGER transfer at each end of a run holds the GIL, so it is the ABC processes that
-overlap rather than the whole call. The recipe study below drops from 44 to 11 seconds on
-sixteen cores — a little under 4x for 400 runs.
+overlap rather than the whole call. The recipe study below drops from 20 to 8 seconds on
+sixteen cores — about 2.5x for its 400 runs.
 
 The wrappers take one network each, but every script they run is reachable as commands:
 {py:func}`~aigverse.abc.expand_script` hands out the canonical ones, and a command with
@@ -569,7 +569,7 @@ repository:
 
 ```console
 uv run examples/abc_recipe_study.py --quick   # four small designs, for a smoke test
-uv run examples/abc_recipe_study.py           # the default ten-design set, ~11 s on sixteen cores
+uv run examples/abc_recipe_study.py           # the default ten-design set, ~8 s on sixteen cores
 uv run examples/abc_recipe_study.py --all     # the whole EPFL suite, hyp and div included (slow)
 ```
 

--- a/docs/abc.md
+++ b/docs/abc.md
@@ -230,6 +230,46 @@ if abc.gia.cec(aig, optimized) is abc.CecStatus.EQUIVALENT:
     print("proven equivalent")
 ```
 
+## Running many networks at once
+
+Optimizing a corpus is the workload this bridge exists for, and the runs are independent:
+every call already gets its own temporary directory, its own working directory and its own
+`abc.history`. {py:func}`~aigverse.abc.run_many` runs one script over many networks on all
+cores, and hands the results back in input order:
+
+```{code-cell} ipython3
+from aigverse.generators import carry_lookahead_adder, ripple_carry_adder
+
+designs = [ripple_carry_adder(8), carry_lookahead_adder(8), ripple_carry_adder(12)]
+optimized = abc.run_many(designs, abc.expand_script("resyn2"))
+
+for before, after in zip(designs, optimized):
+    print(f"{before.num_gates:4d} -> {after.num_gates:4d} AND gates")
+```
+
+One script over many networks, so a cross product of recipes and designs is one call per
+recipe:
+
+```python
+for name, script in recipes.items():
+    rows[name] = abc.run_many(designs, script)
+```
+
+`jobs` caps how many ABC processes run at once and defaults to the number of CPUs available
+to the process. On large designs it is memory rather than CPU that limits it, since every
+worker holds a whole ABC in flight. `timeout` is a budget **per network**, not for the batch
+as a whole. {py:func}`~aigverse.abc.gia.run_many` is the same thing through the `&`-space
+transfer.
+
+Expect a speedup below the number of cores. A batch is only as fast as its slowest network,
+and the AIGER transfer at each end of a run holds the GIL, so it is the ABC processes that
+overlap rather than the whole call. The recipe study below drops from 44 to 11 seconds on
+sixteen cores — a little under 4x for 400 runs.
+
+The wrappers take one network each, but every script they run is reachable as commands:
+{py:func}`~aigverse.abc.expand_script` hands out the canonical ones, and a command with
+options — `abc.rewrite(aig, zero_cost=True)` — is `"rewrite -z"` written out.
+
 ## What ABC thinks of a network
 
 {py:func}`~aigverse.abc.stats` and {py:func}`~aigverse.abc.gia.stats` run ABC's
@@ -423,8 +463,9 @@ types in `aigverse` first.
 :::
 
 Each call starts an ABC process and transfers the network through temporary AIGER files,
-which costs roughly 20 ms of overhead per call — negligible for batch work, but worth
-keeping in mind in a tight optimization loop.
+which costs roughly 20 ms of overhead per call — negligible next to a real script, but worth
+keeping in mind in a tight optimization loop. Independent calls belong in
+[one batch](#running-many-networks-at-once) rather than a loop.
 
 ## When things go wrong
 
@@ -447,6 +488,21 @@ The hierarchy is small: {py:exc}`~aigverse.abc.AbcNotFoundError` when no usable 
 could be located, {py:exc}`~aigverse.abc.AbcTimeoutError` when ABC outlived its `timeout`,
 and {py:exc}`~aigverse.abc.AbcExecutionError` for everything else ABC did wrong. All three
 derive from {py:exc}`~aigverse.abc.AbcError`.
+
+A batch fails the same way by default, which loses the whole sweep to one bad design. Pass
+`return_exceptions=True` and each failure comes back in its network's place instead, still
+carrying the `output` that explains it:
+
+```{code-cell} ipython3
+results = abc.run_many(designs, "no_such_command", return_exceptions=True)
+
+for design, result in zip(designs, results):
+    verdict = "failed" if isinstance(result, abc.AbcError) else f"{result.num_gates} gates"
+    print(f"{design.num_gates:4d} AND gates -> {verdict}")
+```
+
+That covers ABC failures only. A network of the wrong type or a script with no commands in
+it is a fault in the call rather than a per-design failure, and is raised either way.
 
 Options are validated in Python before ABC is started, so a value ABC would reject comes
 back as a `ValueError` naming the keyword you wrote rather than as an ABC message:
@@ -485,8 +541,9 @@ balancing — `rewrite`, `refactor`, `resub` and `balance` — can be applied in
 orders, and every one of them is run on each design. Same transformations, the same
 number of them, different sequence: the order alone moves the final AND count by several
 percent, and the best order is not the same one twice. Each ordering goes to ABC as a
-single script through {py:func}`~aigverse.abc.run_script` rather than as one call per
-command, which is equivalent but avoids a process and an AIGER round-trip per step.
+single script rather than as one call per command, which is equivalent but avoids a process
+and an AIGER round-trip per step, and every design runs that ordering at the same time
+through {py:func}`~aigverse.abc.run_many`.
 
 **Do the two command families trade off?** The classic scripts are plotted against their
 `&`-space counterparts on the area–depth plane. On many designs the smallest and the
@@ -512,7 +569,7 @@ repository:
 
 ```console
 uv run examples/abc_recipe_study.py --quick   # four small designs, for a smoke test
-uv run examples/abc_recipe_study.py           # the default ten-design set, ~18 s of ABC time
+uv run examples/abc_recipe_study.py           # the default ten-design set, ~11 s on sixteen cores
 uv run examples/abc_recipe_study.py --all     # the whole EPFL suite, hyp and div included (slow)
 ```
 
@@ -522,10 +579,12 @@ uses something not yet released.
 
 `--rounds` sets how often each schedule is repeated — two by default, so an ordering
 spends eight commands against `resyn2`'s ten — `--benchmarks` takes an explicit list of
-designs, and `--output` / `--csv` redirect the figure and the tables.
+designs, `--jobs` caps how many ABC processes run at once, and `--output` / `--csv` redirect
+the figure and the tables.
 
 `--verify` equivalence-checks every single result with
-{py:func}`~aigverse.algorithms.equivalence_checking` under a conflict limit, and aborts
+{py:func}`~aigverse.algorithms.equivalence_checking` under a conflict limit, which makes the
+study SAT-bound and hides most of the parallel speedup. It aborts
 the study if any optimization turns out not to be equivalence-preserving: that would be a
 bug in ABC or in the bridge, and every number the study prints rests on it not happening.
 A check that exhausts its conflict budget is reported as undecided rather than counted as

--- a/docs/abc.md
+++ b/docs/abc.md
@@ -261,10 +261,10 @@ worker holds a whole ABC in flight. `timeout` is a budget **per network**, not f
 as a whole. {py:func}`~aigverse.abc.gia.run_many` is the same thing through the `&`-space
 transfer.
 
-Expect a speedup below the number of cores. A batch is only as fast as its slowest network,
-and the AIGER transfer at each end of a run holds the GIL, so it is the ABC processes that
-overlap rather than the whole call. The recipe study below drops from 20 to 8 seconds on
-sixteen cores — about 2.5x for its 400 runs.
+Expect a speedup below the number of cores, because a batch is only as fast as its slowest
+network. The AIGER transfer bracketing each run is not the limit: it is under 2% of a
+`run_script` call on designs of every size, and it releases the GIL. The recipe study below
+drops from about 24 to under 9 seconds on sixteen cores — roughly 2.8x for its 400 runs.
 
 The wrappers take one network each, but every script they run is reachable as commands:
 {py:func}`~aigverse.abc.expand_script` hands out the canonical ones, and a command with

--- a/docs/abc.md
+++ b/docs/abc.md
@@ -569,7 +569,7 @@ repository:
 
 ```console
 uv run examples/abc_recipe_study.py --quick   # four small designs, for a smoke test
-uv run examples/abc_recipe_study.py           # the default ten-design set, ~8 s on sixteen cores
+uv run examples/abc_recipe_study.py           # the default ten-design set
 uv run examples/abc_recipe_study.py --all     # the whole EPFL suite, hyp and div included (slow)
 ```
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,6 +89,8 @@ nitpick_ignore = [
     # `gia.stats` returns the `AbcStats` documented at `aigverse.abc.AbcStats`,
     # but autoapi stringifies the annotation to the defining private module.
     ("py:class", "aigverse.abc._stats.AbcStats"),
+    # the same for `run_many`'s `AbcError`, documented at `aigverse.abc.AbcError`.
+    ("py:class", "aigverse.abc._errors.AbcError"),
 ]
 
 # -- Options for {MyST}NB ----------------------------------------------------

--- a/examples/abc_recipe_study.py
+++ b/examples/abc_recipe_study.py
@@ -38,9 +38,11 @@ input shape with achieved area reduction.
 Benchmarks are fetched and cached by ``aigverse.benchmarks``, so nothing needs to
 be downloaded by hand.
 
-Every recipe goes to ABC as one parallel batch over the whole design set through
-``aigverse.abc.run_many``, so the study runs on every core rather than one.
-``--verify`` makes it SAT-bound instead, which hides most of that.
+Every recipe goes to ABC as one batch over the whole design set through
+``aigverse.abc.run_many``, which overlaps the designs rather than running them one
+after another. How many overlap is ``--jobs``, one per core by default and never
+more than there are designs. ``--verify`` makes the study SAT-bound instead, which
+hides most of what that buys.
 
 Usage:
     ./abc_recipe_study.py                    # default benchmark subset
@@ -311,10 +313,10 @@ def run_batch(
 ) -> list[Benchmark]:
     """Apply one recipe to every benchmark at once and record what it did.
 
-    The whole design set goes to ABC as a single parallel batch, so the recipe
-    costs one round of ABC time rather than one per design. Failures come back in
-    place of their result, so a design ABC chokes on does not cost the sweep the
-    rest of the row.
+    The whole design set goes to ABC as a single batch, so the recipe costs roughly
+    what its slowest design costs rather than the sum over all of them. Failures come
+    back in place of their result, so a design ABC chokes on does not cost the sweep
+    the rest of the row.
 
     Args:
         benchmarks: The benchmarks to optimize.

--- a/examples/abc_recipe_study.py
+++ b/examples/abc_recipe_study.py
@@ -38,11 +38,16 @@ input shape with achieved area reduction.
 Benchmarks are fetched and cached by ``aigverse.benchmarks``, so nothing needs to
 be downloaded by hand.
 
+Every recipe goes to ABC as one parallel batch over the whole design set through
+``aigverse.abc.run_many``, so the study runs on every core rather than one.
+``--verify`` makes it SAT-bound instead, which hides most of that.
+
 Usage:
     ./abc_recipe_study.py                    # default benchmark subset
     ./abc_recipe_study.py --quick            # fewest benchmarks, for a smoke test
     ./abc_recipe_study.py --all              # the whole EPFL suite (slow)
     ./abc_recipe_study.py --benchmarks adder bar ctrl
+    ./abc_recipe_study.py --jobs 4           # cap the ABC processes run at once
     ./abc_recipe_study.py --verify           # equivalence-check every result
 
 `aigverse` does not ship ABC. Install one and put it on ``PATH``, or point
@@ -78,7 +83,7 @@ mpl.use("Agg")
 from matplotlib import pyplot as plt
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Mapping, Sequence
+    from collections.abc import Iterable, Mapping, Sequence
 
     from matplotlib.axes import Axes
 
@@ -131,7 +136,8 @@ CONFLICT_LIMIT: Final = 100_000
 #: commands they issue. `abc.balance`, `abc.rewrite`, `abc.refactor` and `abc.resub`
 #: are the same commands with default options, but calling them one at a time costs
 #: one ABC process and one AIGER round-trip *each*; handing the whole schedule to
-#: `abc.run_script` runs it in a single process instead.
+#: ABC runs it in a single process instead. One schedule then goes out across every
+#: design at once through `abc.run_many`.
 ATOMS: Mapping[str, str] = MappingProxyType({
     "b": "balance",
     "rw": "rewrite",
@@ -140,29 +146,31 @@ ATOMS: Mapping[str, str] = MappingProxyType({
 })
 
 #: The canonical `abc.rc` scripts, plus ABC's own `orchestrate`, for reference
-#: against the brute-forced orders.
-CLASSIC_SCRIPTS: Mapping[str, Callable[[Aig], Aig]] = MappingProxyType({
-    "resyn": abc.resyn,
-    "resyn2": abc.resyn2,
-    "resyn3": abc.resyn3,
-    "compress": abc.compress,
-    "compress2": abc.compress2,
-    "resyn2rs": abc.resyn2rs,
-    "compress2rs": abc.compress2rs,
-    "dc2": abc.dc2,
-    "orchestrate": abc.orchestrate,
+#: against the brute-forced orders. Held as the commands they issue rather than as
+#: the `abc.resyn2`-style wrappers, so a whole design set goes to `abc.run_many` in
+#: one call; at default options every one of those wrappers issues exactly this.
+CLASSIC_SCRIPTS: Mapping[str, tuple[str, ...]] = MappingProxyType({
+    "resyn": abc.expand_script("resyn"),
+    "resyn2": abc.expand_script("resyn2"),
+    "resyn3": abc.expand_script("resyn3"),
+    "compress": abc.expand_script("compress"),
+    "compress2": abc.expand_script("compress2"),
+    "resyn2rs": abc.expand_script("resyn2rs"),
+    "compress2rs": abc.expand_script("compress2rs"),
+    "dc2": abc.expand_script("dc2"),
+    "orchestrate": ("orchestrate",),
 })
 
-#: The &-space counterparts. `gia.fraig` is SAT sweeping rather than restructuring,
-#: and is included because it removes redundancy the others structurally cannot see.
-GIA_SCRIPTS: Mapping[str, Callable[[Aig], Aig]] = MappingProxyType({
-    "&b": abc.gia.balance,
-    "&resub": abc.gia.resub,
-    "&dc2": abc.gia.dc2,
-    "&syn2": abc.gia.syn2,
-    "&syn3": abc.gia.syn3,
-    "&syn4": abc.gia.syn4,
-    "&fraig": abc.gia.fraig,
+#: The &-space counterparts. `&fraig` is SAT sweeping rather than restructuring, and
+#: is included because it removes redundancy the others structurally cannot see.
+GIA_SCRIPTS: Mapping[str, tuple[str, ...]] = MappingProxyType({
+    "&b": ("&b",),
+    "&resub": ("&resub",),
+    "&dc2": ("&dc2",),
+    "&syn2": ("&syn2",),
+    "&syn3": ("&syn3",),
+    "&syn4": ("&syn4",),
+    "&fraig": ("&fraig",),
 })
 
 
@@ -176,7 +184,6 @@ class Result:
     family: str
     gates: int
     levels: int
-    seconds: float
     base_gates: int
     base_levels: int
     #: One of "unchecked", "equivalent" or "undecided". A plain `bool | None`
@@ -291,39 +298,75 @@ def measure(aig: Aig) -> tuple[int, int]:
     return aig.num_gates, DepthAig(aig).num_levels
 
 
-def run_recipe(
+def run_batch(
+    benchmarks: list[Benchmark],
+    experiment: str,
+    recipe: str,
+    family: str,
+    commands: tuple[str, ...],
+    *,
+    gia: bool,
+    jobs: int | None,
+    verify: bool,
+) -> int:
+    """Apply one recipe to every benchmark at once and record what it did.
+
+    The whole design set goes to ABC as a single parallel batch, so the recipe
+    costs one round of ABC time rather than one per design. Failures come back in
+    place of their result, so a design ABC chokes on does not cost the sweep the
+    rest of the row.
+
+    Args:
+        benchmarks: The benchmarks to optimize.
+        experiment: Either :data:`ORDER` or :data:`FAMILY`.
+        recipe: Human-readable name of the recipe.
+        family: Grouping label used when plotting.
+        commands: The ABC commands the recipe issues.
+        gia: Whether the commands are `&`-space ones.
+        jobs: How many ABC processes to run at once, or None for one per core.
+        verify: Whether to equivalence-check every result.
+
+    Returns:
+        The benchmarks ABC failed on, which is empty in the normal case.
+    """
+    run = abc.gia.run_many if gia else abc.run_many
+    optimized = run([bench.aig for bench in benchmarks], commands, jobs=jobs, return_exceptions=True)
+
+    failed: list[Benchmark] = []
+    for bench, result in zip(benchmarks, optimized, strict=True):
+        if isinstance(result, abc.AbcError):
+            print(f"    ! {recipe} failed on {bench.name}: {result}")
+            failed.append(bench)
+            continue
+        bench.results.append(record(bench, experiment, recipe, family, result, verify=verify))
+    return failed
+
+
+def record(
     bench: Benchmark,
     experiment: str,
     recipe: str,
     family: str,
-    apply: Callable[[Aig], Aig],
+    optimized: Aig,
     *,
     verify: bool,
-) -> Result | None:
-    """Apply one recipe to one benchmark and record what it did.
+) -> Result:
+    """Measure one optimized network and turn it into a row.
 
     Args:
-        bench: The benchmark to optimize.
+        bench: The benchmark the result came from.
         experiment: Either :data:`ORDER` or :data:`FAMILY`.
         recipe: Human-readable name of the recipe.
         family: Grouping label used when plotting.
-        apply: Callable performing the optimization.
+        optimized: What ABC produced.
         verify: Whether to equivalence-check the result.
 
     Returns:
-        The measurement, or None if ABC failed on this input.
+        The measurement.
 
     Raises:
         SystemExit: If the optimization changed the function of the network.
     """
-    started = time.perf_counter()
-    try:
-        optimized = apply(bench.aig)
-    except abc.AbcError as exc:
-        print(f"    ! {recipe} failed on {bench.name}: {exc}")
-        return None
-    elapsed = time.perf_counter() - started
-
     gates, levels = measure(optimized)
     equivalence = check(bench, optimized, recipe) if verify else "unchecked"
     if equivalence == "different":
@@ -339,7 +382,6 @@ def run_recipe(
         family=family,
         gates=gates,
         levels=levels,
-        seconds=elapsed,
         base_gates=bench.gates,
         base_levels=bench.levels,
         equivalence=equivalence,
@@ -372,8 +414,8 @@ def check(bench: Benchmark, optimized: Aig, recipe: str) -> str:
     return "equivalent"
 
 
-def apply_sequence(order: Sequence[str], rounds: int) -> Callable[[Aig], Aig]:
-    """Build a callable applying a sequence of atomic commands repeatedly.
+def commands_for(order: Sequence[str], rounds: int) -> tuple[str, ...]:
+    """Expand a schedule of atomic transformations into ABC commands.
 
     The whole schedule goes to ABC as one script, so it costs a single process and
     a single AIGER round-trip no matter how long it is.
@@ -383,10 +425,9 @@ def apply_sequence(order: Sequence[str], rounds: int) -> Callable[[Aig], Aig]:
         rounds: How often to repeat the whole sequence.
 
     Returns:
-        A callable taking and returning a network.
+        The commands, in the order ABC runs them.
     """
-    commands = [ATOMS[key] for key in order] * rounds
-    return lambda aig: abc.run_script(aig, commands)
+    return tuple(ATOMS[key] for key in order) * rounds
 
 
 # --------------------------------------------------------------------------------------
@@ -394,50 +435,62 @@ def apply_sequence(order: Sequence[str], rounds: int) -> Callable[[Aig], Aig]:
 # --------------------------------------------------------------------------------------
 
 
-def experiment_order(benchmarks: list[Benchmark], rounds: int, *, verify: bool) -> None:
+def experiment_order(benchmarks: list[Benchmark], rounds: int, *, jobs: int | None, verify: bool) -> None:
     """Run every ordering of the four atomic transformations.
+
+    One ordering at a time, across every design at once: the designs are what the
+    batch parallelizes over, and keeping the orders sequential keeps the progress
+    line meaningful.
 
     Args:
         benchmarks: The benchmarks to run on.
         rounds: How often each schedule repeats.
+        jobs: How many ABC processes to run at once, or None for one per core.
         verify: Whether to equivalence-check every result.
     """
     orders = list(itertools.permutations(ATOMS))
     print(f"\n[1/2] schedule sensitivity: {len(orders)} orders x {rounds} rounds ({len(ATOMS) * rounds} commands)")
 
-    for bench in benchmarks:
-        print(f"  {bench.name} ({bench.gates} gates, {bench.levels} levels)")
-        for order in orders:
-            result = run_recipe(
-                bench,
-                ORDER,
-                "; ".join(order),
-                "permutation",
-                apply_sequence(order, rounds),
-                verify=verify,
-            )
-            if result is None:
-                bench.order_complete = False
-                continue
-            bench.results.append(result)
+    for order in orders:
+        recipe = "; ".join(order)
+        failed = run_batch(
+            benchmarks,
+            ORDER,
+            recipe,
+            "permutation",
+            commands_for(order, rounds),
+            gia=False,
+            jobs=jobs,
+            verify=verify,
+        )
+        print(f"  {recipe:<20} {len(benchmarks) - len(failed)}/{len(benchmarks)} designs")
+        for bench in failed:
+            bench.order_complete = False
 
 
-def experiment_families(benchmarks: list[Benchmark], *, verify: bool) -> None:
+def experiment_families(benchmarks: list[Benchmark], *, jobs: int | None, verify: bool) -> None:
     """Run the canonical classic scripts and their `&`-space counterparts.
 
     Args:
         benchmarks: The benchmarks to run on.
+        jobs: How many ABC processes to run at once, or None for one per core.
         verify: Whether to equivalence-check every result.
     """
     print(f"\n[2/2] family comparison: {len(CLASSIC_SCRIPTS)} classic + {len(GIA_SCRIPTS)} &-space scripts")
 
-    for bench in benchmarks:
-        print(f"  {bench.name}")
-        for family, scripts in ((CLASSIC, CLASSIC_SCRIPTS), (GIA, GIA_SCRIPTS)):
-            for name, fn in scripts.items():
-                result = run_recipe(bench, FAMILY, name, family, fn, verify=verify)
-                if result is not None:
-                    bench.results.append(result)
+    for family, scripts in ((CLASSIC, CLASSIC_SCRIPTS), (GIA, GIA_SCRIPTS)):
+        for name, commands in scripts.items():
+            failed = run_batch(
+                benchmarks,
+                FAMILY,
+                name,
+                family,
+                commands,
+                gia=family == GIA,
+                jobs=jobs,
+                verify=verify,
+            )
+            print(f"  {name:<20} {len(benchmarks) - len(failed)}/{len(benchmarks)} designs")
 
 
 # --------------------------------------------------------------------------------------
@@ -946,7 +999,6 @@ def write_csv(benchmarks: Iterable[Benchmark], path: Path) -> None:
         "family",
         "gates",
         "levels",
-        "seconds",
         "base_gates",
         "base_levels",
         "equivalence",
@@ -1009,6 +1061,7 @@ def parse_args() -> argparse.Namespace:
     group.add_argument("--benchmarks", nargs="+", metavar="NAME", help="explicit benchmark list")
     parser.add_argument("--rounds", type=positive, default=2, help="repetitions of each schedule (default: 2)")
     parser.add_argument("--verify", action="store_true", help="equivalence-check every result (slow)")
+    parser.add_argument("--jobs", type=positive, help="ABC processes to run at once (default: one per core)")
     parser.add_argument(
         "--cache-dir",
         type=Path,
@@ -1059,9 +1112,14 @@ def main() -> int:
         benchmarks.append(Benchmark(name=name, aig=aig, gates=gates, levels=levels))
 
     started = time.perf_counter()
-    experiment_order(benchmarks, args.rounds, verify=args.verify)
-    experiment_families(benchmarks, verify=args.verify)
-    print(f"\nanalysis  ({time.perf_counter() - started:.1f}s of ABC time)")
+    experiment_order(benchmarks, args.rounds, jobs=args.jobs, verify=args.verify)
+    experiment_families(benchmarks, jobs=args.jobs, verify=args.verify)
+    elapsed = time.perf_counter() - started
+
+    # Wall clock rather than summed ABC time: the runs overlap now, so the two are
+    # no longer the same number and only this one bounds how long the study takes.
+    runs = len(benchmarks) * (math.factorial(len(ATOMS)) + len(CLASSIC_SCRIPTS) + len(GIA_SCRIPTS))
+    print(f"\nanalysis  ({runs} ABC runs in {elapsed:.1f}s of wall clock)")
 
     headline = report(benchmarks, args.rounds)
     write_csv(benchmarks, args.csv)

--- a/examples/abc_recipe_study.py
+++ b/examples/abc_recipe_study.py
@@ -308,7 +308,7 @@ def run_batch(
     gia: bool,
     jobs: int | None,
     verify: bool,
-) -> int:
+) -> list[Benchmark]:
     """Apply one recipe to every benchmark at once and record what it did.
 
     The whole design set goes to ABC as a single parallel batch, so the recipe

--- a/python/aigverse/abc/__init__.py
+++ b/python/aigverse/abc/__init__.py
@@ -25,6 +25,7 @@ Example:
 from __future__ import annotations
 
 from . import gia
+from ._batch import run_many
 from ._binary import (
     ABC_ENV_VAR,
     ABC_RC_ENV_VAR,
@@ -84,6 +85,7 @@ __all__ = [
     "resyn3",
     "rewrite",
     "run_commands",
+    "run_many",
     "run_script",
     "set_abc_binary",
     "set_abc_rc",

--- a/python/aigverse/abc/_batch.py
+++ b/python/aigverse/abc/_batch.py
@@ -1,0 +1,321 @@
+"""Parallel execution of one ABC script over many networks."""
+
+from __future__ import annotations
+
+import os
+import sys
+from concurrent.futures import ALL_COMPLETED, FIRST_EXCEPTION, ThreadPoolExecutor, wait
+from typing import TYPE_CHECKING, overload
+
+from ._errors import AbcError
+from ._runner import AigT, check_gia_supported, check_supported, join_commands, resolve_binary, run_script
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Sequence
+    from concurrent.futures import Future
+    from typing import Literal
+
+__all__ = ["run_many"]
+
+
+def _default_jobs() -> int:
+    """Reports how many ABC processes to keep running at once by default.
+
+    Mirrors what :func:`os.process_cpu_count` does internally, so the interpreters
+    that predate it get the same answer rather than an approximation.
+
+    Returns:
+        The number of CPUs available to this process, at least one.
+    """
+    if sys.version_info >= (3, 13):
+        return os.process_cpu_count() or 1
+    # Only Linux has it, and it is the one that honours CPU affinity -- a batch
+    # pinned with `taskset` must not spawn a process per core of the whole machine.
+    if hasattr(os, "sched_getaffinity"):
+        return len(os.sched_getaffinity(0))
+    return os.cpu_count() or 1
+
+
+def _attribute(exc: BaseException, index: int) -> None:
+    """Records which input a failure belongs to on the exception itself.
+
+    Args:
+        exc: The failure raised for one network.
+        index: Position of that network in the batch.
+    """
+    # `add_note` is 3.11+, and the package still supports 3.10. The traceback
+    # machinery renders notes on its own, which an attribute would not.
+    if sys.version_info >= (3, 11):
+        exc.add_note(f"raised by run_many() for the network at index {index}")
+
+
+@overload
+def run_many(
+    networks: Iterable[AigT],
+    commands: str | Sequence[str],
+    *,
+    jobs: int | None = ...,
+    timeout: float | None = ...,
+    use_init_file: bool = ...,
+    gia: bool = ...,
+    binary: str | os.PathLike[str] | None = ...,
+    return_exceptions: Literal[False] = False,
+) -> list[AigT]: ...
+
+
+@overload
+def run_many(
+    networks: Iterable[AigT],
+    commands: str | Sequence[str],
+    *,
+    jobs: int | None = ...,
+    timeout: float | None = ...,
+    use_init_file: bool = ...,
+    gia: bool = ...,
+    binary: str | os.PathLike[str] | None = ...,
+    return_exceptions: Literal[True],
+) -> list[AigT | AbcError]: ...
+
+
+def run_many(
+    networks: Iterable[AigT],
+    commands: str | Sequence[str],
+    *,
+    jobs: int | None = None,
+    timeout: float | None = None,
+    use_init_file: bool = False,
+    gia: bool = False,
+    binary: str | os.PathLike[str] | None = None,
+    return_exceptions: bool = False,
+) -> list[AigT] | list[AigT | AbcError]:
+    """Runs one ABC script over many networks, in parallel.
+
+    The same script is applied to every network, each in its own ABC process. The
+    bridge already isolates a call completely -- its own temporary directory, its
+    own working directory, its own ``abc.history`` -- so the runs simply overlap.
+    A cross product of scripts and networks is one call per script::
+
+        for name, script in recipes.items():
+            rows[name] = abc.run_many(designs, script)
+
+    Results come back in input order, never completion order, so ``zip(networks,
+    results)`` is always valid.
+
+    Expect a speedup below the number of cores. A batch is as slow as its slowest
+    network, and the AIGER transfer at each end of a run holds the GIL, so only the
+    ABC processes themselves overlap.
+
+    Args:
+        networks: The networks to optimize. Consumed in full before any work starts.
+        commands: A single ``;``-separated ABC command string, or a sequence of
+            individual commands. The same script runs on every network. The
+            canonical scripts are reachable through
+            :func:`~aigverse.abc.expand_script`.
+        jobs: How many ABC processes to keep running at once. ``None`` (default)
+            uses the number of CPUs available to this process, capped at the number
+            of networks; ``1`` runs inline without a thread pool. On large designs
+            memory, not CPU, is what limits this. A CPU *quota* -- ``docker
+            --cpus=2`` -- is not visible here, so set ``jobs`` explicitly under one.
+        timeout: Seconds to wait for ABC to terminate, **per network** rather than
+            for the batch as a whole, or ``None`` for no limit.
+        use_init_file: If ``False`` (default), ABC is invoked with ``-s`` so that
+            no ``abc.rc`` is read and results do not depend on the local install.
+        gia: If ``True``, transfer each network through ``&read``/``&write`` so it
+            lands in ABC9's GIA store, as :func:`~aigverse.abc.run_script` does.
+        binary: Overrides the resolved ABC executable for this call only. It is
+            resolved once for the whole batch.
+        return_exceptions: If ``False`` (default), the first failure aborts the
+            batch and is raised, as :func:`~aigverse.abc.run_script` would. If
+            ``True``, each failing network yields its :exc:`AbcError` in place of a
+            result, so one bad design does not lose a whole sweep. Only an
+            ``AbcError`` is captured: a ``TypeError`` from an unsupported network
+            type, a ``ValueError`` from an invalid script, and anything else that
+            goes wrong are raised either way, because those are faults in the call
+            rather than per-item ABC failures.
+
+    Returns:
+        The optimized networks, in input order, each of the same type as its input
+        -- with :exc:`AbcError` instances in place of the failures when
+        ``return_exceptions`` is set.
+
+    Raises:
+        TypeError: If any element of ``networks`` is not an ``Aig``.
+        ValueError: If ``jobs`` is below 1, if no command was given, or if ``gia``
+            is set and a network has a register whose reset value is undefined.
+        AbcNotFoundError: If no ABC executable could be located.
+        AbcTimeoutError: If ABC did not terminate within ``timeout`` seconds for
+            some network and ``return_exceptions`` is not set.
+        AbcExecutionError: If ABC reported an error for some network and
+            ``return_exceptions`` is not set.
+
+    Note:
+        Which failure is reported when several networks fail is unspecified; use
+        ``return_exceptions=True`` to see all of them. There is no ``verbose``:
+        nothing inside an ABC transcript says which network produced it, so a
+        failure's ``output`` -- reachable through ``return_exceptions`` -- is what
+        carries that.
+
+    Note:
+        Interrupting a batch drops the networks that have not started yet, but does
+        not kill the ABC processes already running; ``timeout`` is what bounds those.
+    """
+    items = list(networks)
+
+    # Everything the caller got wrong is reported before a single process starts,
+    # so a typo in the script is not discovered one design into a long sweep.
+    if jobs is not None and jobs < 1:
+        msg = f"jobs must be at least 1, got {jobs}"
+        raise ValueError(msg)
+    command = join_commands(commands)
+    for ntk in items:
+        check_supported(ntk)
+        if gia:
+            check_gia_supported(ntk)
+
+    # Before resolving the binary, so an empty batch is a no-op on a machine
+    # without ABC rather than an AbcNotFoundError.
+    if not items:
+        return []
+
+    executable = resolve_binary(binary)
+
+    def optimize(ntk: AigT) -> AigT:
+        """Runs the batch's script on one network.
+
+        Args:
+            ntk: The network to optimize.
+
+        Returns:
+            The optimized network.
+        """
+        return run_script(
+            ntk,
+            command,
+            timeout=timeout,
+            use_init_file=use_init_file,
+            gia=gia,
+            binary=executable,
+        )
+
+    workers = min(jobs if jobs is not None else _default_jobs(), len(items))
+    if workers == 1:
+        return _run_serially(items, optimize, return_exceptions=return_exceptions)
+
+    # `max_workers=None` would be min(32, cpu_count + 4); that +4 is tuned for
+    # I/O-bound work, while every worker here occupies a core with an ABC process.
+    pool = ThreadPoolExecutor(max_workers=workers, thread_name_prefix="aigverse-abc")
+    try:
+        futures = [pool.submit(optimize, ntk) for ntk in items]
+        wait(futures, return_when=ALL_COMPLETED if return_exceptions else FIRST_EXCEPTION)
+    finally:
+        # Only drops what has not started. `run_commands` keeps no handle on the
+        # process it spawned, so an ABC already running is waited out, not killed.
+        pool.shutdown(cancel_futures=True)
+
+    if return_exceptions:
+        return _collect(futures)
+    return _collect_or_raise(futures)
+
+
+def _run_serially(
+    items: list[AigT],
+    optimize: Callable[[AigT], AigT],
+    *,
+    return_exceptions: bool,
+) -> list[AigT] | list[AigT | AbcError]:
+    """Runs a batch inline, without a thread pool.
+
+    Keeps ``jobs=1`` a genuine drop-in for a serial loop: no worker frame in the
+    traceback, and an interrupt behaves exactly as it does for a single call.
+
+    Args:
+        items: The networks to optimize.
+        optimize: Runs the batch's script on one network.
+        return_exceptions: Whether a failure is returned in place rather than raised.
+
+    Returns:
+        The optimized networks, in input order.
+
+    Raises:
+        AbcError: If ABC failed on some network and ``return_exceptions`` is not set.
+    """
+    return [_attempt(optimize, ntk, index, return_exceptions=return_exceptions) for index, ntk in enumerate(items)]
+
+
+def _attempt(
+    optimize: Callable[[AigT], AigT],
+    ntk: AigT,
+    index: int,
+    *,
+    return_exceptions: bool,
+) -> AigT | AbcError:
+    """Runs the batch's script on one network, inline.
+
+    Args:
+        optimize: Runs the batch's script on one network.
+        ntk: The network to optimize.
+        index: Position of that network in the batch.
+        return_exceptions: Whether a failure is returned rather than raised.
+
+    Returns:
+        The optimized network, or the :exc:`AbcError` it failed with when
+        ``return_exceptions`` is set.
+
+    Raises:
+        AbcError: If ABC failed and ``return_exceptions`` is not set.
+    """
+    try:
+        return optimize(ntk)
+    except AbcError as exc:
+        if not return_exceptions:
+            _attribute(exc, index)
+            raise
+        return exc
+
+
+def _collect(futures: list[Future[AigT]]) -> list[AigT | AbcError]:
+    """Gathers a completed batch, keeping each ABC failure in place.
+
+    Args:
+        futures: The batch's futures, in input order.
+
+    Returns:
+        The optimized networks, with an :exc:`AbcError` in place of each failure.
+
+    Raises:
+        BaseException: Whatever a worker raised that was not an ``AbcError``, since
+            a disk filling up is not a per-network ABC failure.
+    """
+    results: list[AigT | AbcError] = []
+    for future in futures:
+        exc = future.exception()
+        if exc is None:
+            results.append(future.result())
+        elif isinstance(exc, AbcError):
+            results.append(exc)
+        else:
+            raise exc
+    return results
+
+
+def _collect_or_raise(futures: list[Future[AigT]]) -> list[AigT]:
+    """Gathers a completed batch, raising the lowest-indexed failure it holds.
+
+    Args:
+        futures: The batch's futures, in input order.
+
+    Returns:
+        The optimized networks, in input order.
+
+    Raises:
+        BaseException: Whatever the lowest-indexed failed network raised.
+    """
+    for index, future in enumerate(futures):
+        # Cancelled means the batch was aborted before this network started.
+        if future.cancelled():
+            continue
+        exc = future.exception()
+        if exc is not None:
+            _attribute(exc, index)
+            raise exc
+    return [future.result() for future in futures]

--- a/python/aigverse/abc/_batch.py
+++ b/python/aigverse/abc/_batch.py
@@ -77,6 +77,22 @@ def run_many(
 ) -> list[AigT | AbcError]: ...
 
 
+# For a caller whose `return_exceptions` is decided at runtime, which neither literal
+# overload above can match.
+@overload
+def run_many(
+    networks: Iterable[AigT],
+    commands: str | Sequence[str],
+    *,
+    jobs: int | None = ...,
+    timeout: float | None = ...,
+    use_init_file: bool = ...,
+    gia: bool = ...,
+    binary: str | os.PathLike[str] | None = ...,
+    return_exceptions: bool,
+) -> list[AigT] | list[AigT | AbcError]: ...
+
+
 def run_many(
     networks: Iterable[AigT],
     commands: str | Sequence[str],

--- a/python/aigverse/abc/_batch.py
+++ b/python/aigverse/abc/_batch.py
@@ -118,9 +118,8 @@ def run_many(
     results)`` is always valid. Every result is held at once regardless of ``jobs``,
     which is the memory a whole corpus costs.
 
-    Expect a speedup below the number of cores. A batch is as slow as its slowest
-    network, and the AIGER transfer at each end of a run holds the GIL, so only the
-    ABC processes themselves overlap.
+    Expect a speedup below the number of cores: a batch is as slow as its slowest
+    network.
 
     Args:
         networks: The networks to optimize. Consumed in full before any work starts.

--- a/python/aigverse/abc/_batch.py
+++ b/python/aigverse/abc/_batch.py
@@ -77,8 +77,8 @@ def run_many(
 ) -> list[AigT | AbcError]: ...
 
 
-# For a caller whose `return_exceptions` is decided at runtime, which neither literal
-# overload above can match.
+# For a caller whose `return_exceptions` is decided at runtime. mypy and pyright
+# expand a `bool` into its two literals and match the overloads above; `ty` does not.
 @overload
 def run_many(
     networks: Iterable[AigT],
@@ -115,7 +115,8 @@ def run_many(
             rows[name] = abc.run_many(designs, script)
 
     Results come back in input order, never completion order, so ``zip(networks,
-    results)`` is always valid.
+    results)`` is always valid. Every result is held at once regardless of ``jobs``,
+    which is the memory a whole corpus costs.
 
     Expect a speedup below the number of cores. A batch is as slow as its slowest
     network, and the AIGER transfer at each end of a run holds the GIL, so only the
@@ -130,8 +131,9 @@ def run_many(
         jobs: How many ABC processes to keep running at once. ``None`` (default)
             uses the number of CPUs available to this process, capped at the number
             of networks; ``1`` runs inline without a thread pool. On large designs
-            memory, not CPU, is what limits this. A CPU *quota* -- ``docker
-            --cpus=2`` -- is not visible here, so set ``jobs`` explicitly under one.
+            memory rather than CPU is what limits this, since each worker holds a
+            whole ABC in flight. A CPU *quota* -- ``docker --cpus=2`` -- is not
+            visible here, so set ``jobs`` explicitly under one.
         timeout: Seconds to wait for ABC to terminate, **per network** rather than
             for the batch as a whole, or ``None`` for no limit.
         use_init_file: If ``False`` (default), ABC is invoked with ``-s`` so that
@@ -158,7 +160,9 @@ def run_many(
         TypeError: If any element of ``networks`` is not an ``Aig``.
         ValueError: If ``jobs`` is below 1, if no command was given, or if ``gia``
             is set and a network has a register whose reset value is undefined.
-        AbcNotFoundError: If no ABC executable could be located.
+        AbcNotFoundError: If no ABC executable could be located. Resolution
+            happens once before any network is run, so this is raised whatever
+            ``return_exceptions`` says.
         AbcTimeoutError: If ABC did not terminate within ``timeout`` seconds for
             some network and ``return_exceptions`` is not set.
         AbcExecutionError: If ABC reported an error for some network and
@@ -172,8 +176,11 @@ def run_many(
         carries that.
 
     Note:
-        Interrupting a batch drops the networks that have not started yet, but does
-        not kill the ABC processes already running; ``timeout`` is what bounds those.
+        Interrupting a batch drops the networks that have not started yet. Ctrl-C in a
+        terminal reaches the running ABC processes too, because they share the
+        foreground process group, but an interrupt delivered to the interpreter alone
+        does not -- ``run_commands`` keeps no handle on what it spawned, so ``timeout``
+        is what bounds those.
     """
     items = list(networks)
 
@@ -182,11 +189,11 @@ def run_many(
     if jobs is not None and jobs < 1:
         msg = f"jobs must be at least 1, got {jobs}"
         raise ValueError(msg)
-    command = join_commands(commands)
     for ntk in items:
         check_supported(ntk)
         if gia:
             check_gia_supported(ntk)
+    command = join_commands(commands)
 
     # Before resolving the binary, so an empty batch is a no-op on a machine
     # without ABC rather than an AbcNotFoundError.

--- a/python/aigverse/abc/_runner.py
+++ b/python/aigverse/abc/_runner.py
@@ -67,7 +67,7 @@ def _find_error(output: str) -> str | None:
     return None
 
 
-def _join(commands: str | Sequence[str]) -> str:
+def join_commands(commands: str | Sequence[str]) -> str:
     """Normalizes user-supplied ABC commands into a single command string.
 
     Args:
@@ -218,7 +218,7 @@ def run_commands(
         AbcTimeoutError: If ABC did not terminate within ``timeout`` seconds.
         AbcExecutionError: If ABC reported an error.
     """
-    command = _join(commands)
+    command = join_commands(commands)
     executable = resolve_binary(binary)
 
     if cwd is None:
@@ -346,7 +346,12 @@ def run_script(
     check_supported(ntk)
     if gia:
         check_gia_supported(ntk)
-    command = _join(commands)
+    command = join_commands(commands)
+
+    # Resolved once, up front: discovery walks PATH, and the error paths below need
+    # the same executable that actually ran -- re-resolving afterwards would report
+    # a binary that disappeared mid-run instead of the result ABC produced.
+    executable = resolve_binary(binary)
 
     from ..io import read_aiger_into_aig, read_aiger_into_sequential_aig, write_aiger
 
@@ -372,24 +377,23 @@ def run_script(
             timeout=timeout,
             use_init_file=use_init_file,
             cwd=directory,
-            binary=binary,
+            binary=executable,
         )
 
         if verbose:
             print(output)  # ruff: ignore[print]
 
-        executable = str(resolve_binary(binary))
         result_path = directory / _OUTPUT_FILE
         if not result_path.is_file() or result_path.stat().st_size == 0:
             msg = "ABC produced no output network"
-            raise AbcExecutionError(msg, binary=executable, command=script, output=output)
+            raise AbcExecutionError(msg, binary=str(executable), command=script, output=output)
 
         try:
             reader = read_aiger_into_sequential_aig if sequential else read_aiger_into_aig
             result = reader(result_path)
         except RuntimeError as exc:
             msg = f"could not read the network ABC produced: {exc}"
-            raise AbcExecutionError(msg, binary=executable, command=script, output=output) from exc
+            raise AbcExecutionError(msg, binary=str(executable), command=script, output=output) from exc
 
     # read_aiger_into_sequential_aig already yields a SequentialAig, and
     # read_aiger_into_aig yields a NamedAig; narrow the latter back to a plain Aig

--- a/python/aigverse/abc/_runner.py
+++ b/python/aigverse/abc/_runner.py
@@ -349,8 +349,8 @@ def run_script(
     command = join_commands(commands)
 
     # Resolved once, up front: discovery walks PATH, and the error paths below need
-    # the same executable that actually ran -- re-resolving afterwards would report
-    # a binary that disappeared mid-run instead of the result ABC produced.
+    # the same executable that actually ran. Re-resolving afterwards would discard a
+    # successful result whenever the binary disappeared while ABC was running.
     executable = resolve_binary(binary)
 
     from ..io import read_aiger_into_aig, read_aiger_into_sequential_aig, write_aiger

--- a/python/aigverse/abc/gia.py
+++ b/python/aigverse/abc/gia.py
@@ -864,6 +864,21 @@ def run_many(
 ) -> list[AigT | AbcError]: ...
 
 
+# For a caller whose `return_exceptions` is decided at runtime, which neither literal
+# overload above can match.
+@overload
+def run_many(
+    networks: Iterable[AigT],
+    commands: str | Sequence[str],
+    *,
+    jobs: int | None = ...,
+    timeout: float | None = ...,
+    use_init_file: bool = ...,
+    binary: str | os.PathLike[str] | None = ...,
+    return_exceptions: bool,
+) -> list[AigT] | list[AigT | AbcError]: ...
+
+
 def run_many(
     networks: Iterable[AigT],
     commands: str | Sequence[str],
@@ -894,11 +909,11 @@ def run_many(
         binary: Overrides the resolved ABC executable for this call only. It is
             resolved once for the whole batch.
         return_exceptions: If ``True``, each failing network yields its
-            :exc:`AbcError` in place of a result instead of aborting the batch.
+            :exc:`~aigverse.abc.AbcError` in place of a result instead of aborting the batch.
 
     Returns:
         The optimized networks, in input order, each of the same type as its input
-        -- with :exc:`AbcError` instances in place of the failures when
+        -- with :exc:`~aigverse.abc.AbcError` instances in place of the failures when
         ``return_exceptions`` is set.
 
     Raises:
@@ -911,19 +926,6 @@ def run_many(
         AbcExecutionError: If ABC reported an error for some network and
             ``return_exceptions`` is not set.
     """
-    # Split rather than forwarded: `return_exceptions` is a plain bool here, which
-    # matches neither of the batch function's literal overloads.
-    if return_exceptions:
-        return _base_run_many(
-            networks,
-            commands,
-            jobs=jobs,
-            timeout=timeout,
-            use_init_file=use_init_file,
-            gia=True,
-            binary=binary,
-            return_exceptions=True,
-        )
     return _base_run_many(
         networks,
         commands,
@@ -932,4 +934,5 @@ def run_many(
         use_init_file=use_init_file,
         gia=True,
         binary=binary,
+        return_exceptions=return_exceptions,
     )

--- a/python/aigverse/abc/gia.py
+++ b/python/aigverse/abc/gia.py
@@ -42,8 +42,9 @@ from __future__ import annotations
 import tempfile
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
+from ._batch import run_many as _base_run_many
 from ._errors import AbcExecutionError, AbcTimeoutError
 from ._options import check_option
 from ._runner import AigT, budgeted_timeout, check_gia_supported, check_supported, resolve_binary, run_commands
@@ -52,9 +53,11 @@ from ._stats import AbcStats, collect_stats
 
 if TYPE_CHECKING:
     import os
-    from collections.abc import Sequence
+    from collections.abc import Iterable, Sequence
+    from typing import Literal
 
     from ..networks import Aig
+    from ._errors import AbcError
 
 __all__ = [
     "CecStatus",
@@ -64,6 +67,7 @@ __all__ = [
     "deepsyn",
     "fraig",
     "resub",
+    "run_many",
     "run_script",
     "stats",
     "syn2",
@@ -830,5 +834,102 @@ def run_script(
         use_init_file=use_init_file,
         gia=True,
         verbose=verbose,
+        binary=binary,
+    )
+
+
+@overload
+def run_many(
+    networks: Iterable[AigT],
+    commands: str | Sequence[str],
+    *,
+    jobs: int | None = ...,
+    timeout: float | None = ...,
+    use_init_file: bool = ...,
+    binary: str | os.PathLike[str] | None = ...,
+    return_exceptions: Literal[False] = False,
+) -> list[AigT]: ...
+
+
+@overload
+def run_many(
+    networks: Iterable[AigT],
+    commands: str | Sequence[str],
+    *,
+    jobs: int | None = ...,
+    timeout: float | None = ...,
+    use_init_file: bool = ...,
+    binary: str | os.PathLike[str] | None = ...,
+    return_exceptions: Literal[True],
+) -> list[AigT | AbcError]: ...
+
+
+def run_many(
+    networks: Iterable[AigT],
+    commands: str | Sequence[str],
+    *,
+    jobs: int | None = None,
+    timeout: float | None = None,
+    use_init_file: bool = False,
+    binary: str | os.PathLike[str] | None = None,
+    return_exceptions: bool = False,
+) -> list[AigT] | list[AigT | AbcError]:
+    """Runs arbitrary ``&``-space commands over many networks, in parallel.
+
+    The GIA counterpart of :func:`~aigverse.abc.run_many`: every network is
+    transferred with ``&read``/``&write`` so that ``&``-prefixed commands operate
+    on it directly. Equivalent to calling that function with ``gia=True``.
+
+    Args:
+        networks: The networks to optimize. Consumed in full before any work starts.
+        commands: A single ``;``-separated ABC command string, or a sequence of
+            individual commands. The same script runs on every network.
+        jobs: How many ABC processes to keep running at once. ``None`` (default)
+            uses the number of CPUs available to this process, capped at the number
+            of networks; ``1`` runs inline without a thread pool.
+        timeout: Seconds to wait for ABC to terminate, **per network** rather than
+            for the batch as a whole, or ``None`` for no limit.
+        use_init_file: If ``False`` (default), ABC is invoked with ``-s`` so that
+            no ``abc.rc`` is read.
+        binary: Overrides the resolved ABC executable for this call only. It is
+            resolved once for the whole batch.
+        return_exceptions: If ``True``, each failing network yields its
+            :exc:`AbcError` in place of a result instead of aborting the batch.
+
+    Returns:
+        The optimized networks, in input order, each of the same type as its input
+        -- with :exc:`AbcError` instances in place of the failures when
+        ``return_exceptions`` is set.
+
+    Raises:
+        TypeError: If any element of ``networks`` is not an ``Aig``.
+        ValueError: If ``jobs`` is below 1, if no command was given, or if a
+            network has a register whose reset value is undefined.
+        AbcNotFoundError: If no ABC executable could be located.
+        AbcTimeoutError: If ABC did not terminate within ``timeout`` seconds for
+            some network and ``return_exceptions`` is not set.
+        AbcExecutionError: If ABC reported an error for some network and
+            ``return_exceptions`` is not set.
+    """
+    # Split rather than forwarded: `return_exceptions` is a plain bool here, which
+    # matches neither of the batch function's literal overloads.
+    if return_exceptions:
+        return _base_run_many(
+            networks,
+            commands,
+            jobs=jobs,
+            timeout=timeout,
+            use_init_file=use_init_file,
+            gia=True,
+            binary=binary,
+            return_exceptions=True,
+        )
+    return _base_run_many(
+        networks,
+        commands,
+        jobs=jobs,
+        timeout=timeout,
+        use_init_file=use_init_file,
+        gia=True,
         binary=binary,
     )

--- a/python/aigverse/abc/gia.py
+++ b/python/aigverse/abc/gia.py
@@ -864,8 +864,8 @@ def run_many(
 ) -> list[AigT | AbcError]: ...
 
 
-# For a caller whose `return_exceptions` is decided at runtime, which neither literal
-# overload above can match.
+# For a caller whose `return_exceptions` is decided at runtime. mypy and pyright
+# expand a `bool` into its two literals and match the overloads above; `ty` does not.
 @overload
 def run_many(
     networks: Iterable[AigT],

--- a/test/abc/test_batch.py
+++ b/test/abc/test_batch.py
@@ -9,6 +9,7 @@ count, which is what makes a batch's items distinguishable from inside ABC.
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -27,7 +28,6 @@ from aigverse.networks import Aig, NamedAig, SequentialAig
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from pathlib import Path
 
 # The fake-ABC shims rely on the executable bit, which does not carry over on Windows.
 requires_posix = pytest.mark.skipif(sys.platform == "win32", reason="the fake ABC shims rely on POSIX executable bits")
@@ -242,7 +242,7 @@ if inputs == 4:
     with pytest.raises(AbcExecutionError) as excinfo:
         run_many(networks, "balance", jobs=2, binary=shim)
 
-    assert any("index 2" in note for note in excinfo.value.__notes__)
+    assert any("index 2" in note for note in getattr(excinfo.value, "__notes__", []))
 
 
 @requires_posix
@@ -358,7 +358,7 @@ def test_the_binary_is_resolved_once_for_a_batch(
 def test_a_single_call_resolves_the_binary_once(
     monkeypatch: pytest.MonkeyPatch, and_aig: Aig, fake_abc: Callable[[str], Path]
 ) -> None:
-    """`run_script` used to resolve again after ABC had run, only to name it in errors.
+    """Discovery walks PATH, so a single call must not repeat it either.
 
     Args:
         monkeypatch: Used to count discovery calls.
@@ -385,6 +385,90 @@ def test_a_single_call_resolves_the_binary_once(
     run_script(and_aig, "balance")
 
     assert calls == 1
+
+
+@requires_posix
+def test_one_job_returns_failures_in_place_too(and_aig: Aig, fake_abc: Callable[[str], Path]) -> None:
+    """The serial path is the threaded path's twin, not a shortcut past its behaviour.
+
+    Args:
+        and_aig: A small network to batch.
+        fake_abc: Builds the stand-in executable.
+    """
+    shim = fake_abc("print(\"** cmd error: unknown command 'nope'\")\nsys.exit(0)")
+
+    results = run_many([and_aig, and_aig], "nope", jobs=1, binary=shim, return_exceptions=True)
+
+    assert [type(result) for result in results] == [AbcExecutionError, AbcExecutionError]
+
+
+@requires_posix
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="exception notes are 3.11+")
+def test_one_job_names_the_failing_network_too(fake_abc: Callable[[str], Path]) -> None:
+    """The index note is attached on the serial path as well.
+
+    Args:
+        fake_abc: Builds the stand-in executable.
+    """
+    shim = fake_abc(
+        _READ_INPUTS
+        + """
+if inputs == 3:
+    print("** cmd error: unknown command 'nope'")
+    sys.exit(0)
+(cwd / "out.aig").write_bytes(source.read_bytes())
+"""
+    )
+
+    with pytest.raises(AbcExecutionError) as excinfo:
+        run_many([aig_with_pis(2), aig_with_pis(3)], "balance", jobs=1, binary=shim)
+
+    assert any("index 1" in note for note in getattr(excinfo.value, "__notes__", []))
+
+
+@requires_posix
+def test_networks_may_be_any_iterable(and_aig: Aig, fake_abc: Callable[[str], Path]) -> None:
+    """`networks` is consumed in full up front, so a one-shot iterable is fine.
+
+    Args:
+        and_aig: A small network to batch.
+        fake_abc: Builds the stand-in executable.
+    """
+    results = run_many((and_aig for _ in range(3)), "balance", jobs=2, binary=fake_abc(_HAPPY))
+
+    assert len(results) == 3
+
+
+def test_a_non_abc_failure_is_never_returned_in_place(monkeypatch: pytest.MonkeyPatch, and_aig: Aig) -> None:
+    """A full disk is not a per-network ABC failure, so it must not land in the list.
+
+    Args:
+        monkeypatch: Used to make the per-network work fail with an OSError.
+        and_aig: A small network to batch.
+    """
+    from aigverse.abc import _batch
+
+    def explode(*_args: object, **_kwargs: object) -> None:
+        """Fails the way the filesystem would.
+
+        Raises:
+            OSError: Always.
+        """
+        msg = "no space left on device"
+        raise OSError(msg)
+
+    monkeypatch.setattr(_batch, "run_script", explode)
+    monkeypatch.setattr(_batch, "resolve_binary", lambda _binary: Path("/nonexistent/abc"))
+
+    with pytest.raises(OSError, match="no space left"):
+        run_many([and_aig, and_aig], "balance", jobs=2, return_exceptions=True)
+
+
+def test_the_default_job_count_is_at_least_one() -> None:
+    """Every fallback in the ladder must yield a usable worker count."""
+    from aigverse.abc._batch import _default_jobs
+
+    assert _default_jobs() >= 1
 
 
 @requires_posix

--- a/test/abc/test_batch.py
+++ b/test/abc/test_batch.py
@@ -138,8 +138,8 @@ def test_non_aig_is_rejected_either_way(
     """
     hide_abc(monkeypatch)
     with pytest.raises(TypeError, match="expected an Aig"):
-        run_many(
-            [and_aig, "not a network"],  # ty: ignore[invalid-argument-type]
+        run_many(  # ty: ignore[no-matching-overload]
+            [and_aig, "not a network"],
             "balance",
             return_exceptions=return_exceptions,
         )

--- a/test/abc/test_batch.py
+++ b/test/abc/test_batch.py
@@ -258,7 +258,7 @@ def test_a_failure_cancels_the_queued_networks(tmp_path: Path, fake_abc: Callabl
     shim = fake_abc(
         _READ_INPUTS
         + f"""
-(pathlib.Path({str(markers)!r}) / f"{{os.getpid()}}").touch()
+(pathlib.Path({str(markers)!r}) / f"{{os.getpid()}}-{{time.time_ns()}}").touch()
 if inputs == 2:
     print("** cmd error: unknown command 'nope'")
     sys.exit(0)
@@ -272,8 +272,9 @@ time.sleep(1.0)
     with pytest.raises(AbcExecutionError):
         run_many(networks, "balance", jobs=2, binary=shim)
 
-    # Two workers, so at most a handful can have started; the margin is deliberately
-    # enormous, because what is being pinned is "not all of them", not a count.
+    # A PID alone would not identify an invocation, since the shims are short-lived
+    # and a PID is reusable. Two workers, so at most a handful can have started; the
+    # margin is deliberately enormous, because what is pinned is "not all of them".
     assert len(list(markers.iterdir())) < len(networks) // 2
 
 

--- a/test/abc/test_batch.py
+++ b/test/abc/test_batch.py
@@ -1,0 +1,459 @@
+"""Tests for `run_many`, the parallel map over the ABC bridge.
+
+Every argument is validated before a single process starts, so the validation
+half needs neither ABC nor a stand-in and runs everywhere. The concurrency half
+is driven by `fake_abc` shims that branch on the input network's primary-input
+count, which is what makes a batch's items distinguishable from inside ABC.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from aigverse.abc import (
+    AbcError,
+    AbcExecutionError,
+    AbcTimeoutError,
+    expand_script,
+    gia,
+    run_many,
+    run_script,
+    set_abc_binary,
+)
+from aigverse.networks import Aig, NamedAig, SequentialAig
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+# The fake-ABC shims rely on the executable bit, which does not carry over on Windows.
+requires_posix = pytest.mark.skipif(sys.platform == "win32", reason="the fake ABC shims rely on POSIX executable bits")
+
+# Reads the primary-input count out of the binary AIGER header, which is
+# `aig M I L O A`. It is the only thing telling a shim which item it is running.
+_READ_INPUTS = """
+import os
+cwd = pathlib.Path.cwd()
+source = cwd / "in.aig"
+inputs = int(source.read_bytes().split(b"\\n")[0].split()[2])
+"""
+
+# A well-behaved ABC that changes nothing.
+_HAPPY = (
+    _READ_INPUTS
+    + """
+(cwd / "out.aig").write_bytes(source.read_bytes())
+"""
+)
+
+# Finishes in reverse submission order, so a batch that returned results as they
+# complete would come back scrambled rather than merely lucky.
+_HAPPY_REVERSED = (
+    _READ_INPUTS
+    + """
+time.sleep(0.05 * (12 - inputs))
+(cwd / "out.aig").write_bytes(source.read_bytes())
+"""
+)
+
+
+def aig_with_pis(count: int) -> Aig:
+    """Builds a network with a given number of primary inputs.
+
+    Args:
+        count: How many primary inputs to create, at least two.
+
+    Returns:
+        A network whose AIGER header carries ``count`` as its input count.
+    """
+    ntk = Aig()
+    pis = [ntk.create_pi() for _ in range(count)]
+    ntk.create_po(ntk.create_and(pis[0], pis[1]))
+    return ntk
+
+
+def hide_abc(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Makes discovery fail, so a test can prove a check runs before it.
+
+    Args:
+        monkeypatch: Used to hide any installed ABC.
+    """
+    monkeypatch.delenv("AIGVERSE_ABC", raising=False)
+    monkeypatch.setenv("PATH", "")
+
+
+# --------------------------------------------------------------------------------------
+# Validation -- no ABC, no shim, every platform
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("jobs", [0, -1])
+def test_non_positive_jobs_is_rejected(monkeypatch: pytest.MonkeyPatch, and_aig: Aig, jobs: int) -> None:
+    """`jobs` is checked before anything looks for ABC.
+
+    Args:
+        monkeypatch: Used to hide any installed ABC.
+        and_aig: A small network to batch.
+        jobs: The rejected worker count.
+    """
+    hide_abc(monkeypatch)
+    with pytest.raises(ValueError, match="jobs must be at least 1"):
+        run_many([and_aig], "balance", jobs=jobs)
+
+
+def test_empty_batch_needs_no_abc(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Nothing to run is not an error, so it must not require an executable.
+
+    Args:
+        monkeypatch: Used to hide any installed ABC.
+    """
+    hide_abc(monkeypatch)
+    assert run_many([], "balance") == []
+
+
+def test_empty_batch_still_rejects_an_empty_script(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A typo in the script must not pass because the data happened to be empty.
+
+    Args:
+        monkeypatch: Used to hide any installed ABC.
+    """
+    hide_abc(monkeypatch)
+    with pytest.raises(ValueError, match="no ABC commands"):
+        run_many([], "   ")
+
+
+@pytest.mark.parametrize("return_exceptions", [False, True])
+def test_non_aig_is_rejected_either_way(
+    monkeypatch: pytest.MonkeyPatch, and_aig: Aig, *, return_exceptions: bool
+) -> None:
+    """`return_exceptions` governs ABC failures, not a fault in the call itself.
+
+    Args:
+        monkeypatch: Used to hide any installed ABC.
+        and_aig: A valid network, so the rejection is about its neighbour.
+        return_exceptions: Whether ABC failures would be returned in place.
+    """
+    hide_abc(monkeypatch)
+    with pytest.raises(TypeError, match="expected an Aig"):
+        run_many(
+            [and_aig, "not a network"],  # ty: ignore[invalid-argument-type]
+            "balance",
+            return_exceptions=return_exceptions,
+        )
+
+
+def test_gia_rejects_an_undefined_reset(
+    monkeypatch: pytest.MonkeyPatch, sequential_aig: Callable[..., SequentialAig]
+) -> None:
+    """Every network is guarded, not just the first one.
+
+    Args:
+        monkeypatch: Used to hide any installed ABC.
+        sequential_aig: Builds the network; called with no reset value.
+    """
+    hide_abc(monkeypatch)
+    with pytest.raises(ValueError, match="no defined reset value"):
+        gia.run_many([sequential_aig(0), sequential_aig()], "&syn2")
+
+
+# --------------------------------------------------------------------------------------
+# Concurrency -- a stand-in ABC, still no real one
+# --------------------------------------------------------------------------------------
+
+
+@requires_posix
+def test_results_come_back_in_input_order(fake_abc: Callable[[str], Path]) -> None:
+    """The shim finishes in reverse, so completion order cannot pass by accident.
+
+    Args:
+        fake_abc: Builds the stand-in executable.
+    """
+    networks = [aig_with_pis(count) for count in range(2, 10)]
+
+    results = run_many(networks, "balance", jobs=4, binary=fake_abc(_HAPPY_REVERSED))
+
+    assert [result.num_pis for result in results] == [network.num_pis for network in networks]
+
+
+@requires_posix
+def test_failures_are_returned_in_place(fake_abc: Callable[[str], Path]) -> None:
+    """One bad network must not cost the sweep the results of the good ones.
+
+    Args:
+        fake_abc: Builds the stand-in executable.
+    """
+    shim = fake_abc(
+        _READ_INPUTS
+        + """
+if inputs % 2:
+    print("** cmd error: unknown command 'nope'")
+    sys.exit(0)
+(cwd / "out.aig").write_bytes(source.read_bytes())
+"""
+    )
+    networks = [aig_with_pis(count) for count in range(2, 8)]
+
+    results = run_many(networks, "balance", jobs=3, binary=shim, return_exceptions=True)
+
+    failed = [index for index, result in enumerate(results) if isinstance(result, AbcError)]
+    assert failed == [1, 3, 5]
+    for index, result in enumerate(results):
+        if index not in failed:
+            assert isinstance(result, Aig)
+            assert result.num_pis == networks[index].num_pis
+
+
+@requires_posix
+def test_a_failure_aborts_the_batch_by_default(fake_abc: Callable[[str], Path]) -> None:
+    """Without `return_exceptions`, a batch fails the way a single call does.
+
+    Args:
+        fake_abc: Builds the stand-in executable.
+    """
+    shim = fake_abc("print(\"** cmd error: unknown command 'nope'\")\nsys.exit(0)")
+    networks = [aig_with_pis(count) for count in range(2, 6)]
+
+    with pytest.raises(AbcExecutionError, match="unknown command"):
+        run_many(networks, "nope", jobs=2, binary=shim)
+
+
+@requires_posix
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="exception notes are 3.11+")
+def test_a_raised_failure_names_its_network(fake_abc: Callable[[str], Path]) -> None:
+    """The raised error says which input it belongs to; the command alone does not.
+
+    Args:
+        fake_abc: Builds the stand-in executable.
+    """
+    shim = fake_abc(
+        _READ_INPUTS
+        + """
+if inputs == 4:
+    print("** cmd error: unknown command 'nope'")
+    sys.exit(0)
+(cwd / "out.aig").write_bytes(source.read_bytes())
+"""
+    )
+    networks = [aig_with_pis(count) for count in (2, 3, 4, 5)]
+
+    with pytest.raises(AbcExecutionError) as excinfo:
+        run_many(networks, "balance", jobs=2, binary=shim)
+
+    assert any("index 2" in note for note in excinfo.value.__notes__)
+
+
+@requires_posix
+def test_a_failure_cancels_the_queued_networks(tmp_path: Path, fake_abc: Callable[[str], Path]) -> None:
+    """Aborting a batch must stop it, not merely stop reporting it.
+
+    Args:
+        tmp_path: Holds the marker directory the shim records itself in.
+        fake_abc: Builds the stand-in executable.
+    """
+    markers = tmp_path / "markers"
+    markers.mkdir()
+    shim = fake_abc(
+        _READ_INPUTS
+        + f"""
+(pathlib.Path({str(markers)!r}) / f"{{os.getpid()}}").touch()
+if inputs == 2:
+    print("** cmd error: unknown command 'nope'")
+    sys.exit(0)
+time.sleep(1.0)
+(cwd / "out.aig").write_bytes(source.read_bytes())
+"""
+    )
+    # The failing network is submitted first, so everything after it is still queued.
+    networks = [aig_with_pis(2), *(aig_with_pis(3) for _ in range(40))]
+
+    with pytest.raises(AbcExecutionError):
+        run_many(networks, "balance", jobs=2, binary=shim)
+
+    # Two workers, so at most a handful can have started; the margin is deliberately
+    # enormous, because what is being pinned is "not all of them", not a count.
+    assert len(list(markers.iterdir())) < len(networks) // 2
+
+
+@requires_posix
+def test_timeout_applies_to_each_network(and_aig: Aig, fake_abc: Callable[[str], Path]) -> None:
+    """`timeout` is a per-network budget, so every network hits it rather than one.
+
+    Args:
+        and_aig: A small network to batch.
+        fake_abc: Builds the stand-in executable.
+    """
+    shim = fake_abc("time.sleep(30)")
+
+    results = run_many([and_aig, and_aig], "balance", jobs=2, timeout=0.5, binary=shim, return_exceptions=True)
+
+    assert [type(result) for result in results] == [AbcTimeoutError, AbcTimeoutError]
+
+
+@requires_posix
+def test_one_job_runs_without_a_thread_pool(
+    monkeypatch: pytest.MonkeyPatch, and_aig: Aig, fake_abc: Callable[[str], Path]
+) -> None:
+    """`jobs=1` is a genuine serial loop, so a traceback carries no worker frame.
+
+    Args:
+        monkeypatch: Used to make any pool construction fail loudly.
+        and_aig: A small network to batch.
+        fake_abc: Builds the stand-in executable.
+    """
+    from aigverse.abc import _batch
+
+    def refuse(*_args: object, **_kwargs: object) -> None:
+        """Fails if a thread pool is constructed at all.
+
+        Raises:
+            AssertionError: Always.
+        """
+        msg = "jobs=1 must not build a thread pool"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(_batch, "ThreadPoolExecutor", refuse)
+
+    results = run_many([and_aig, and_aig], "balance", jobs=1, binary=fake_abc(_HAPPY))
+
+    assert len(results) == 2
+
+
+@requires_posix
+def test_the_binary_is_resolved_once_for_a_batch(
+    monkeypatch: pytest.MonkeyPatch, fake_abc: Callable[[str], Path]
+) -> None:
+    """Discovery walks PATH, so a batch must not repeat it per network.
+
+    Args:
+        monkeypatch: Used to count discovery calls.
+        fake_abc: Builds the stand-in executable.
+    """
+    from aigverse.abc import _binary, _runner
+
+    calls = 0
+
+    def counted() -> Path:
+        """Counts a discovery call and performs it.
+
+        Returns:
+            The resolved ABC executable.
+        """
+        nonlocal calls
+        calls += 1
+        return _binary.abc_binary()
+
+    monkeypatch.setattr(_runner, "abc_binary", counted)
+    set_abc_binary(fake_abc(_HAPPY))
+
+    run_many([aig_with_pis(count) for count in range(2, 7)], "balance", jobs=2)
+
+    assert calls == 1
+
+
+@requires_posix
+def test_a_single_call_resolves_the_binary_once(
+    monkeypatch: pytest.MonkeyPatch, and_aig: Aig, fake_abc: Callable[[str], Path]
+) -> None:
+    """`run_script` used to resolve again after ABC had run, only to name it in errors.
+
+    Args:
+        monkeypatch: Used to count discovery calls.
+        and_aig: A small network to optimize.
+        fake_abc: Builds the stand-in executable.
+    """
+    from aigverse.abc import _binary, _runner
+
+    calls = 0
+
+    def counted() -> Path:
+        """Counts a discovery call and performs it.
+
+        Returns:
+            The resolved ABC executable.
+        """
+        nonlocal calls
+        calls += 1
+        return _binary.abc_binary()
+
+    monkeypatch.setattr(_runner, "abc_binary", counted)
+    set_abc_binary(fake_abc(_HAPPY))
+
+    run_script(and_aig, "balance")
+
+    assert calls == 1
+
+
+@requires_posix
+def test_gia_batch_uses_the_gia_transfer(and_aig: Aig, fake_abc: Callable[[str], Path]) -> None:
+    """The `gia` namespace loads the GIA store, as its single-network twin does.
+
+    Args:
+        and_aig: A small network to batch.
+        fake_abc: Builds the stand-in executable.
+    """
+    shim = fake_abc("print(\"** cmd error: unknown command 'nope'\")\nsys.exit(0)")
+
+    results = gia.run_many([and_aig], "nope", binary=shim, return_exceptions=True)
+
+    failure = results[0]
+    assert isinstance(failure, AbcExecutionError)
+    assert "&read in.aig" in failure.command
+    assert "&write out.aig" in failure.command
+
+
+@requires_posix
+def test_every_network_keeps_its_type(
+    and_aig: Aig, sequential_aig: Callable[..., SequentialAig], fake_abc: Callable[[str], Path]
+) -> None:
+    """A batch is as type-preserving as the single-network path it delegates to.
+
+    Args:
+        and_aig: The plain-Aig member of the batch.
+        sequential_aig: Builds the SequentialAig member.
+        fake_abc: Builds the stand-in executable.
+    """
+    named = NamedAig()
+    x0 = named.create_pi()
+    named.set_name(x0, "alpha")
+    named.create_po(named.create_and(x0, named.create_pi()))
+
+    networks: list[Aig] = [and_aig, named, sequential_aig(0)]
+
+    results = run_many(networks, "balance", jobs=2, binary=fake_abc(_HAPPY))
+
+    assert [type(result) for result in results] == [Aig, NamedAig, SequentialAig]
+
+
+# --------------------------------------------------------------------------------------
+# Integration -- a real ABC
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("abc_available")
+def test_a_batch_matches_a_serial_loop() -> None:
+    """A batch is a parallel map, so it must agree with the loop it replaces."""
+    from aigverse.generators import carry_lookahead_adder, ripple_carry_adder
+
+    networks = [ripple_carry_adder(8), carry_lookahead_adder(8), ripple_carry_adder(12)]
+    script = expand_script("resyn2")
+
+    batched = run_many(networks, script)
+    serial = [run_script(network, script) for network in networks]
+
+    assert [result.num_gates for result in batched] == [result.num_gates for result in serial]
+
+
+@pytest.mark.usefixtures("abc_available")
+def test_a_gia_batch_matches_a_serial_loop() -> None:
+    """The same, through the `&`-space transfer."""
+    from aigverse.generators import carry_lookahead_adder, ripple_carry_adder
+
+    networks = [ripple_carry_adder(8), carry_lookahead_adder(8)]
+
+    batched = gia.run_many(networks, "&syn2")
+    serial = [gia.run_script(network, "&syn2") for network in networks]
+
+    assert [result.num_gates for result in batched] == [result.num_gates for result in serial]


### PR DESCRIPTION
## Description

Adds `aigverse.abc.run_many`, which runs one ABC script over many networks at once, one process per network, across all cores. `abc.gia.run_many` mirrors it through the `&`-space transfer.

```python
from aigverse import abc

optimized = abc.run_many(designs, abc.expand_script("resyn2"))
```

`aigverse.abc` starts one ABC process per call and runs it to completion before returning. `examples/abc_recipe_study.py` issues 400 such runs over ten designs one at a time, with every core but one idle — yet the calls were already isolated from each other: each gets its own temporary directory, working directory, subprocess and `abc.history`. Only the API was missing. On sixteen cores the study's 400 runs now go from about 24 s to under 9 s.

Fixes #408.

### Semantics

- One script over every network: `commands` is typed exactly as `run_script`'s, so there is no ambiguity with "one script per network". A cross product of recipes and designs is one call per recipe.
- Results come back in **input order**, never completion order, so `zip(networks, results)` is always valid.
- Threads, not processes — the work is `subprocess.run`, which releases the GIL for its whole duration. Each item still goes through `run_script`, so batch and single-call semantics cannot drift.
- `return_exceptions=True` puts each failing network's `AbcError` at its own index instead of losing the sweep to the first bad design; the default stays fail-fast, matching `run_script`, and the raised error carries a note naming the index (3.11+). It governs `AbcError` only — a wrong type, an empty script or an `OSError` is a fault in the call, raised either way and checked before a single process starts.
- `jobs` defaults to the CPUs available to the process, honouring `sched_getaffinity` below 3.13; `jobs=1` runs inline with no executor. `timeout` is a budget **per network**, not for the batch.

Expect a speedup below the number of cores, and the docs say so: a batch is only as fast as its slowest network. On sixteen cores the study's 400 runs go from about 24 s at `--jobs 1` to under 9 s, roughly 2.8x.

### A bug the batch surfaced

`run_script` resolved the ABC executable **twice** per call, the second time *after* ABC had already finished, purely to name the binary in an error message — so a binary deleted mid-run raised `AbcNotFoundError` after a successful run, discarding the result. The `PATH` walk now happens once, up front, and the resolved path is passed down; a batch resolves once for the whole run. `_join` became `join_commands`, matching the other shared `_runner` helpers.

### The study, batched

`examples/abc_recipe_study.py` now sends each recipe out as one `run_many` over the whole design set, its recipe tables holding command strings rather than wrapper functions. CSV rows and headline statistics are identical to the serial run's, on both the `--quick` and the default design set. `Result.seconds` is gone, so the CSV loses that column — under concurrency a per-item `perf_counter` measures neither the item's cost nor a share of the total. That is the one user-visible change, and it is in the changelog.

### Testing

`test/abc/test_batch.py` covers input order, per-item failure positions, fail-fast and the index note, cancellation of queued work, per-network `timeout`, `jobs=1` never constructing a pool, the binary resolving once, the GIA transfer, type preservation across `Aig`/`NamedAig`/`SequentialAig`, and a batch agreeing with the serial loop it replaces. Because everything is validated before a process starts, the validation half needs no ABC and runs on Windows too; the shims branch on the AIGER header's input count, so one network can fail while its neighbours succeed and the order test can finish in reverse submission order.

Verified locally: `nox -s tests-3.12` — 536 passed, 1 skipped with ABC, 441 passed, 96 skipped without; `nox -s lint` clean; `nox -s docs` builds with the same 8 warnings `main` produces.

### Follow-ups

- #474 — the persistent-ABC-session variant, factored out of #408, which is now just the parallel-map half this PR implements.
- ~~#475 — releasing the GIL in the `io` bindings.~~ Done in #477, and it turned out **not** to be a reason this speedup lands below the core count. Instrumenting one `run_script` call puts the AIGER transfer at 1.5% of it on this study's design set and 0.2% on `hyp`, so Amdahl caps anything the GIL could have cost here at about a percent — and merging #477 under this branch moved the study by less than run-to-run noise. The slowest-network effect is the whole story, and the caveat in `docs/abc.md` and `run_many`'s docstring now says only that.
- #476 — exposing the command builders through `.cmd(...)`, so a batch can reach `abc.rewrite`'s `"rewrite -z"` without writing the switch by hand. The one thing `run_many` cannot reach today.
- `nox -s lint` does not type-check `examples/`: the `ty` hook runs with `pass_filenames: false` against the package.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry for any noteworthy addition, change, fix, or removal.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch ABC execution with parallel jobs, input-order results, per-network timeouts, and optional per-network error reporting.
  * Added equivalent batch support for GIA workflows.
  * Added a `--jobs` option to control concurrent recipe-study processes.
* **Bug Fixes**
  * Improved ABC executable handling so each script run performs a single path lookup.
* **Documentation**
  * Updated ABC and recipe-study guidance for batching, timeouts, verification, output behavior, and runtime estimates.
* **Changes**
  * Recipe-study results no longer include per-item timing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->