### PR TITLE
⚡️ Release the GIL in the io bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ releases may include breaking changes.
 
 - ⚡️ Release the GIL in the `io` bindings, so AIGER, PLA, Verilog and DOT reads
   and writes overlap across threads instead of serializing against each other
-  ([#476]) ([**@marcelwa**])
+  ([#477]) ([**@marcelwa**])
 
 ## [0.1.5] - 2026-08-24
 
@@ -207,7 +207,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#010)._
 
 <!-- PR links -->
 
-[#476]: https://github.com/marcelwa/aigverse/pull/476
+[#477]: https://github.com/marcelwa/aigverse/pull/477
 [#463]: https://github.com/marcelwa/aigverse/pull/463
 [#458]: https://github.com/marcelwa/aigverse/pull/458
 [#457]: https://github.com/marcelwa/aigverse/pull/457

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ releases may include breaking changes.
 
 ### Changed
 
-- ⚡️ Release the GIL in the `io` bindings, so AIGER, PLA, Verilog and DOT reads
-  and writes overlap across threads instead of serializing against each other
+- ⚡️ Release the GIL in the `io` bindings, so reading and writing networks
+  overlaps across threads instead of serializing against every other worker
   ([#477]) ([**@marcelwa**])
 
 ## [0.1.5] - 2026-08-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+### Changed
+
+- ⚡️ Release the GIL in the `io` bindings, so AIGER, PLA, Verilog and DOT reads
+  and writes overlap across threads instead of serializing against each other
+  ([#476]) ([**@marcelwa**])
+
 ## [0.1.5] - 2026-08-24
 
 ### Added
@@ -201,6 +207,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#010)._
 
 <!-- PR links -->
 
+[#476]: https://github.com/marcelwa/aigverse/pull/476
 [#463]: https://github.com/marcelwa/aigverse/pull/463
 [#458]: https://github.com/marcelwa/aigverse/pull/458
 [#457]: https://github.com/marcelwa/aigverse/pull/457

--- a/src/aigverse/io/read_aiger.cpp
+++ b/src/aigverse/io/read_aiger.cpp
@@ -121,7 +121,7 @@ Raises:
     RuntimeError: If parsing the AIGER file fails{})pb",
                     latch_clause)
             .c_str(),
-        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
+        nb::call_guard<nb::gil_scoped_release>());
 
     m.def(
         fmt::format("read_ascii_aiger_into_{}", network_name).c_str(),

--- a/src/aigverse/io/read_aiger.cpp
+++ b/src/aigverse/io/read_aiger.cpp
@@ -120,7 +120,8 @@ Returns:
 Raises:
     RuntimeError: If parsing the AIGER file fails{})pb",
                     latch_clause)
-            .c_str());
+            .c_str(),
+        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
 
     m.def(
         fmt::format("read_ascii_aiger_into_{}", network_name).c_str(),
@@ -153,7 +154,8 @@ Returns:
 Raises:
     RuntimeError: If parsing the ASCII AIGER file fails{})pb",
                     latch_clause)
-            .c_str());
+            .c_str(),
+        nb::call_guard<nb::gil_scoped_release>());
 }
 
 // Explicit instantiations for named AIG and sequential AIG

--- a/src/aigverse/io/read_pla.cpp
+++ b/src/aigverse/io/read_pla.cpp
@@ -54,7 +54,7 @@ Returns:
 
 Raises:
     RuntimeError: If parsing the PLA file fails.)pb",
-        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
+        nb::call_guard<nb::gil_scoped_release>());
 }
 
 // Explicit instantiation for AIG

--- a/src/aigverse/io/read_pla.cpp
+++ b/src/aigverse/io/read_pla.cpp
@@ -53,7 +53,8 @@ Returns:
     The parsed network instance.
 
 Raises:
-    RuntimeError: If parsing the PLA file fails.)pb");  // NOLINT(misc-include-cleaner)
+    RuntimeError: If parsing the PLA file fails.)pb",
+        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
 }
 
 // Explicit instantiation for AIG

--- a/src/aigverse/io/read_verilog.cpp
+++ b/src/aigverse/io/read_verilog.cpp
@@ -55,7 +55,8 @@ Returns:
     The parsed network instance.
 
 Raises:
-    RuntimeError: If parsing the Verilog file fails.)pb");
+    RuntimeError: If parsing the Verilog file fails.)pb",
+        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
 }
 
 // Explicit instantiation for named AIG

--- a/src/aigverse/io/read_verilog.cpp
+++ b/src/aigverse/io/read_verilog.cpp
@@ -56,7 +56,7 @@ Returns:
 
 Raises:
     RuntimeError: If parsing the Verilog file fails.)pb",
-        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
+        nb::call_guard<nb::gil_scoped_release>());
 }
 
 // Explicit instantiation for named AIG

--- a/src/aigverse/io/write_aiger.cpp
+++ b/src/aigverse/io/write_aiger.cpp
@@ -28,7 +28,8 @@ void write_aiger(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
 
     Args:
         ntk: The network to serialize.
-        filename: Destination path for the AIGER file.)pb");
+        filename: Destination path for the AIGER file.)pb",
+        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
 }
 
 // Explicit instantiations

--- a/src/aigverse/io/write_aiger.cpp
+++ b/src/aigverse/io/write_aiger.cpp
@@ -29,7 +29,7 @@ void write_aiger(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
     Args:
         ntk: The network to serialize.
         filename: Destination path for the AIGER file.)pb",
-        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
+        nb::call_guard<nb::gil_scoped_release>());
 }
 
 // Explicit instantiations

--- a/src/aigverse/io/write_dot.cpp
+++ b/src/aigverse/io/write_dot.cpp
@@ -29,7 +29,7 @@ void write_dot(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
     Args:
         ntk: The network to serialize.
         filename: Destination path for the DOT file.)pb",
-        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
+        nb::call_guard<nb::gil_scoped_release>());
 }
 
 // Explicit instantiation for AIG

--- a/src/aigverse/io/write_dot.cpp
+++ b/src/aigverse/io/write_dot.cpp
@@ -21,6 +21,11 @@ void write_dot(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
 {
     namespace nb = nanobind;  // NOLINT(misc-unused-alias-decls)
 
+    // No GIL release here, unlike the other writers. `write_dot` takes the network
+    // by const reference but is not read-only: its default drawer lazily builds a
+    // `depth_view` over it, and that both registers an event on the network's shared
+    // storage and stamps `visited` flags across its node array. Two threads writing
+    // the same network corrupt the heap.
     m.def(
         "write_dot", [](const Ntk& ntk, const std::filesystem::path& filename)
         { mockturtle::write_dot(ntk, filename.string()); }, nb::arg("ntk"), nb::arg("filename"),
@@ -28,8 +33,7 @@ void write_dot(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
 
     Args:
         ntk: The network to serialize.
-        filename: Destination path for the DOT file.)pb",
-        nb::call_guard<nb::gil_scoped_release>());
+        filename: Destination path for the DOT file.)pb");
 }
 
 // Explicit instantiation for AIG

--- a/src/aigverse/io/write_dot.cpp
+++ b/src/aigverse/io/write_dot.cpp
@@ -28,7 +28,8 @@ void write_dot(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
 
     Args:
         ntk: The network to serialize.
-        filename: Destination path for the DOT file.)pb");
+        filename: Destination path for the DOT file.)pb",
+        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
 }
 
 // Explicit instantiation for AIG

--- a/src/aigverse/io/write_verilog.cpp
+++ b/src/aigverse/io/write_verilog.cpp
@@ -28,7 +28,8 @@ void write_verilog(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
 
     Args:
         ntk: The network to serialize.
-        filename: Destination path for the Verilog file.)pb");
+        filename: Destination path for the Verilog file.)pb",
+        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
 }
 
 // Explicit instantiation for AIG

--- a/src/aigverse/io/write_verilog.cpp
+++ b/src/aigverse/io/write_verilog.cpp
@@ -29,7 +29,7 @@ void write_verilog(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
     Args:
         ntk: The network to serialize.
         filename: Destination path for the Verilog file.)pb",
-        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
+        nb::call_guard<nb::gil_scoped_release>());
 }
 
 // Explicit instantiation for AIG

--- a/test/inout/test_concurrency.py
+++ b/test/inout/test_concurrency.py
@@ -15,7 +15,6 @@ from aigverse.io import (
     read_pla_into_aig,
     read_verilog_into_aig,
     write_aiger,
-    write_dot,
     write_verilog,
 )
 
@@ -54,7 +53,9 @@ def test_concurrent_reads(reader: Callable[[str], Aig], resource: str):
     assert [shape(aig) for aig in aigs] == [expected] * REPEATS
 
 
-@pytest.mark.parametrize(("writer", "suffix"), [(write_aiger, "aig"), (write_verilog, "v"), (write_dot, "dot")])
+# write_dot is absent by design: its drawer mutates the network's shared storage, so
+# its binding keeps the GIL. See the comment in src/aigverse/io/write_dot.cpp.
+@pytest.mark.parametrize(("writer", "suffix"), [(write_aiger, "aig"), (write_verilog, "v")])
 def test_concurrent_writes(
     writer: Callable[[Aig, str], None], suffix: str, three_input_and_chain_aig: Aig, tmp_path: Path
 ):

--- a/test/inout/test_concurrency.py
+++ b/test/inout/test_concurrency.py
@@ -5,48 +5,64 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from aigverse.io import read_aiger_into_aig, read_ascii_aiger_into_aig, write_aiger
+import pytest
+
+from aigverse.io import (
+    read_aiger_into_aig,
+    read_aiger_into_sequential_aig,
+    read_ascii_aiger_into_aig,
+    read_ascii_aiger_into_sequential_aig,
+    read_pla_into_aig,
+    read_verilog_into_aig,
+    write_aiger,
+    write_dot,
+    write_verilog,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from aigverse.networks import Aig
 
 dir_path = Path(os.path.realpath(__file__)).parent
 
-# enough work per pool that the reads genuinely overlap rather than finishing
-# before the second thread starts
-REPEATS = 32
+REPEATS = 16
 THREADS = 8
+
+READERS = [
+    (read_aiger_into_aig, "mux21.aig"),
+    (read_ascii_aiger_into_aig, "or.aag"),
+    (read_aiger_into_sequential_aig, "lfsr.aig"),
+    (read_ascii_aiger_into_sequential_aig, "seq.aag"),
+    (read_pla_into_aig, "test.pla"),
+    (read_verilog_into_aig, "test.v"),
+]
 
 
 def shape(aig: Aig) -> tuple[int, int, int, int, list[int], list[int]]:
     return (aig.size, aig.num_pis, aig.num_pos, aig.num_gates, aig.pis(), aig.gates())
 
 
-def test_concurrent_binary_reads():
-    path = str(dir_path / "../resources/mux21.aig")
-    expected = shape(read_aiger_into_aig(path))
+@pytest.mark.parametrize(("reader", "resource"), READERS, ids=[r for _, r in READERS])
+def test_concurrent_reads(reader: Callable[[str], Aig], resource: str):
+    path = str(dir_path / "../resources" / resource)
+    expected = shape(reader(path))
 
     with ThreadPoolExecutor(THREADS) as pool:
-        aigs = list(pool.map(read_aiger_into_aig, [path] * REPEATS))
+        aigs = list(pool.map(reader, [path] * REPEATS))
 
     assert [shape(aig) for aig in aigs] == [expected] * REPEATS
 
 
-def test_concurrent_ascii_reads():
-    path = str(dir_path / "../resources/or.aag")
-    expected = shape(read_ascii_aiger_into_aig(path))
+@pytest.mark.parametrize(("writer", "suffix"), [(write_aiger, "aig"), (write_verilog, "v"), (write_dot, "dot")])
+def test_concurrent_writes(
+    writer: Callable[[Aig, str], None], suffix: str, three_input_and_chain_aig: Aig, tmp_path: Path
+):
+    paths = [tmp_path / f"{i}.{suffix}" for i in range(REPEATS)]
 
     with ThreadPoolExecutor(THREADS) as pool:
-        aigs = list(pool.map(read_ascii_aiger_into_aig, [path] * REPEATS))
+        list(pool.map(lambda p: writer(three_input_and_chain_aig, str(p)), paths))
 
-    assert [shape(aig) for aig in aigs] == [expected] * REPEATS
-
-
-def test_concurrent_writes(three_input_and_chain_aig: Aig, tmp_path: Path):
-    paths = [str(tmp_path / f"{i}.aig") for i in range(REPEATS)]
-
-    with ThreadPoolExecutor(THREADS) as pool:
-        list(pool.map(lambda p: write_aiger(three_input_and_chain_aig, p), paths))
-
-    expected = shape(three_input_and_chain_aig)
-    assert [shape(read_aiger_into_aig(p)) for p in paths] == [expected] * REPEATS
+    serial = tmp_path / f"serial.{suffix}"
+    writer(three_input_and_chain_aig, str(serial))
+    assert [p.read_bytes() for p in paths] == [serial.read_bytes()] * REPEATS

--- a/test/inout/test_concurrency.py
+++ b/test/inout/test_concurrency.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from aigverse.io import read_aiger_into_aig, read_ascii_aiger_into_aig, write_aiger
+
+if TYPE_CHECKING:
+    from aigverse.networks import Aig
+
+dir_path = Path(os.path.realpath(__file__)).parent
+
+# enough work per pool that the reads genuinely overlap rather than finishing
+# before the second thread starts
+REPEATS = 32
+THREADS = 8
+
+
+def shape(aig: Aig) -> tuple[int, int, int, int, list[int], list[int]]:
+    return (aig.size, aig.num_pis, aig.num_pos, aig.num_gates, aig.pis(), aig.gates())
+
+
+def test_concurrent_binary_reads():
+    path = str(dir_path / "../resources/mux21.aig")
+    expected = shape(read_aiger_into_aig(path))
+
+    with ThreadPoolExecutor(THREADS) as pool:
+        aigs = list(pool.map(read_aiger_into_aig, [path] * REPEATS))
+
+    assert [shape(aig) for aig in aigs] == [expected] * REPEATS
+
+
+def test_concurrent_ascii_reads():
+    path = str(dir_path / "../resources/or.aag")
+    expected = shape(read_ascii_aiger_into_aig(path))
+
+    with ThreadPoolExecutor(THREADS) as pool:
+        aigs = list(pool.map(read_ascii_aiger_into_aig, [path] * REPEATS))
+
+    assert [shape(aig) for aig in aigs] == [expected] * REPEATS
+
+
+def test_concurrent_writes(three_input_and_chain_aig: Aig, tmp_path: Path):
+    paths = [str(tmp_path / f"{i}.aig") for i in range(REPEATS)]
+
+    with ThreadPoolExecutor(THREADS) as pool:
+        list(pool.map(lambda p: write_aiger(three_input_and_chain_aig, p), paths))
+
+    expected = shape(three_input_and_chain_aig)
+    assert [shape(read_aiger_into_aig(p)) for p in paths] == [expected] * REPEATS


### PR DESCRIPTION
## Description

Adds `nb::call_guard<nb::gil_scoped_release>()` to all nine `m.def` sites in `src/aigverse/io/`. The `io` module was the last one holding the GIL for its whole duration — `algorithms/` and `utils/` already released it everywhere — so any threaded code that reads or writes a corpus serialized on time spent in lorina and in file descriptors, not in the interpreter.

Fixes #475.

### The audit

The issue asks for the audit before the guard, and it comes back clean for every def site. Each takes a `std::filesystem::path` (plus a `const Ntk&` for the writers) and returns a network by value or `void`. `nb::object`, `nb::cast` and `nb::handle` appear nowhere in the directory — the only nanobind includes are `<nanobind/nanobind.h>` and `<nanobind/stl/filesystem.h>`. No overload takes a Python file-like object, and no reader exposes a callback that could re-enter Python, so `gil_scoped_release` is the right tool rather than the wrong one.

Errors are plain C++ exceptions throughout, including the one `refuse_latches::on_header` throws from inside lorina's parse callback. nanobind constructs the guard as a local inside its wrapper lambda (`nb_func.h:129-137`), so the destructor reacquires the GIL during unwinding, before the exception translator ever touches a Python object. Argument and return casting happen in the outer dispatcher with the GIL held, which is what makes the `path` caster and the network return caster safe.

The writers' `const Ntk&` borrows into a Python-owned object while the GIL is down. nanobind keeps the argument alive across the call; the only exposure is another thread mutating that same network concurrently, and that is exactly the exposure `simulate`, `equivalence_checking` and `cleanup_dangling` already accept.

`bindings.cpp` is untouched — it has no defs, and its `import_("aigverse.networks")` runs at import time.

### What it buys: 0.8x → 3-4x on threaded I/O

Sixteen threads over 160 AIGER files (the 20 EPFL designs, eight copies each, 11.5 MB), best of three, `main` versus this branch:

| | serial | threaded (16) | speedup |
| --- | --- | --- | --- |
| **read, `main`** | 0.86-1.08 s | 0.66-1.17 s | 0.92x, 1.12x, 1.30x |
| **read, this branch** | 0.88-1.10 s | 0.23-0.30 s | 3.05x, 3.10x, 4.76x |
| **write, `main`** | 0.27-0.40 s | 0.33-0.54 s | 0.74x, 0.80x, 0.82x |
| **write, this branch** | 0.28-0.37 s | 0.08-0.10 s | 3.24x, 3.55x, 3.87x |

On `main` threading a write loop is a net *loss* — all contention, no overlap. That is the case the issue names second, the dataset generation loop and the benchmark loader, and it is where the guard actually pays.

### What it does not buy: the #467 study is unchanged

The issue predicted this would widen #467's 2.5x, and it does not. Merging this branch onto `abc-run-many` and running `examples/abc_recipe_study.py` both ways, two rounds each:

| | round 1 | round 2 |
| --- | --- | --- |
| `abc-run-many` | 7.7 s | 7.7 s |
| + these guards | 7.6 s | 7.5 s |

Within noise. Instrumenting one `abc.run_script` call explains why — the AIGER transfer is a rounding error against ABC itself, on designs of every size:

| design | gates | `run_script` | transfer | share |
| --- | --- | --- | --- | --- |
| `ctrl` | 174 | 0.051 s | 0.000 s | 0.9% |
| `bar` | 3336 | 0.116 s | 0.002 s | 1.5% |
| `mem_ctrl` | 46836 | 1.370 s | 0.011 s | 0.8% |
| `div` | 57247 | 2.230 s | 0.012 s | 0.5% |
| `hyp` | 214335 | 37.872 s | 0.065 s | 0.2% |

1.5% of the study's design set, 0.2% of the largest. Amdahl caps the achievable gain there at about one percent, which is what the two runs show. So #467's sub-linear speedup is the *other* reason it names on its own: a batch is only as fast as its slowest network. The transfer never was a meaningful share, and #467's caveat that names it should be narrowed to the slowest-network effect when that PR lands.

The guard is still worth having on its own measurement — it is the difference between threaded I/O being a loss and being a 3-4x win — but it is not the fix for that batch.

### Testing

`test/inout/test_concurrency.py` covers the risk the guard actually introduces, which is data races rather than wall clock. It parametrizes over all six readers — both AIGER encodings for both network types, PLA and Verilog — and all three writers: eight threads, sixteen calls each, every result checked against what a serial call produces. Verilog is the one that matters most of the six, since its parser holds the largest shared static-regex surface in lorina. The writers compare file bytes rather than a reparsed network, which is stricter and is the only assertion available for `write_dot`.

It is a data-race smoke test, not a regression test for the guard itself: it passes with the guards reverted, because the GIL gives those invariants for free. That is deliberate — the only way to assert the release directly is a wall-clock threshold, which would be flaky in CI, so the measurement lives in this description instead. The throw-under-guard path is already covered single-threaded by `test_read_aiger.py:105`, `:118`, `:186` and `:205`, which drive `refuse_latches`' `std::runtime_error` and the file-not-found errors through the new guard.

Verified locally: `nox -s tests-3.12` — 514 passed, 1 skipped with ABC, 421 passed, 94 skipped without; `nox -s lint` clean; `nox -s stubs` leaves `python/aigverse/io.pyi` byte-identical, as a call guard does not alter a signature.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry for any noteworthy addition, change, fix, or removal.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * File imports and exports for AIGER, PLA, Verilog, and DOT can now run concurrently across Python threads.
  * Improved responsiveness for applications performing multiple I/O operations in parallel.

* **Tests**
  * Added coverage to verify concurrent AIG reading and writing produces consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
