### PR TITLE
🔥 Remove dead clang-tidy NOLINT suppressions

### DIFF
--- a/src/aigverse/algorithms/balancing.cpp
+++ b/src/aigverse/algorithms/balancing.cpp
@@ -78,7 +78,7 @@ Returns:
 
 Raises:
     ValueError: If ``rebalance_function`` is not one of the supported values.)pb",
-        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
+        nb::call_guard<nb::gil_scoped_release>());
 }
 
 // Explicit instantiation for AIG

--- a/src/aigverse/algorithms/cleanup_dangling.cpp
+++ b/src/aigverse/algorithms/cleanup_dangling.cpp
@@ -32,7 +32,7 @@ Args:
 
 Returns:
     A cleaned network with dangling structures removed.)pb",
-        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
+        nb::call_guard<nb::gil_scoped_release>());
 }
 
 template void cleanup<aigverse::aig>(nanobind::module_& m);

--- a/src/aigverse/algorithms/equivalence_checking.cpp
+++ b/src/aigverse/algorithms/equivalence_checking.cpp
@@ -61,7 +61,7 @@ Returns:
 
 Raises:
     RuntimeError: If miter construction fails due to incompatible interfaces (PI/PO count mismatch).)pb",
-        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
+        nb::call_guard<nb::gil_scoped_release>());
 }
 
 // Explicit instantiation for AIG

--- a/src/aigverse/algorithms/refactoring.cpp
+++ b/src/aigverse/algorithms/refactoring.cpp
@@ -85,7 +85,7 @@ Returns:
 
 Raises:
     RuntimeError: If refactoring fails in the underlying synthesis engine.)pb",
-        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
+        nb::call_guard<nb::gil_scoped_release>());
 }
 
 // Explicit instantiation for AIG

--- a/src/aigverse/algorithms/resubstitution.cpp
+++ b/src/aigverse/algorithms/resubstitution.cpp
@@ -66,7 +66,7 @@ Args:
 
 Returns:
     The optimized network if ``inplace`` is ``False``. Otherwise ``None``.)pb",
-        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
+        nb::call_guard<nb::gil_scoped_release>());
 }
 
 // Explicit instantiation for AIG

--- a/src/aigverse/algorithms/rewriting.cpp
+++ b/src/aigverse/algorithms/rewriting.cpp
@@ -68,7 +68,7 @@ Args:
 
 Returns:
     A rewritten network.)pb",
-        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
+        nb::call_guard<nb::gil_scoped_release>());
 }
 
 // Explicit instantiation for AIG

--- a/src/aigverse/algorithms/sequential_simulation.cpp
+++ b/src/aigverse/algorithms/sequential_simulation.cpp
@@ -116,7 +116,7 @@ Returns:
 
 Raises:
     ValueError: If an assignment in ``stimulus`` does not have one value per primary input.)pb",
-        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
+        nb::call_guard<nb::gil_scoped_release>());
 }
 
 // Explicit instantiation for the sequential AIG

--- a/src/aigverse/algorithms/simulation.cpp
+++ b/src/aigverse/algorithms/simulation.cpp
@@ -42,7 +42,6 @@ void simulation(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
             {
                 return mockturtle::simulate<kitty::dynamic_truth_table>(
                     ntk,
-                    // NOLINTNEXTLINE
                     mockturtle::default_simulator<kitty::dynamic_truth_table>{static_cast<unsigned>(ntk.num_pis())});
             }
             catch (const std::bad_alloc&)
@@ -62,7 +61,7 @@ Returns:
 
 Raises:
     MemoryError: If the truth tables cannot be allocated due to memory limits.)pb",
-        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
+        nb::call_guard<nb::gil_scoped_release>());
 
     m.def(
         "simulate_nodes",
@@ -78,7 +77,6 @@ Raises:
             {
                 const auto n_map = mockturtle::simulate_nodes<kitty::dynamic_truth_table>(
                     ntk,
-                    // NOLINTNEXTLINE
                     mockturtle::default_simulator<kitty::dynamic_truth_table>{static_cast<unsigned>(ntk.num_pis())});
 
                 std::unordered_map<mockturtle::node<Ntk>, kitty::dynamic_truth_table> node_to_tt{};
@@ -104,7 +102,7 @@ Returns:
 
 Raises:
     MemoryError: If the truth tables cannot be allocated due to memory limits.)pb",
-        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
+        nb::call_guard<nb::gil_scoped_release>());
 }
 
 // Explicit instantiation for AIG

--- a/src/aigverse/networks/edge_list.cpp
+++ b/src/aigverse/networks/edge_list.cpp
@@ -9,7 +9,7 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>  // NOLINT(misc-include-cleaner)
 #include <mockturtle/traits.hpp>
-#include <nanobind/make_iterator.h>  // NOLINT(misc-include-cleaner)
+#include <nanobind/make_iterator.h>
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>  // NOLINT(misc-include-cleaner)
 #include <nanobind/stl/vector.h>  // NOLINT(misc-include-cleaner)
@@ -96,7 +96,7 @@ Returns:
 
         ;
 
-    nb::implicitly_convertible<nb::tuple, Edge>();  // NOLINT(misc-include-cleaner)
+    nb::implicitly_convertible<nb::tuple, Edge>();
 
     /**
      * Edge list.
@@ -193,7 +193,7 @@ Raises:
 
         ;
 
-    nb::implicitly_convertible<nb::list, EdgeList>();  // NOLINT(misc-include-cleaner)
+    nb::implicitly_convertible<nb::list, EdgeList>();
 }
 
 // Explicit instantiation for AIG

--- a/src/aigverse/networks/index_list.cpp
+++ b/src/aigverse/networks/index_list.cpp
@@ -153,7 +153,7 @@ Returns:
                     const auto& v = il.raw();
                     if (i >= v.size())
                     {
-                        throw nb::index_error("index out of range");  // NOLINT(misc-include-cleaner)
+                        throw nb::index_error("index out of range");
                     }
                     return v[i];
                 },
@@ -175,7 +175,7 @@ Raises:
                     auto v = il.raw();
                     if (i >= v.size())
                     {
-                        throw nb::index_error("index out of range");  // NOLINT(misc-include-cleaner)
+                        throw nb::index_error("index out of range");
                     }
                     v[i] = value;
                     il   = IndexList(v);  // reconstruct the index list with the new vector

--- a/src/aigverse/networks/logic_networks.cpp
+++ b/src/aigverse/networks/logic_networks.cpp
@@ -601,7 +601,7 @@ Returns:
                     // ntk is uninitialized memory provided by nanobind; must construct in-place
                     construct_at(&ntk, std::move(restored));
                 }
-                catch (const nb::cast_error& e)  // NOLINT(misc-include-cleaner)
+                catch (const nb::cast_error& e)
                 {
                     const auto message = fmt::format("Invalid state: expected an index list. {}", e.what());
                     throw nb::value_error(message.c_str());

--- a/src/aigverse/utils/truth_table.cpp
+++ b/src/aigverse/utils/truth_table.cpp
@@ -11,9 +11,9 @@
 #include <kitty/hash.hpp>
 #include <kitty/operations.hpp>
 #include <kitty/print.hpp>
-#include <nanobind/make_iterator.h>  // NOLINT(misc-include-cleaner)
+#include <nanobind/make_iterator.h>
 #include <nanobind/nanobind.h>
-#include <nanobind/operators.h>   // NOLINT(misc-include-cleaner)
+#include <nanobind/operators.h>
 #include <nanobind/stl/string.h>  // NOLINT(misc-include-cleaner)
 #include <nanobind/stl/vector.h>  // NOLINT(misc-include-cleaner)
 
@@ -150,7 +150,7 @@ Args:
                 }
                 if (index < 0 || static_cast<uint64_t>(index) >= self.num_bits())
                 {
-                    throw nb::index_error("index out of range");  // NOLINT(misc-include-cleaner)
+                    throw nb::index_error("index out of range");
                 }
 
                 return kitty::get_bit(self, static_cast<uint64_t>(index));
@@ -176,7 +176,7 @@ Raises:
                 }
                 if (index < 0 || static_cast<uint64_t>(index) >= self.num_bits())
                 {
-                    throw nb::index_error("index out of range");  // NOLINT(misc-include-cleaner)
+                    throw nb::index_error("index out of range");
                 }
                 if (value)
                 {
@@ -204,7 +204,7 @@ Raises:
                                          detail::truth_table_bit_iterator(self, 0),
                                          detail::truth_table_bit_iterator(self, self.num_bits()));
             },
-            R"pb(Returns an iterator over all bits.)pb", nb::keep_alive<0, 1>())  // NOLINT(misc-include-cleaner)
+            R"pb(Returns an iterator over all bits.)pb", nb::keep_alive<0, 1>())
 
         // Method bindings
         .def("num_vars", &aigverse::truth_table::num_vars, R"pb(Returns the number of variables.)pb")
@@ -277,7 +277,7 @@ Raises:
             {
                 if (index >= self.num_bits())
                 {
-                    throw nb::index_error("index out of range");  // NOLINT(misc-include-cleaner)
+                    throw nb::index_error("index out of range");
                 }
                 kitty::set_bit(self, index);
             },
@@ -295,7 +295,7 @@ Raises:
             {
                 if (index >= self.num_bits())
                 {
-                    throw nb::index_error("index out of range");  // NOLINT(misc-include-cleaner)
+                    throw nb::index_error("index out of range");
                 }
                 return static_cast<bool>(kitty::get_bit(self, index));
             },
@@ -316,7 +316,7 @@ Raises:
             {
                 if (index >= self.num_bits())
                 {
-                    throw nb::index_error("index out of range");  // NOLINT(misc-include-cleaner)
+                    throw nb::index_error("index out of range");
                 }
                 kitty::clear_bit(self, index);
             },
@@ -334,7 +334,7 @@ Raises:
             {
                 if (index >= self.num_bits())
                 {
-                    throw nb::index_error("index out of range");  // NOLINT(misc-include-cleaner)
+                    throw nb::index_error("index out of range");
                 }
                 kitty::flip_bit(self, index);
             },

--- a/src/aigverse/utils/truth_table_operations.cpp
+++ b/src/aigverse/utils/truth_table_operations.cpp
@@ -33,7 +33,7 @@ Args:
 
 Returns:
     The bitwise majority truth table.)pb",
-        nb::call_guard<nb::gil_scoped_release>());  // NOLINT(misc-include-cleaner)
+        nb::call_guard<nb::gil_scoped_release>());
 
     m.def(
         "cofactor0",


### PR DESCRIPTION
## Description

Outside `src/aigverse/io/`, the tree carries 116 `NOLINT` markers; 27 of them suppress nothing at all. This removes exactly those 27, proven dead by stripping every marker in the tree and re-running clang-tidy against the real compile database to see which lines actually anchor a diagnostic. `src/aigverse/io/` is untouched here because #477 already removed its dead suppressions before merging; with this branch rebased onto that, the sweep over `.cpp` files is complete.

### The evidence

Baseline is `main` configured with `cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`, then `clang-tidy -p build` over all 20 non-`io` translation units. The experiment strips all 116 markers, blanking their 121 lines rather than deleting them so line numbers stay aligned, and re-runs the same 20 units; every marker whose covered lines light up is live, every marker whose lines stay silent is dead.

| run | diagnostics in `src/aigverse/` |
| --- | --- |
| baseline (`main`, all markers present) | 16 |
| all 116 markers stripped | 118 |
| after this PR (27 removed) | 16 |

The before and after sets are identical, modulo the two-line shift that deleting two `// NOLINTNEXTLINE` lines gives the pre-existing `simulation.cpp` warning (`:87` → `:85`). Zero new diagnostics.

### What went, what stayed

Removed: the 10 `// NOLINT(misc-include-cleaner)` markers trailing a `nb::call_guard<nb::gil_scoped_release>());` line, the two bare `// NOLINTNEXTLINE` in `simulation.cpp` (which suppressed *every* check on the following line and needed to suppress none), and 15 more `misc-include-cleaner` markers — on `nb::index_error`, `nb::implicitly_convertible`, `nb::cast_error` and `nb::keep_alive` uses, plus three `#include` lines whose headers include-cleaner resolves without help.

Kept: every marker that anchors a diagnostic — all 31 `misc-use-internal-linkage`, all 8 `misc-unused-alias-decls`, all 6 `readability-identifier-naming`, the 26 `misc-include-cleaner` markers on genuinely unused-looking includes and uses, and the `misc-redundant-expression`, `cppcoreguidelines-owning-memory`, unchecked-container-access and pointer-arithmetic blocks. Header markers are kept wholesale even where they look dead from a `.cpp`: the CI linter's default extension list covers `hpp`, so a changed header is analysed as its own main file, and there `edge_list.hpp:8`, `edge_list.hpp:203`, `index_list.hpp:10` and `index_list.hpp:29` do fire. Proving the remaining header markers dead would need a separate header-first pass, so no header is touched here.

### CI parity

The workflow pins clang-tidy 21, one major behind the local 22, so the 13 changed files were re-run through `clang-tidy 21.1.6` on the same compile database: zero diagnostics, including the four `cppcoreguidelines-pro-bounds-avoid-unchecked-container-access` warnings that 22 raises and 21 does not. The invocation was sanity-checked by stripping one known-live marker and confirming 21 reports it. The one configuration difference left is that CI omits `CMAKE_BUILD_TYPE`, where this used `Release`.

### Testing and changelog

No test. This is a comment-only change: the preprocessor never sees a `NOLINT` marker, so no bytes of the extension differ. `nox -s tests-3.12` passes unchanged (418 passed, 94 skipped without an ABC binary) and `nox -s lint` is clean, including `clang-format` on all 13 files.

No changelog entry either. The `CHANGELOG.md` here records user-visible behaviour and CI/packaging changes a contributor would notice; removing dead lint suppressions changes neither the API, the wheel, nor how any job runs, and the file has no precedent for pure-hygiene entries. Say the word and I will add one under `### Changed`.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry for any noteworthy addition, change, fix, or removal.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up redundant static-analysis suppression annotations across algorithm, network, and utility components.
  * Standardized code annotations around bindings, iterators, conversions, and error handling.

* **Bug Fixes**
  * No user-visible behavior, runtime functionality, error handling, or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
