### PR TITLE
🐛 Stop the algorithms bindings from racing on a shared network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ releases may include breaking changes.
 
 ### Fixed
 
+- 🐛 Stop `equivalence_checking`, `aig_cut_rewriting`, `balancing`, and `cleanup_dangling`
+  from returning silently wrong results when several threads call them on one shared
+  network. Each wrote traversal state into the caller's network through a mockturtle view
+  while the GIL was released ([#483]) ([**@marcelwa**])
 - 🐛 Look the ABC executable up on `PATH` once per `run_script` call instead of twice.
   The second lookup ran after ABC finished purely to name the binary in an error, so a
   binary that disappeared mid-run discarded a successful result ([#467])
@@ -226,6 +230,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#010)._
 
 <!-- PR links -->
 
+[#483]: https://github.com/marcelwa/aigverse/pull/483
 [#481]: https://github.com/marcelwa/aigverse/pull/481
 [#467]: https://github.com/marcelwa/aigverse/pull/467
 [#478]: https://github.com/marcelwa/aigverse/pull/478

--- a/python/aigverse/algorithms.pyi
+++ b/python/aigverse/algorithms.pyi
@@ -70,7 +70,8 @@ def sop_refactoring(
         try_both_polarities: Whether both output polarities are explored.
         consider_inverter_cost: Whether inverter cost is included in optimization.
         verbose: Whether to print verbose progress output.
-        inplace: Whether to mutate ``ntk`` in place.
+        inplace: Whether to mutate ``ntk`` in place. A network being transformed in place
+            must not be shared with another thread.
 
     Returns:
         The refactored network if ``inplace`` is ``False``. Otherwise ``None``.
@@ -106,7 +107,8 @@ def aig_resubstitution(
         use_dont_cares: Whether to use don't-care information.
         window_size: Window size used for don't-care computation.
         preserve_depth: Whether replacements must preserve depth.
-        inplace: Whether to mutate ``ntk`` in place.
+        inplace: Whether to mutate ``ntk`` in place. A network being transformed in place
+            must not be shared with another thread.
 
     Returns:
         The optimized network if ``inplace`` is ``False``. Otherwise ``None``.

--- a/src/aigverse/algorithms/balancing.cpp
+++ b/src/aigverse/algorithms/balancing.cpp
@@ -28,10 +28,16 @@ void balancing(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
 
     m.def(
         "balancing",
-        [](Ntk& ntk, const uint32_t cut_size = 4, const uint32_t cut_limit = 8, const bool minimize_truth_table = true,
-           const bool only_on_critical_path = false, const std::string& rebalance_function = "sop",
-           const bool sop_both_phases = true, const bool verbose = false) -> Ntk
+        [](const Ntk& ntk, const uint32_t cut_size = 4, const uint32_t cut_limit = 8,
+           const bool minimize_truth_table = true, const bool only_on_critical_path = false,
+           const std::string& rebalance_function = "sop", const bool sop_both_phases = true,
+           const bool verbose = false) -> Ntk
         {
+            // `balancing` builds a `mapping_view`, a `topo_view`, and a `depth_view` over the network it is handed,
+            // and each of them writes into that network's storage; run it on a clone instead. The clone costs 2.8% of
+            // the call at 1k gates. See `transform_helpers.hpp` for the rule.
+            const auto snapshot = ntk.clone();
+
             mockturtle::balancing_params ps{};
             ps.cut_enumeration_ps.cut_size             = cut_size;
             ps.cut_enumeration_ps.cut_limit            = cut_limit;
@@ -44,14 +50,14 @@ void balancing(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
                 mockturtle::sop_rebalancing<Ntk> rebalance_fn{};
                 rebalance_fn.both_phases_ = sop_both_phases;
 
-                return mockturtle::balancing(ntk, {rebalance_fn}, ps);
+                return mockturtle::balancing(snapshot, {rebalance_fn}, ps);
             }
             if (rebalance_function == "esop")
             {
                 mockturtle::esop_rebalancing<Ntk> rebalance_fn{};
                 rebalance_fn.both_phases = sop_both_phases;
 
-                return mockturtle::balancing(ntk, {rebalance_fn}, ps);
+                return mockturtle::balancing(snapshot, {rebalance_fn}, ps);
             }
 
             throw std::invalid_argument(fmt::format(

--- a/src/aigverse/algorithms/cleanup_dangling.cpp
+++ b/src/aigverse/algorithms/cleanup_dangling.cpp
@@ -18,6 +18,10 @@ void cleanup(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
 {
     namespace nb = nanobind;  // NOLINT(misc-unused-alias-decls)
 
+    // No GIL release here. `cleanup_dangling` builds a `topo_view` over the caller's network, which writes into that
+    // network's storage; see `transform_helpers.hpp` for the rule. The other three view-building bindings run on a
+    // clone instead and keep their guard, but this call is a single pass: a clone costs 75% of it at 10k gates and
+    // 3.7x at 1k, against a threaded gain that is 2.36x at 10k and 0.87x at 1k (#482).
     m.def(
         "cleanup_dangling",
         [](const Ntk& ntk, const bool remove_dangling_pis = false, const bool remove_redundant_pos = false) -> Ntk
@@ -31,8 +35,7 @@ Args:
     remove_redundant_pos: Whether to remove redundant primary outputs.
 
 Returns:
-    A cleaned network with dangling structures removed.)pb",
-        nb::call_guard<nb::gil_scoped_release>());
+    A cleaned network with dangling structures removed.)pb");
 }
 
 template void cleanup<aigverse::aig>(nanobind::module_& m);

--- a/src/aigverse/algorithms/equivalence_checking.cpp
+++ b/src/aigverse/algorithms/equivalence_checking.cpp
@@ -30,7 +30,13 @@ void equivalence_checking(nanobind::module_& m)  // NOLINT(misc-use-internal-lin
         [](const Spec& spec, const Impl& impl, const uint32_t conflict_limit = 0,
            const bool functional_reduction = true, const bool verbose = false) -> std::optional<bool>
         {
-            const auto miter = mockturtle::miter<mockturtle::aig_network, Spec, Impl>(spec, impl);
+            // `miter` runs `cleanup_dangling` over both networks, which builds a `topo_view` over each and writes into
+            // its storage; run it on clones instead. The clones cost 2.1% of the call at 1k gates. See
+            // `transform_helpers.hpp` for the rule.
+            const auto spec_snapshot = spec.clone();
+            const auto impl_snapshot = impl.clone();
+
+            const auto miter = mockturtle::miter<mockturtle::aig_network, Spec, Impl>(spec_snapshot, impl_snapshot);
 
             if (!miter.has_value())
             {

--- a/src/aigverse/algorithms/refactoring.cpp
+++ b/src/aigverse/algorithms/refactoring.cpp
@@ -78,7 +78,8 @@ Args:
     try_both_polarities: Whether both output polarities are explored.
     consider_inverter_cost: Whether inverter cost is included in optimization.
     verbose: Whether to print verbose progress output.
-    inplace: Whether to mutate ``ntk`` in place.
+    inplace: Whether to mutate ``ntk`` in place. A network being transformed in place
+        must not be shared with another thread.
 
 Returns:
     The refactored network if ``inplace`` is ``False``. Otherwise ``None``.

--- a/src/aigverse/algorithms/resubstitution.cpp
+++ b/src/aigverse/algorithms/resubstitution.cpp
@@ -62,7 +62,8 @@ Args:
     use_dont_cares: Whether to use don't-care information.
     window_size: Window size used for don't-care computation.
     preserve_depth: Whether replacements must preserve depth.
-    inplace: Whether to mutate ``ntk`` in place.
+    inplace: Whether to mutate ``ntk`` in place. A network being transformed in place
+        must not be shared with another thread.
 
 Returns:
     The optimized network if ``inplace`` is ``False``. Otherwise ``None``.)pb",

--- a/src/aigverse/algorithms/rewriting.cpp
+++ b/src/aigverse/algorithms/rewriting.cpp
@@ -25,11 +25,17 @@ void rewriting(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
 
     m.def(
         "aig_cut_rewriting",
-        [](Ntk& ntk, const uint32_t cut_size = 4, const uint32_t cut_limit = 8, const bool minimize_truth_table = true,
-           const bool allow_zero_gain = false, const bool use_dont_cares = false, const uint32_t min_cand_cut_size = 3,
+        [](const Ntk& ntk, const uint32_t cut_size = 4, const uint32_t cut_limit = 8,
+           const bool minimize_truth_table = true, const bool allow_zero_gain = false,
+           const bool use_dont_cares = false, const uint32_t min_cand_cut_size = 3,
            const std::optional<uint32_t> min_cand_cut_size_override = std::nullopt, const bool preserve_depth = false,
            const bool verbose = false, const bool very_verbose = false) -> Ntk
         {
+            // `cut_rewriting` clears the visited flags and the values of the network it is handed and builds
+            // `cut_view`s over it; run it on a clone instead. The clone costs 0.3% of the call at 1k gates. See
+            // `transform_helpers.hpp` for the rule.
+            const auto snapshot = ntk.clone();
+
             mockturtle::cut_rewriting_params params{};
             params.cut_enumeration_ps.cut_size             = cut_size;
             params.cut_enumeration_ps.cut_limit            = cut_limit;
@@ -45,7 +51,7 @@ void rewriting(nanobind::module_& m)  // NOLINT(misc-use-internal-linkage)
             const mockturtle::xag_npn_resynthesis<Ntk, aigverse::aig, mockturtle::xag_npn_db_kind::aig_complete>
                 aig_npn_resyn_engine{};
 
-            return mockturtle::cut_rewriting(ntk, aig_npn_resyn_engine, params);
+            return mockturtle::cut_rewriting(snapshot, aig_npn_resyn_engine, params);
         },
         nb::arg("ntk"), nb::kw_only(), nb::arg("cut_size") = 4, nb::arg("cut_limit") = 8,
         nb::arg("minimize_truth_table") = true, nb::arg("allow_zero_gain") = false, nb::arg("use_dont_cares") = false,

--- a/src/aigverse/algorithms/transform_helpers.hpp
+++ b/src/aigverse/algorithms/transform_helpers.hpp
@@ -15,6 +15,16 @@ namespace aigverse::detail
 /**
  * @brief Helper function to run a transformation either in-place or on a copy of the input network.
  *
+ * The copy is also what makes the released GIL safe, and the rule the `algorithms` bindings follow: a binding may
+ * release the GIL only if it never writes to the caller's network. Every mockturtle view shares that network's storage
+ * rather than copying it, and the marking mutators (`incr_trav_id`, `set_visited`, `clear_values`) are `const` members
+ * writing through that shared storage, so a `const Ntk&` is not a promise of read-only. A binding whose algorithm
+ * builds a view therefore either runs on a clone, as this function and `balancing`, `aig_cut_rewriting`, and
+ * `equivalence_checking` do, or keeps the GIL, as `cleanup_dangling` does.
+ *
+ * The in-place path writes to the caller's network by definition, so a network transformed in place must not be shared
+ * across threads.
+ *
  * @tparam Ntk The type of the logic network.
  * @tparam Fn The type of the transformation function, which should accept a non-const reference to an Ntk.
  * @param ntk The input logic network to transform.

--- a/test/algorithms/conftest.py
+++ b/test/algorithms/conftest.py
@@ -4,10 +4,24 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from aigverse.generators import random_aig
 from aigverse.networks import Aig
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+
+@pytest.fixture
+def race_prone_aig() -> Aig:
+    """Create a network large enough for a traversal to lose a race in.
+
+    The three-gate fixtures are too small to expose one: their traversals finish
+    before another thread can interleave with them (#481).
+
+    Returns:
+        A 600-gate random AIG network.
+    """
+    return random_aig(num_pis=10, num_gates=600, seed=42)
 
 
 @pytest.fixture

--- a/test/algorithms/test_algorithm_concurrency.py
+++ b/test/algorithms/test_algorithm_concurrency.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from aigverse.algorithms import (
+    aig_cut_rewriting,
+    aig_resubstitution,
+    balancing,
+    cleanup_dangling,
+    equivalence_checking,
+    simulate,
+    simulate_nodes,
+    sop_refactoring,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from aigverse.networks import Aig
+
+# More repeats than the io and generators suites use: a single call is wrong in roughly
+# one attempt in ten, so 16 of them would let a regression through too often.
+REPEATS = 32
+THREADS = 8
+
+
+def shape(aig: Aig | None) -> tuple[int, int, int, int, list[int]]:
+    assert aig is not None  # the transforms return None only for inplace=True
+    return (aig.size, aig.num_pis, aig.num_pos, aig.num_gates, aig.to_index_list().raw())
+
+
+# Every binding that takes a network. `spec` and `impl` are the same object here: a
+# network is equivalent to itself, so any False is a race. `cleanup_dangling` is trivially
+# correct while it keeps the GIL and is listed anyway, as the tripwire for a guard being
+# put back without a clone; see src/aigverse/algorithms/transform_helpers.hpp.
+CASES: list[tuple[str, Callable[[Aig], Any]]] = [
+    ("equivalence_checking", lambda aig: equivalence_checking(aig, aig)),
+    ("aig_cut_rewriting", lambda aig: shape(aig_cut_rewriting(aig))),
+    ("cleanup_dangling", lambda aig: shape(cleanup_dangling(aig))),
+    ("balancing", lambda aig: shape(balancing(aig))),
+    ("sop_refactoring", lambda aig: shape(sop_refactoring(aig))),
+    ("aig_resubstitution", lambda aig: shape(aig_resubstitution(aig))),
+    ("simulate", lambda aig: [tt.to_binary() for tt in simulate(aig)]),
+    ("simulate_nodes", lambda aig: sorted((n, tt.to_binary()) for n, tt in simulate_nodes(aig).items())),
+]
+
+
+@pytest.mark.parametrize("call", [c for _, c in CASES], ids=[name for name, _ in CASES])
+def test_concurrent_calls_on_one_shared_network(call: Callable[[Aig], Any], race_prone_aig: Aig) -> None:
+    expected = call(race_prone_aig)
+
+    with ThreadPoolExecutor(THREADS) as pool:
+        results = [f.result() for f in [pool.submit(call, race_prone_aig) for _ in range(REPEATS)]]
+
+    assert results == [expected] * REPEATS


### PR DESCRIPTION
## Description

Four `algorithms` bindings wrote traversal state into the caller's network through a mockturtle view while the GIL was released, so threads sharing one network overwrote each other's walk and got silently wrong answers. `equivalence_checking`, `aig_cut_rewriting` and `balancing` now run on a clone and keep their guard; `cleanup_dangling` keeps the GIL instead, because there the clone costs more than the parallelism it buys. The rule the whole directory now follows is written down once, next to `run_transform` in `transform_helpers.hpp`.

The issue's `nb::arg("ntk").lock()` option was measured out rather than tried: nanobind compiles the argument lock out of every non-`NB_FREE_THREADED` build (`nb_func.h:301`), and CPython suspends a thread's critical sections whenever it detaches (`cpython/critical_section.h:39-45`) — which is exactly what `gil_scoped_release` does. It is a no-op on every build this project ships.

### Measured

16 threads on one shared 600-gate `random_aig`, 192 calls per binding, each result compared against the serial one. Clone cost and threaded speedup are from a separate sweep over 1k/10k/100k-gate networks, 8 threads on 8 **distinct** networks:

| binding | wrong before | wrong after | fix | clone cost @1k/10k | 8-thread speedup |
| --- | --- | --- | --- | --- | --- |
| `equivalence_checking` | 2 / 192 | 0 / 192 | clone | 2.1% / 0.2% | 3.61x / 4.30x kept |
| `aig_cut_rewriting` | 24 / 192 | 0 / 192 | clone | 0.3% / 0.5% | 3.30x / 3.81x kept |
| `balancing` | 16 / 192 | 0 / 192 | clone | 2.8% / 0.9% | 3.84x / 3.89x kept |
| `cleanup_dangling` | 20 / 192 | 0 / 192 | keep the GIL | 372% / 75% | 0.87x / 2.36x given up |

`cleanup_dangling` is the one call cheap enough for the copy to dominate it: a single O(n) pass, where the clone costs 75% of the call at 10k gates and 3.7x at 1k, against a threaded gain that is 0.87x at 1k. Every other binding in the directory was audited against the rule — `sop_refactoring` and `aig_resubstitution` already route through `run_transform`'s clone, `simulate`/`simulate_nodes`/`simulate_sequential` only read, and the three `utils` truth-table ops are pure.

`inplace=True` keeps its released GIL: it writes to the caller's network by definition, so sharing one network across threads is caller error, the same way `write_aiger` already races against a concurrent `aig.create_and()`. That contract is now in both `inplace` docstrings.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry for any noteworthy addition, change, fix, or removal.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

Fixes #482


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread safety for network analysis and transformation algorithms when called concurrently on a shared network.
  * Prevented certain operations from producing silently incorrect results or unexpectedly modifying the caller’s network.

* **Documentation**
  * Clarified requirements and safety considerations for in-place transformations and multithreaded use.

* **Tests**
  * Added concurrency coverage across key equivalence, rewriting, cleanup, balancing, refactoring, resubstitution, and simulation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->