### PR TITLE
🐛 Keep the GIL in write_verilog, which corrupts its output without it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ releases may include breaking changes.
 - ⚡️ Release the GIL in the `generators` bindings, so random and structured
   network construction overlaps across threads instead of blocking every other
   worker ([#478]) ([**@marcelwa**])
-- ⚡️ Release the GIL in the `io` bindings, so reading and writing networks
+- ⚡️ Release the GIL in the `io` bindings, so reading networks and writing AIGER
   overlaps across threads instead of serializing against every other worker
-  ([#477]) ([**@marcelwa**])
+  ([#477], [#481]) ([**@marcelwa**])
 
 ## [0.1.5] - 2026-08-24
 
@@ -210,6 +210,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#010)._
 
 <!-- PR links -->
 
+[#481]: https://github.com/marcelwa/aigverse/pull/481
 [#478]: https://github.com/marcelwa/aigverse/pull/478
 [#477]: https://github.com/marcelwa/aigverse/pull/477
 [#463]: https://github.com/marcelwa/aigverse/pull/463

--- a/src/aigverse/io/write_dot.cpp
+++ b/src/aigverse/io/write_dot.cpp
@@ -21,11 +21,13 @@ void write_dot(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
 {
     namespace nb = nanobind;  // NOLINT(misc-unused-alias-decls)
 
-    // No GIL release here, unlike the other writers. `write_dot` takes the network
-    // by const reference but is not read-only: its default drawer lazily builds a
-    // `depth_view` over it, and that both registers an event on the network's shared
-    // storage and stamps `visited` flags across its node array. Two threads writing
-    // the same network corrupt the heap.
+    // No GIL release here. A writer may only release it if it never builds a
+    // mockturtle view over the caller's network: every view shares that network's
+    // storage rather than copying it, so constructing one mutates state the caller
+    // still owns. `write_dot`'s default drawer lazily builds a `depth_view`, which
+    // registers an event on the shared event list and stamps `visited` across the
+    // shared node array. Two threads writing one network corrupt the heap.
+    // `write_aiger` builds no view and does release.
     m.def(
         "write_dot", [](const Ntk& ntk, const std::filesystem::path& filename)
         { mockturtle::write_dot(ntk, filename.string()); }, nb::arg("ntk"), nb::arg("filename"),

--- a/src/aigverse/io/write_verilog.cpp
+++ b/src/aigverse/io/write_verilog.cpp
@@ -21,6 +21,12 @@ void write_verilog(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
 {
     namespace nb = nanobind;  // NOLINT(misc-unused-alias-decls)
 
+    // No GIL release here, for the same reason as `write_dot`. The const network
+    // reference is not a promise of read-only: `write_verilog` builds a `topo_view`
+    // over it, and that view shares the caller's storage, so ordering the nodes bumps
+    // the shared traversal id and stamps `visited` across the shared node array. Two
+    // threads writing one network interleave those and silently emit a netlist with a
+    // dropped assignment and an empty operand -- corrupt output, not a crash.
     m.def(
         "write_verilog", [](const Ntk& ntk, const std::filesystem::path& filename)
         { mockturtle::write_verilog(ntk, filename.string()); }, nb::arg("ntk"), nb::arg("filename"),
@@ -28,8 +34,7 @@ void write_verilog(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
 
     Args:
         ntk: The network to serialize.
-        filename: Destination path for the Verilog file.)pb",
-        nb::call_guard<nb::gil_scoped_release>());
+        filename: Destination path for the Verilog file.)pb");
 }
 
 // Explicit instantiation for AIG

--- a/test/inout/test_concurrency.py
+++ b/test/inout/test_concurrency.py
@@ -15,7 +15,6 @@ from aigverse.io import (
     read_pla_into_aig,
     read_verilog_into_aig,
     write_aiger,
-    write_verilog,
 )
 
 if TYPE_CHECKING:
@@ -53,9 +52,10 @@ def test_concurrent_reads(reader: Callable[[str], Aig], resource: str):
     assert [shape(aig) for aig in aigs] == [expected] * REPEATS
 
 
-# write_dot is absent by design: its drawer mutates the network's shared storage, so
-# its binding keeps the GIL. See the comment in src/aigverse/io/write_dot.cpp.
-@pytest.mark.parametrize(("writer", "suffix"), [(write_aiger, "aig"), (write_verilog, "v")])
+# write_aiger is the only writer here by design. write_dot and write_verilog build a
+# mockturtle view over the caller's network, so their bindings keep the GIL; see the
+# comment in src/aigverse/io/write_dot.cpp.
+@pytest.mark.parametrize(("writer", "suffix"), [(write_aiger, "aig")])
 def test_concurrent_writes(
     writer: Callable[[Aig, str], None], suffix: str, three_input_and_chain_aig: Aig, tmp_path: Path
 ):


### PR DESCRIPTION
## Description

#477 released the GIL in `write_verilog`. That was wrong, and the failure mode is silent output corruption rather than a crash. This reverts that one binding.

Fixes a regression in #477, which is unreleased, so no released version is affected.

### What happens

`write_verilog` builds a `topo_view` over the caller's network to order the nodes. A mockturtle view shares the caller's storage rather than copying it, so `topo_view`'s constructor calls `update_topo()`, which bumps the shared traversal id (`incr_trav_id()`, twice) and stamps `visited` across the shared node array.

Two threads writing the same network interleave those writes. A worker whose traversal state has been overwritten mid-walk treats a node as already emitted, skips its assignment, and then refers to it by an empty name:

```verilog
  wire n4 , n5 , n6 ;
  assign n5 = x0 & x2 ;
  assign n6 =  & n5 ;      // n4's assignment is gone, and n4 is now an empty operand
```

That is invalid Verilog, written to disk, with no error raised. It is strictly worse than the `write_dot` crash the same audit missed earlier on this branch — a crash is loud.

### Measured

An 800-gate AIG, sixteen threads, 32 files per trial, 20 trials, each file compared byte-for-byte against a serial write:

| | corrupt files |
| --- | --- |
| with the guard (`main` today) | **132 / 640** |
| without it (this PR) | **0 / 640** |

It reproduces on x86 Linux too. The reason it slipped local testing before merge is that the concurrency suite's fixture is a three-gate AIG — too small a traversal to lose a race in. CI caught it on macOS, where the timing did expose it even at that size.

### The rule the original audit was missing

**A writer may release the GIL only if it never builds a mockturtle view over the caller's network.** Views share storage, so constructing one mutates state the caller still owns, and a `const Ntk&` parameter is not a promise of read-only.

| binding | builds a view? | releases the GIL |
| --- | --- | --- |
| `write_aiger` | no — plain `foreach_*` traversal | **yes** |
| `write_verilog` | `topo_view` | no (this PR) |
| `write_dot` | `depth_view` via its drawer | no (earlier in #477) |
| the six readers | n/a — each fills a network it constructs itself | **yes** |

The readers are untouched and are where the measured gain was: 3.05–4.76x on threaded reads versus 0.92–1.30x before. `write_aiger` keeps its 3.24–3.87x.

The rule is now written down in `write_dot.cpp` rather than restated per file, so the next person adding a writer has the criterion instead of the two instances.

### Testing

`nox -s tests-3.12`: 432 passed, 94 skipped. `nox -s lint` clean.

The concurrency test drops its `write_verilog` case, as it dropped `write_dot`: with the GIL held these are trivially correct, so a concurrency test over them asserts nothing. `write_aiger` and all six readers stay covered.

The unreleased `[#477]` changelog entry is narrowed to what still holds rather than a new entry being added, since both land in the same release.

## Separately: this is not only an `io` problem

While confirming the fix I probed the `algorithms/` bindings, which have released the GIL since #214 (Sept 2025) and #298 — long before this work. Several of them are wrong under the same conditions, on today's `main`. Calling each on one shared network from sixteen threads and comparing against the serial result:

| binding | wrong results |
| --- | --- |
| `equivalence_checking` | 62 / 192 |
| `aig_cut_rewriting` | 32 / 192 |
| `cleanup_dangling` | 16 / 192 |
| `balancing` | 5 / 192 |
| `sop_refactoring` | 0 / 192 |
| `aig_resubstitution` | 0 / 192 |

`equivalence_checking(aig, aig)` — a network checked against itself, which is `True` every time serially — returns **`False` in up to 59% of concurrent calls**. A silently wrong answer from an equivalence checker is about the worst failure mode this library has.

That is out of scope here and needs its own decision (drop those guards, lock the argument with `nb::arg("ntk").lock()`, or push a copy down), so I have filed it separately rather than widening this PR.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry for any noteworthy addition, change, fix, or removal.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the reliability of Verilog and DOT export operations by ensuring they run safely when sharing network data.
  - Updated concurrency handling so export operations avoid unsafe parallel execution scenarios.

- **Documentation**
  - Clarified export behavior and concurrency considerations in the changelog and developer documentation.
  - Updated release tracking to include the latest related change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->