### PR TITLE
✨ Expose the ABC command builders through `.cmd(...)`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,9 @@ repos:
         priority: 0
       - id: check-docstring-first
         priority: 0
+        # the wrapper instances carry attribute docstrings, which autoapi renders
+        # and this hook mistakes for a second module docstring
+        exclude: ^python/aigverse/abc/(_commands|gia)\.py$
       - id: check-merge-conflict
         priority: 0
       - id: check-symlinks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Expose each ABC command wrapper's switch translation as `.cmd(...)`, which builds
+  the `abc.Command` the wrapper would run instead of running it, so a parameterized
+  command reaches `run_script` and `run_many` as itself rather than as a hand-written
+  switch string ([#486]) ([**@marcelwa**])
 - ✨ Add `run_many` to the `aigverse.abc` bridge, running one ABC script over many
   networks in parallel and reporting each failure in place instead of losing the
   batch to the first bad design ([#467]) ([**@marcelwa**])
@@ -232,6 +236,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#010)._
 
 [#483]: https://github.com/marcelwa/aigverse/pull/483
 [#481]: https://github.com/marcelwa/aigverse/pull/481
+[#486]: https://github.com/marcelwa/aigverse/pull/486
 [#467]: https://github.com/marcelwa/aigverse/pull/467
 [#478]: https://github.com/marcelwa/aigverse/pull/478
 [#477]: https://github.com/marcelwa/aigverse/pull/477

--- a/docs/abc.md
+++ b/docs/abc.md
@@ -49,7 +49,8 @@ installation where no `abc.rc` is found, and they silently mean something else o
 where a user has customized that file. `aigverse` sidesteps both problems by shipping the
 expansions itself and running ABC with `-s`, so a script means the same thing on every
 machine. The exact expansion of each script is available in
-{py:data}`~aigverse.abc.SCRIPTS`.
+{py:data}`~aigverse.abc.SCRIPTS`, and {py:func}`~aigverse.abc.expand_script` hands it out
+as commands — these scripts take no options, so they need no builder of their own.
 
 ## Individual commands
 

--- a/docs/abc.md
+++ b/docs/abc.md
@@ -67,7 +67,7 @@ print(f"{aig.num_gates} -> {result.num_gates} AND gates")
 Their options are exposed as keyword arguments rather than as ABC switches:
 `abc.rewrite(aig, zero_cost=True)` or `abc.resub(aig, max_cut_size=12)`.
 
-{py:func}`~aigverse.abc.orchestrate` is a fifth: instead of running rewriting,
+{py:obj}`~aigverse.abc.orchestrate` is a fifth: instead of running rewriting,
 refactoring and resubstitution one after another, it interleaves them and picks per node
 which to apply — a whole schedule in a single command.
 
@@ -125,10 +125,10 @@ print(f"abc.dc2:     {abc.dc2(aig).num_gates} gates")       # ABC's `dc2`
 print(f"abc.gia.dc2: {abc.gia.dc2(aig).num_gates} gates")   # ABC's `&dc2`
 ```
 
-It holds {py:func}`~aigverse.abc.gia.balance` (`&b`), {py:func}`~aigverse.abc.gia.resub`,
-{py:func}`~aigverse.abc.gia.dc2`, {py:func}`~aigverse.abc.gia.syn2`,
-{py:func}`~aigverse.abc.gia.syn3`, {py:func}`~aigverse.abc.gia.syn4` and
-{py:func}`~aigverse.abc.gia.fraig`, plus the high-effort searches below,
+It holds {py:obj}`~aigverse.abc.gia.balance` (`&b`), {py:obj}`~aigverse.abc.gia.resub`,
+{py:obj}`~aigverse.abc.gia.dc2`, {py:obj}`~aigverse.abc.gia.syn2`,
+{py:obj}`~aigverse.abc.gia.syn3`, {py:obj}`~aigverse.abc.gia.syn4` and
+{py:obj}`~aigverse.abc.gia.fraig`, plus the high-effort searches below,
 {py:func}`~aigverse.abc.gia.cec`, {py:func}`~aigverse.abc.gia.stats`, and
 {py:func}`~aigverse.abc.gia.run_script` for anything not wrapped.
 
@@ -159,7 +159,7 @@ area. On the adder it does neither — it adds gates and leaves the depth alone,
 `resyn2` wins outright. Neither family dominates, so measure on your own designs instead
 of assuming.
 
-{py:func}`~aigverse.abc.gia.fraig` is the odd one out and worth knowing about: it is
+{py:obj}`~aigverse.abc.gia.fraig` is the odd one out and worth knowing about: it is
 combinational SAT sweeping, which merges nodes that are functionally equivalent but
 structurally different. No amount of rewriting finds those, which makes it a useful pass
 _between_ two structural scripts that each introduced their own duplicates.
@@ -168,13 +168,13 @@ _between_ two structural scripts that each introduced their own duplicates.
 
 Three more `&` commands are searches rather than passes, and are priced accordingly:
 
-- {py:func}`~aigverse.abc.gia.deepsyn` repeatedly restructures with randomized parameters
+- {py:obj}`~aigverse.abc.gia.deepsyn` repeatedly restructures with randomized parameters
   and keeps the smallest result. Different `seed` values can give different results, so it
   is worth running more than once.
-- {py:func}`~aigverse.abc.gia.transduction` reasons about permissible functions per node
+- {py:obj}`~aigverse.abc.gia.transduction` reasons about permissible functions per node
   and finds redundancy structural rewriting cannot. It is BDD-based, so its cost climbs
   steeply with size.
-- {py:func}`~aigverse.abc.gia.transtoch` is stochastic transduction — transduction run
+- {py:obj}`~aigverse.abc.gia.transtoch` is stochastic transduction — transduction run
   repeatedly with randomized parameters. It is the most expensive thing here by a wide
   margin.
 

--- a/docs/abc.md
+++ b/docs/abc.md
@@ -67,6 +67,23 @@ print(f"{aig.num_gates} -> {result.num_gates} AND gates")
 Their options are exposed as keyword arguments rather than as ABC switches:
 `abc.rewrite(aig, zero_cost=True)` or `abc.resub(aig, max_cut_size=12)`.
 
+Every wrapper also builds its command without running it, which is what lets a
+parameterized command go anywhere a command string goes:
+
+```{code-cell} ipython3
+print(abc.rewrite.cmd(zero_cost=True))
+print(abc.resub.cmd(max_cut_size=12))
+```
+
+A schedule is then a list of commands, and the whole list runs in one ABC process:
+
+```{code-cell} ipython3
+schedule = [abc.balance.cmd(), abc.rewrite.cmd(zero_cost=True), abc.refactor.cmd()]
+result = abc.run_script(aig, schedule)
+
+print(f"{aig.num_gates} -> {result.num_gates} AND gates")
+```
+
 {py:obj}`~aigverse.abc.orchestrate` is a fifth: instead of running rewriting,
 refactoring and resubstitution one after another, it interleaves them and picks per node
 which to apply — a whole schedule in a single command.
@@ -267,8 +284,20 @@ network. The AIGER transfer bracketing each run is not the limit: it is under 2%
 drops from about 24 to under 9 seconds on sixteen cores — roughly 2.8x for its 400 runs.
 
 The wrappers take one network each, but every script they run is reachable as commands:
-{py:func}`~aigverse.abc.expand_script` hands out the canonical ones, and a command with
-options — `abc.rewrite(aig, zero_cost=True)` — is `"rewrite -z"` written out.
+{py:func}`~aigverse.abc.expand_script` hands out the canonical ones, and `cmd()` builds a
+parameterized one, so a whole corpus gets it in a single call:
+
+```{code-cell} ipython3
+recipe = [abc.balance.cmd(), abc.rewrite.cmd(zero_cost=True), abc.refactor.cmd()]
+optimized = abc.run_many(designs, recipe)
+
+for before, after in zip(designs, optimized):
+    print(f"{before.num_gates:4d} -> {after.num_gates:4d} AND gates")
+```
+
+A {py:class}`~aigverse.abc.Command` carries no store affinity, though: the `&`-space ones
+belong to {py:func}`~aigverse.abc.gia.run_many`, and handing them to the classic
+{py:func}`~aigverse.abc.run_many` fails with _there is no AIG_.
 
 ## What ABC thinks of a network
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,6 +93,8 @@ nitpick_ignore = [
     ("py:class", "aigverse.abc._errors.AbcError"),
     # and for the `Command` the wrappers build, documented at `aigverse.abc.Command`.
     ("py:class", "aigverse.abc._runner.Command"),
+    # and for the wrappers' base, documented at `aigverse.abc.CommandWrapper`.
+    ("py:class", "aigverse.abc._runner.CommandWrapper"),
 ]
 
 # -- Options for {MyST}NB ----------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,6 +91,8 @@ nitpick_ignore = [
     ("py:class", "aigverse.abc._stats.AbcStats"),
     # the same for `run_many`'s `AbcError`, documented at `aigverse.abc.AbcError`.
     ("py:class", "aigverse.abc._errors.AbcError"),
+    # and for the `Command` the wrappers build, documented at `aigverse.abc.Command`.
+    ("py:class", "aigverse.abc._runner.Command"),
 ]
 
 # -- Options for {MyST}NB ----------------------------------------------------

--- a/examples/abc_recipe_study.py
+++ b/examples/abc_recipe_study.py
@@ -134,24 +134,23 @@ CONFLICT_LIMIT: Final = 100_000
 # fail rather than quietly reshape the experiment. Insertion order is meaningful
 # here too -- it fixes the column order of the rank heatmap.
 
-#: The four atomic transformations every canonical script is built from, as the ABC
-#: commands they issue. `abc.balance`, `abc.rewrite`, `abc.refactor` and `abc.resub`
-#: are the same commands with default options, but calling them one at a time costs
-#: one ABC process and one AIGER round-trip *each*; handing the whole schedule to
-#: ABC runs it in a single process instead. One schedule then goes out across every
+#: The four atomic transformations every canonical script is built from, as the
+#: commands their wrappers build. Calling the wrappers one at a time would cost one
+#: ABC process and one AIGER round-trip *each*; handing the whole schedule to ABC
+#: runs it in a single process instead. One schedule then goes out across every
 #: design at once through `abc.run_many`.
-ATOMS: Mapping[str, str] = MappingProxyType({
-    "b": "balance",
-    "rw": "rewrite",
-    "rf": "refactor",
-    "rs": "resub",
+ATOMS: Mapping[str, abc.Command] = MappingProxyType({
+    "b": abc.balance.cmd(),
+    "rw": abc.rewrite.cmd(),
+    "rf": abc.refactor.cmd(),
+    "rs": abc.resub.cmd(),
 })
 
 #: The canonical `abc.rc` scripts, plus ABC's own `orchestrate`, for reference
-#: against the brute-forced orders. Held as the commands they issue rather than as
-#: the `abc.resyn2`-style wrappers, so a whole design set goes to `abc.run_many` in
-#: one call; at default options every one of those wrappers issues exactly this.
-CLASSIC_SCRIPTS: Mapping[str, tuple[str, ...]] = MappingProxyType({
+#: against the brute-forced orders. The canonical ones are option-less, so
+#: `abc.expand_script` hands out exactly what the `abc.resyn2`-style wrappers run,
+#: and a whole design set goes to `abc.run_many` in one call.
+CLASSIC_SCRIPTS: Mapping[str, tuple[str | abc.Command, ...]] = MappingProxyType({
     "resyn": abc.expand_script("resyn"),
     "resyn2": abc.expand_script("resyn2"),
     "resyn3": abc.expand_script("resyn3"),
@@ -160,19 +159,19 @@ CLASSIC_SCRIPTS: Mapping[str, tuple[str, ...]] = MappingProxyType({
     "resyn2rs": abc.expand_script("resyn2rs"),
     "compress2rs": abc.expand_script("compress2rs"),
     "dc2": abc.expand_script("dc2"),
-    "orchestrate": ("orchestrate",),
+    "orchestrate": (abc.orchestrate.cmd(),),
 })
 
 #: The &-space counterparts. `&fraig` is SAT sweeping rather than restructuring, and
 #: is included because it removes redundancy the others structurally cannot see.
-GIA_SCRIPTS: Mapping[str, tuple[str, ...]] = MappingProxyType({
-    "&b": ("&b",),
-    "&resub": ("&resub",),
-    "&dc2": ("&dc2",),
-    "&syn2": ("&syn2",),
-    "&syn3": ("&syn3",),
-    "&syn4": ("&syn4",),
-    "&fraig": ("&fraig",),
+GIA_SCRIPTS: Mapping[str, tuple[abc.Command, ...]] = MappingProxyType({
+    "&b": (abc.gia.balance.cmd(),),
+    "&resub": (abc.gia.resub.cmd(),),
+    "&dc2": (abc.gia.dc2.cmd(),),
+    "&syn2": (abc.gia.syn2.cmd(),),
+    "&syn3": (abc.gia.syn3.cmd(),),
+    "&syn4": (abc.gia.syn4.cmd(),),
+    "&fraig": (abc.gia.fraig.cmd(),),
 })
 
 
@@ -305,7 +304,7 @@ def run_batch(
     experiment: str,
     recipe: str,
     family: str,
-    commands: tuple[str, ...],
+    commands: tuple[str | abc.Command, ...],
     *,
     gia: bool,
     jobs: int | None,
@@ -416,7 +415,7 @@ def check(bench: Benchmark, optimized: Aig, recipe: str) -> str:
     return "equivalent"
 
 
-def commands_for(order: Sequence[str], rounds: int) -> tuple[str, ...]:
+def commands_for(order: Sequence[str], rounds: int) -> tuple[abc.Command, ...]:
     """Expand a schedule of atomic transformations into ABC commands.
 
     The whole schedule goes to ABC as one script, so it costs a single process and
@@ -877,7 +876,7 @@ def _plot_order_spread(ax: Axes, benchmarks: list[Benchmark], rounds: int) -> No
     # label both marks with their own budget: the star is not drawn at the same
     # effort as the dots, and a reader comparing them needs to be told so
     ax.set_title(
-        f"A  All {math.factorial(len(ATOMS))} orders of {'/'.join(ATOMS.values())}, "
+        f"A  All {math.factorial(len(ATOMS))} orders of {'/'.join(str(atom) for atom in ATOMS.values())}, "
         f"{rounds} round{'' if rounds == 1 else 's'}\n"
         f"dot = one ordering ({issued} commands) \u00b7 "
         f"red star = {REFERENCE_SCRIPT} ({reference_length} commands)",

--- a/examples/abc_recipe_study.py
+++ b/examples/abc_recipe_study.py
@@ -147,9 +147,8 @@ ATOMS: Mapping[str, abc.Command] = MappingProxyType({
 })
 
 #: The canonical `abc.rc` scripts, plus ABC's own `orchestrate`, for reference
-#: against the brute-forced orders. The canonical ones are option-less, so
-#: `abc.expand_script` hands out exactly what the `abc.resyn2`-style wrappers run,
-#: and a whole design set goes to `abc.run_many` in one call.
+#: against the brute-forced orders. `abc.expand_script` hands the canonical ones
+#: out as commands, so a whole design set goes to `abc.run_many` in one call.
 CLASSIC_SCRIPTS: Mapping[str, tuple[str | abc.Command, ...]] = MappingProxyType({
     "resyn": abc.expand_script("resyn"),
     "resyn2": abc.expand_script("resyn2"),

--- a/python/aigverse/abc/__init__.py
+++ b/python/aigverse/abc/__init__.py
@@ -50,7 +50,7 @@ from ._commands import (
     rewrite,
 )
 from ._errors import AbcError, AbcExecutionError, AbcNotFoundError, AbcTimeoutError
-from ._runner import Command, run_commands, run_script
+from ._runner import Command, CommandWrapper, run_commands, run_script
 from ._scripts import SCRIPTS, expand_script
 from ._stats import AbcStats, stats
 from ._wrappers import (
@@ -77,6 +77,7 @@ __all__ = [
     "Balance",
     "CecStatus",
     "Command",
+    "CommandWrapper",
     "Orchestrate",
     "Refactor",
     "Resub",

--- a/python/aigverse/abc/__init__.py
+++ b/python/aigverse/abc/__init__.py
@@ -39,7 +39,7 @@ from ._binary import (
 )
 from ._commands import balance, orchestrate, refactor, resub, rewrite
 from ._errors import AbcError, AbcExecutionError, AbcNotFoundError, AbcTimeoutError
-from ._runner import run_commands, run_script
+from ._runner import Command, run_commands, run_script
 from ._scripts import SCRIPTS, expand_script
 from ._stats import AbcStats, stats
 from ._wrappers import (
@@ -64,6 +64,7 @@ __all__ = [
     "AbcStats",
     "AbcTimeoutError",
     "CecStatus",
+    "Command",
     "abc_binary",
     "abc_rc",
     "abc_version",

--- a/python/aigverse/abc/__init__.py
+++ b/python/aigverse/abc/__init__.py
@@ -37,7 +37,18 @@ from ._binary import (
     set_abc_binary,
     set_abc_rc,
 )
-from ._commands import balance, orchestrate, refactor, resub, rewrite
+from ._commands import (
+    Balance,
+    Orchestrate,
+    Refactor,
+    Resub,
+    Rewrite,
+    balance,
+    orchestrate,
+    refactor,
+    resub,
+    rewrite,
+)
 from ._errors import AbcError, AbcExecutionError, AbcNotFoundError, AbcTimeoutError
 from ._runner import Command, run_commands, run_script
 from ._scripts import SCRIPTS, expand_script
@@ -63,8 +74,13 @@ __all__ = [
     "AbcNotFoundError",
     "AbcStats",
     "AbcTimeoutError",
+    "Balance",
     "CecStatus",
     "Command",
+    "Orchestrate",
+    "Refactor",
+    "Resub",
+    "Rewrite",
     "abc_binary",
     "abc_rc",
     "abc_version",

--- a/python/aigverse/abc/_batch.py
+++ b/python/aigverse/abc/_batch.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
     from concurrent.futures import Future
     from typing import Literal
 
+    from ._runner import Command
+
 __all__ = ["run_many"]
 
 
@@ -52,7 +54,7 @@ def _attribute(exc: BaseException, index: int) -> None:
 @overload
 def run_many(
     networks: Iterable[AigT],
-    commands: str | Sequence[str],
+    commands: str | Command | Sequence[str | Command],
     *,
     jobs: int | None = ...,
     timeout: float | None = ...,
@@ -66,7 +68,7 @@ def run_many(
 @overload
 def run_many(
     networks: Iterable[AigT],
-    commands: str | Sequence[str],
+    commands: str | Command | Sequence[str | Command],
     *,
     jobs: int | None = ...,
     timeout: float | None = ...,
@@ -82,7 +84,7 @@ def run_many(
 @overload
 def run_many(
     networks: Iterable[AigT],
-    commands: str | Sequence[str],
+    commands: str | Command | Sequence[str | Command],
     *,
     jobs: int | None = ...,
     timeout: float | None = ...,
@@ -95,7 +97,7 @@ def run_many(
 
 def run_many(
     networks: Iterable[AigT],
-    commands: str | Sequence[str],
+    commands: str | Command | Sequence[str | Command],
     *,
     jobs: int | None = None,
     timeout: float | None = None,
@@ -123,10 +125,11 @@ def run_many(
 
     Args:
         networks: The networks to optimize. Consumed in full before any work starts.
-        commands: A single ``;``-separated ABC command string, or a sequence of
-            individual commands. The same script runs on every network. The
-            canonical scripts are reachable through
-            :func:`~aigverse.abc.expand_script`.
+        commands: A single ``;``-separated ABC command string, a
+            :class:`~aigverse.abc.Command`, or a sequence of individual commands.
+            The same script runs on every network. The canonical scripts are
+            reachable through :func:`~aigverse.abc.expand_script`, and a
+            parameterized one through each wrapper's ``cmd()``.
         jobs: How many ABC processes to keep running at once. ``None`` (default)
             uses the number of CPUs available to this process, capped at the number
             of networks; ``1`` runs inline without a thread pool. On large designs

--- a/python/aigverse/abc/_commands.py
+++ b/python/aigverse/abc/_commands.py
@@ -5,6 +5,10 @@ Exposing them individually makes it possible to compose a schedule from Python -
 for instance in a reinforcement-learning loop over synthesis actions -- without
 assembling ABC command strings by hand.
 
+Every wrapper here is callable on a network, and its ``cmd()`` builds the same
+command without running it, so a parameterized command can be handed to
+:func:`~aigverse.abc.run_script` or :func:`~aigverse.abc.run_many` like any other.
+
 Every one of these is an ABC builtin, so they work regardless of whether an
 ``abc.rc`` can be found.
 
@@ -19,7 +23,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ._options import check_option
-from ._runner import AigT, run_script
+from ._runner import AigT, Command, run_script
 
 if TYPE_CHECKING:
     import os
@@ -27,255 +31,463 @@ if TYPE_CHECKING:
 __all__ = ["balance", "orchestrate", "refactor", "resub", "rewrite"]
 
 
-def balance(
-    ntk: AigT,
-    *,
-    minimize_levels: bool = True,
-    exor: bool = False,
-    duplicate: bool = False,
-    duplicate_critical: bool = False,
-    timeout: float | None = None,
-    verbose: bool = False,
-    binary: str | os.PathLike[str] | None = None,
-) -> AigT:
-    """Runs ABC's ``balance`` command on a network.
+class _Balance:
+    """Runs ABC's ``balance`` command on a network, or builds it as a command."""
 
-    Restructures the AND trees of the network to reduce its depth.
+    @staticmethod
+    def cmd(
+        *,
+        minimize_levels: bool = True,
+        exor: bool = False,
+        duplicate: bool = False,
+        duplicate_critical: bool = False,
+    ) -> Command:
+        """Builds ABC's ``balance`` command without running it.
 
-    Args:
-        ntk: The network to optimize.
-        minimize_levels: If ``True`` (ABC's default), balance for minimal depth.
-        exor: If ``True``, balance multi-input EXOR structures as well.
-        duplicate: If ``True``, allow logic to be duplicated.
-        duplicate_critical: If ``True``, duplicate logic on the critical paths
-            only, which buys depth for less area than ``duplicate`` does.
-        timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
-        verbose: If ``True``, print everything ABC wrote.
-        binary: Overrides the resolved ABC executable for this call only.
+        Args:
+            minimize_levels: If ``True`` (ABC's default), balance for minimal depth.
+            exor: If ``True``, balance multi-input EXOR structures as well.
+            duplicate: If ``True``, allow logic to be duplicated.
+            duplicate_critical: If ``True``, duplicate logic on the critical paths
+                only, which buys depth for less area than ``duplicate`` does.
 
-    Returns:
-        The optimized network, of the same type as ``ntk``.
-    """
-    command = "balance"
-    if not minimize_levels:
-        command += " -l"
-    if duplicate:
-        command += " -d"
-    if duplicate_critical:
-        command += " -s"
-    if exor:
-        command += " -x"
-    return run_script(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
+        Returns:
+            The command, ready for :func:`~aigverse.abc.run_script` or
+            :func:`~aigverse.abc.run_many`.
+        """
+        command = "balance"
+        if not minimize_levels:
+            command += " -l"
+        if duplicate:
+            command += " -d"
+        if duplicate_critical:
+            command += " -s"
+        if exor:
+            command += " -x"
+        return Command(command)
 
+    def __call__(
+        self,
+        ntk: AigT,
+        *,
+        minimize_levels: bool = True,
+        exor: bool = False,
+        duplicate: bool = False,
+        duplicate_critical: bool = False,
+        timeout: float | None = None,
+        verbose: bool = False,
+        binary: str | os.PathLike[str] | None = None,
+    ) -> AigT:
+        """Runs ABC's ``balance`` command on a network.
 
-def rewrite(
-    ntk: AigT,
-    *,
-    preserve_levels: bool = True,
-    zero_cost: bool = False,
-    timeout: float | None = None,
-    verbose: bool = False,
-    binary: str | os.PathLike[str] | None = None,
-) -> AigT:
-    """Runs ABC's ``rewrite`` command on a network.
+        Restructures the AND trees of the network to reduce its depth.
 
-    Replaces 4-input subgraphs with smaller pre-computed equivalents.
+        Args:
+            ntk: The network to optimize.
+            minimize_levels: If ``True`` (ABC's default), balance for minimal depth.
+            exor: If ``True``, balance multi-input EXOR structures as well.
+            duplicate: If ``True``, allow logic to be duplicated.
+            duplicate_critical: If ``True``, duplicate logic on the critical paths
+                only, which buys depth for less area than ``duplicate`` does.
+            timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
+            verbose: If ``True``, print everything ABC wrote.
+            binary: Overrides the resolved ABC executable for this call only.
 
-    Args:
-        ntk: The network to optimize.
-        preserve_levels: If ``True`` (ABC's default), never increase the depth.
-        zero_cost: If ``True``, also apply replacements that do not reduce the
-            size, which perturbs the structure and can unlock later gains.
-        timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
-        verbose: If ``True``, print everything ABC wrote.
-        binary: Overrides the resolved ABC executable for this call only.
-
-    Returns:
-        The optimized network, of the same type as ``ntk``.
-    """
-    command = "rewrite"
-    if not preserve_levels:
-        command += " -l"
-    if zero_cost:
-        command += " -z"
-    return run_script(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
-
-
-def refactor(
-    ntk: AigT,
-    *,
-    max_support: int | None = None,
-    min_saved: int | None = None,
-    preserve_levels: bool = True,
-    zero_cost: bool = False,
-    timeout: float | None = None,
-    verbose: bool = False,
-    binary: str | os.PathLike[str] | None = None,
-) -> AigT:
-    """Runs ABC's ``refactor`` command on a network.
-
-    Collapses a cone into a single node and resynthesizes it from its truth
-    table, which reaches larger cuts than :func:`rewrite` does.
-
-    Args:
-        ntk: The network to optimize.
-        max_support: Maximum support of a collapsed node (ABC's ``-N``, 1 to 15),
-            or ``None`` for ABC's default of 10. Larger values are slower. ABC
-            documents no range but rejects anything above 15.
-        min_saved: Minimum number of nodes a single step must save to be applied
-            (ABC's ``-M``, at least 0), or ``None`` for ABC's default of 1.
-            Setting it to 0 accepts steps that save nothing.
-        preserve_levels: If ``True`` (ABC's default), never increase the depth.
-        zero_cost: If ``True``, also apply replacements that do not reduce the
-            size, which perturbs the structure and can unlock later gains.
-        timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
-        verbose: If ``True``, print everything ABC wrote.
-        binary: Overrides the resolved ABC executable for this call only.
-
-    Returns:
-        The optimized network, of the same type as ``ntk``.
-
-    Raises:
-        ValueError: If ``max_support`` is outside the range ABC accepts.
-    """
-    command = "refactor"
-    if max_support is not None:
-        check_option("refactor", "N", max_support, name="max_support")
-        command += f" -N {max_support}"
-    if min_saved is not None:
-        check_option("refactor", "M", min_saved, name="min_saved")
-        command += f" -M {min_saved}"
-    if not preserve_levels:
-        command += " -l"
-    if zero_cost:
-        command += " -z"
-    return run_script(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
+        Returns:
+            The optimized network, of the same type as ``ntk``.
+        """
+        command = self.cmd(
+            minimize_levels=minimize_levels,
+            exor=exor,
+            duplicate=duplicate,
+            duplicate_critical=duplicate_critical,
+        )
+        return run_script(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
 
 
-def resub(
-    ntk: AigT,
-    *,
-    max_cut_size: int | None = None,
-    max_inserts: int | None = None,
-    min_saved: int | None = None,
-    odc_levels: int | None = None,
-    preserve_levels: bool = True,
-    zero_cost: bool = False,
-    timeout: float | None = None,
-    verbose: bool = False,
-    binary: str | os.PathLike[str] | None = None,
-) -> AigT:
-    """Runs ABC's ``resub`` command on a network.
-
-    Re-expresses a node in terms of other nodes already present, which removes
-    logic that rewriting and refactoring cannot reach because it is not local.
-
-    Args:
-        ntk: The network to optimize.
-        max_cut_size: Maximum cut size (ABC's ``-K``, 4 to 16), or ``None`` for
-            ABC's default of 8. The canonical scripts sweep this from 6 to 12.
-        max_inserts: Maximum number of nodes to add (ABC's ``-N``, 0 to 3), or
-            ``None`` for ABC's default of 1.
-        min_saved: Minimum number of nodes a single step must save to be applied
-            (ABC's ``-M``, at least 0), or ``None`` for ABC's default of 1.
-        odc_levels: Fanout levels used for observability-don't-care computation
-            (ABC's ``-F``, at least 0), or ``None`` for ABC's default of 0, which
-            disables it. Don't-cares find substitutions that are only valid in
-            context, at the cost of a more expensive analysis.
-        preserve_levels: If ``True`` (ABC's default), never increase the depth.
-        zero_cost: If ``True``, also apply replacements that do not reduce the
-            size, which perturbs the structure and can unlock later gains.
-        timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
-        verbose: If ``True``, print everything ABC wrote.
-        binary: Overrides the resolved ABC executable for this call only.
-
-    Returns:
-        The optimized network, of the same type as ``ntk``.
-
-    Raises:
-        ValueError: If ``max_cut_size`` or ``max_inserts`` is outside the range
-            ABC accepts.
-    """
-    command = "resub"
-    if max_cut_size is not None:
-        check_option("resub", "K", max_cut_size, name="max_cut_size")
-        command += f" -K {max_cut_size}"
-    if max_inserts is not None:
-        check_option("resub", "N", max_inserts, name="max_inserts")
-        command += f" -N {max_inserts}"
-    if min_saved is not None:
-        check_option("resub", "M", min_saved, name="min_saved")
-        command += f" -M {min_saved}"
-    if odc_levels is not None:
-        check_option("resub", "F", odc_levels, name="odc_levels")
-        command += f" -F {odc_levels}"
-    if not preserve_levels:
-        command += " -l"
-    if zero_cost:
-        command += " -z"
-    return run_script(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
+#: Runs ABC's ``balance`` command on a network, or builds it as a command.
+balance = _Balance()
 
 
-def orchestrate(
-    ntk: AigT,
-    *,
-    max_cut_size: int | None = None,
-    max_inserts: int | None = None,
-    odc_levels: int | None = None,
-    preserve_levels: bool = True,
-    zero_cost_rewrite: bool = True,
-    zero_cost_refactor: bool = True,
-    timeout: float | None = None,
-    verbose: bool = False,
-    binary: str | os.PathLike[str] | None = None,
-) -> AigT:
-    """Runs ABC's ``orchestrate`` command on a network.
+class _Rewrite:
+    """Runs ABC's ``rewrite`` command on a network, or builds it as a command."""
 
-    Interleaves rewriting, refactoring and resubstitution rather than running
-    them one after another, choosing per node which of the three to apply. It is
-    a single command doing the job of a whole schedule.
+    @staticmethod
+    def cmd(*, preserve_levels: bool = True, zero_cost: bool = False) -> Command:
+        """Builds ABC's ``rewrite`` command without running it.
 
-    Note that ABC enables zero-cost replacements here by default, unlike in the
-    standalone :func:`rewrite` and :func:`refactor` commands.
+        Args:
+            preserve_levels: If ``True`` (ABC's default), never increase the depth.
+            zero_cost: If ``True``, also apply replacements that do not reduce the
+                size, which perturbs the structure and can unlock later gains.
 
-    Args:
-        ntk: The network to optimize.
-        max_cut_size: Resubstitution cut size (ABC's ``-K``, 4 to 16), or ``None``
-            for ABC's default of 8.
-        max_inserts: Nodes resubstitution may add (ABC's ``-N``, 0 to 3), or
-            ``None`` for ABC's default of 1.
-        odc_levels: Fanout levels used for don't-care computation (ABC's ``-F``),
-            or ``None`` for ABC's default of 0.
-        preserve_levels: If ``True`` (ABC's default), never increase the depth.
-        zero_cost_rewrite: If ``True`` (ABC's default here), let the rewriting
-            part apply replacements that do not reduce the size.
-        zero_cost_refactor: If ``True`` (ABC's default here), the same for the
-            refactoring part.
-        timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
-        verbose: If ``True``, print everything ABC wrote.
-        binary: Overrides the resolved ABC executable for this call only.
+        Returns:
+            The command, ready for :func:`~aigverse.abc.run_script` or
+            :func:`~aigverse.abc.run_many`.
+        """
+        command = "rewrite"
+        if not preserve_levels:
+            command += " -l"
+        if zero_cost:
+            command += " -z"
+        return Command(command)
 
-    Returns:
-        The optimized network, of the same type as ``ntk``.
+    def __call__(
+        self,
+        ntk: AigT,
+        *,
+        preserve_levels: bool = True,
+        zero_cost: bool = False,
+        timeout: float | None = None,
+        verbose: bool = False,
+        binary: str | os.PathLike[str] | None = None,
+    ) -> AigT:
+        """Runs ABC's ``rewrite`` command on a network.
 
-    Raises:
-        ValueError: If an option is outside the range ABC accepts.
-    """
-    command = "orchestrate"
-    if max_cut_size is not None:
-        check_option("orchestrate", "K", max_cut_size, name="max_cut_size")
-        command += f" -K {max_cut_size}"
-    if max_inserts is not None:
-        check_option("orchestrate", "N", max_inserts, name="max_inserts")
-        command += f" -N {max_inserts}"
-    if odc_levels is not None:
-        check_option("orchestrate", "F", odc_levels, name="odc_levels")
-        command += f" -F {odc_levels}"
-    # every one of these switches toggles a default of "on"
-    if not preserve_levels:
-        command += " -l"
-    if not zero_cost_rewrite:
-        command += " -z"
-    if not zero_cost_refactor:
-        command += " -Z"
-    return run_script(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
+        Replaces 4-input subgraphs with smaller pre-computed equivalents.
+
+        Args:
+            ntk: The network to optimize.
+            preserve_levels: If ``True`` (ABC's default), never increase the depth.
+            zero_cost: If ``True``, also apply replacements that do not reduce the
+                size, which perturbs the structure and can unlock later gains.
+            timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
+            verbose: If ``True``, print everything ABC wrote.
+            binary: Overrides the resolved ABC executable for this call only.
+
+        Returns:
+            The optimized network, of the same type as ``ntk``.
+        """
+        command = self.cmd(preserve_levels=preserve_levels, zero_cost=zero_cost)
+        return run_script(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
+
+
+#: Runs ABC's ``rewrite`` command on a network, or builds it as a command.
+rewrite = _Rewrite()
+
+
+class _Refactor:
+    """Runs ABC's ``refactor`` command on a network, or builds it as a command."""
+
+    @staticmethod
+    def cmd(
+        *,
+        max_support: int | None = None,
+        min_saved: int | None = None,
+        preserve_levels: bool = True,
+        zero_cost: bool = False,
+    ) -> Command:
+        """Builds ABC's ``refactor`` command without running it.
+
+        Args:
+            max_support: Maximum support of a collapsed node (ABC's ``-N``, 1 to 15),
+                or ``None`` for ABC's default of 10. Larger values are slower. ABC
+                documents no range but rejects anything above 15.
+            min_saved: Minimum number of nodes a single step must save to be applied
+                (ABC's ``-M``, at least 0), or ``None`` for ABC's default of 1.
+                Setting it to 0 accepts steps that save nothing.
+            preserve_levels: If ``True`` (ABC's default), never increase the depth.
+            zero_cost: If ``True``, also apply replacements that do not reduce the
+                size, which perturbs the structure and can unlock later gains.
+
+        Returns:
+            The command, ready for :func:`~aigverse.abc.run_script` or
+            :func:`~aigverse.abc.run_many`.
+
+        Raises:
+            ValueError: If ``max_support`` is outside the range ABC accepts.
+        """
+        command = "refactor"
+        if max_support is not None:
+            check_option("refactor", "N", max_support, name="max_support")
+            command += f" -N {max_support}"
+        if min_saved is not None:
+            check_option("refactor", "M", min_saved, name="min_saved")
+            command += f" -M {min_saved}"
+        if not preserve_levels:
+            command += " -l"
+        if zero_cost:
+            command += " -z"
+        return Command(command)
+
+    def __call__(
+        self,
+        ntk: AigT,
+        *,
+        max_support: int | None = None,
+        min_saved: int | None = None,
+        preserve_levels: bool = True,
+        zero_cost: bool = False,
+        timeout: float | None = None,
+        verbose: bool = False,
+        binary: str | os.PathLike[str] | None = None,
+    ) -> AigT:
+        """Runs ABC's ``refactor`` command on a network.
+
+        Collapses a cone into a single node and resynthesizes it from its truth
+        table, which reaches larger cuts than :obj:`rewrite` does.
+
+        Args:
+            ntk: The network to optimize.
+            max_support: Maximum support of a collapsed node (ABC's ``-N``, 1 to 15),
+                or ``None`` for ABC's default of 10. Larger values are slower. ABC
+                documents no range but rejects anything above 15.
+            min_saved: Minimum number of nodes a single step must save to be applied
+                (ABC's ``-M``, at least 0), or ``None`` for ABC's default of 1.
+                Setting it to 0 accepts steps that save nothing.
+            preserve_levels: If ``True`` (ABC's default), never increase the depth.
+            zero_cost: If ``True``, also apply replacements that do not reduce the
+                size, which perturbs the structure and can unlock later gains.
+            timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
+            verbose: If ``True``, print everything ABC wrote.
+            binary: Overrides the resolved ABC executable for this call only.
+
+        Returns:
+            The optimized network, of the same type as ``ntk``.
+
+        Raises:
+            ValueError: If ``max_support`` is outside the range ABC accepts.
+        """
+        command = self.cmd(
+            max_support=max_support,
+            min_saved=min_saved,
+            preserve_levels=preserve_levels,
+            zero_cost=zero_cost,
+        )
+        return run_script(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
+
+
+#: Runs ABC's ``refactor`` command on a network, or builds it as a command.
+refactor = _Refactor()
+
+
+class _Resub:
+    """Runs ABC's ``resub`` command on a network, or builds it as a command."""
+
+    @staticmethod
+    def cmd(
+        *,
+        max_cut_size: int | None = None,
+        max_inserts: int | None = None,
+        min_saved: int | None = None,
+        odc_levels: int | None = None,
+        preserve_levels: bool = True,
+        zero_cost: bool = False,
+    ) -> Command:
+        """Builds ABC's ``resub`` command without running it.
+
+        Args:
+            max_cut_size: Maximum cut size (ABC's ``-K``, 4 to 16), or ``None`` for
+                ABC's default of 8. The canonical scripts sweep this from 6 to 12.
+            max_inserts: Maximum number of nodes to add (ABC's ``-N``, 0 to 3), or
+                ``None`` for ABC's default of 1.
+            min_saved: Minimum number of nodes a single step must save to be applied
+                (ABC's ``-M``, at least 0), or ``None`` for ABC's default of 1.
+            odc_levels: Fanout levels used for observability-don't-care computation
+                (ABC's ``-F``, at least 0), or ``None`` for ABC's default of 0, which
+                disables it. Don't-cares find substitutions that are only valid in
+                context, at the cost of a more expensive analysis.
+            preserve_levels: If ``True`` (ABC's default), never increase the depth.
+            zero_cost: If ``True``, also apply replacements that do not reduce the
+                size, which perturbs the structure and can unlock later gains.
+
+        Returns:
+            The command, ready for :func:`~aigverse.abc.run_script` or
+            :func:`~aigverse.abc.run_many`.
+
+        Raises:
+            ValueError: If ``max_cut_size`` or ``max_inserts`` is outside the range
+                ABC accepts.
+        """
+        command = "resub"
+        if max_cut_size is not None:
+            check_option("resub", "K", max_cut_size, name="max_cut_size")
+            command += f" -K {max_cut_size}"
+        if max_inserts is not None:
+            check_option("resub", "N", max_inserts, name="max_inserts")
+            command += f" -N {max_inserts}"
+        if min_saved is not None:
+            check_option("resub", "M", min_saved, name="min_saved")
+            command += f" -M {min_saved}"
+        if odc_levels is not None:
+            check_option("resub", "F", odc_levels, name="odc_levels")
+            command += f" -F {odc_levels}"
+        if not preserve_levels:
+            command += " -l"
+        if zero_cost:
+            command += " -z"
+        return Command(command)
+
+    def __call__(
+        self,
+        ntk: AigT,
+        *,
+        max_cut_size: int | None = None,
+        max_inserts: int | None = None,
+        min_saved: int | None = None,
+        odc_levels: int | None = None,
+        preserve_levels: bool = True,
+        zero_cost: bool = False,
+        timeout: float | None = None,
+        verbose: bool = False,
+        binary: str | os.PathLike[str] | None = None,
+    ) -> AigT:
+        """Runs ABC's ``resub`` command on a network.
+
+        Re-expresses a node in terms of other nodes already present, which removes
+        logic that rewriting and refactoring cannot reach because it is not local.
+
+        Args:
+            ntk: The network to optimize.
+            max_cut_size: Maximum cut size (ABC's ``-K``, 4 to 16), or ``None`` for
+                ABC's default of 8. The canonical scripts sweep this from 6 to 12.
+            max_inserts: Maximum number of nodes to add (ABC's ``-N``, 0 to 3), or
+                ``None`` for ABC's default of 1.
+            min_saved: Minimum number of nodes a single step must save to be applied
+                (ABC's ``-M``, at least 0), or ``None`` for ABC's default of 1.
+            odc_levels: Fanout levels used for observability-don't-care computation
+                (ABC's ``-F``, at least 0), or ``None`` for ABC's default of 0, which
+                disables it. Don't-cares find substitutions that are only valid in
+                context, at the cost of a more expensive analysis.
+            preserve_levels: If ``True`` (ABC's default), never increase the depth.
+            zero_cost: If ``True``, also apply replacements that do not reduce the
+                size, which perturbs the structure and can unlock later gains.
+            timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
+            verbose: If ``True``, print everything ABC wrote.
+            binary: Overrides the resolved ABC executable for this call only.
+
+        Returns:
+            The optimized network, of the same type as ``ntk``.
+
+        Raises:
+            ValueError: If ``max_cut_size`` or ``max_inserts`` is outside the range
+                ABC accepts.
+        """
+        command = self.cmd(
+            max_cut_size=max_cut_size,
+            max_inserts=max_inserts,
+            min_saved=min_saved,
+            odc_levels=odc_levels,
+            preserve_levels=preserve_levels,
+            zero_cost=zero_cost,
+        )
+        return run_script(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
+
+
+#: Runs ABC's ``resub`` command on a network, or builds it as a command.
+resub = _Resub()
+
+
+class _Orchestrate:
+    """Runs ABC's ``orchestrate`` command on a network, or builds it as a command."""
+
+    @staticmethod
+    def cmd(
+        *,
+        max_cut_size: int | None = None,
+        max_inserts: int | None = None,
+        odc_levels: int | None = None,
+        preserve_levels: bool = True,
+        zero_cost_rewrite: bool = True,
+        zero_cost_refactor: bool = True,
+    ) -> Command:
+        """Builds ABC's ``orchestrate`` command without running it.
+
+        Args:
+            max_cut_size: Resubstitution cut size (ABC's ``-K``, 4 to 16), or ``None``
+                for ABC's default of 8.
+            max_inserts: Nodes resubstitution may add (ABC's ``-N``, 0 to 3), or
+                ``None`` for ABC's default of 1.
+            odc_levels: Fanout levels used for don't-care computation (ABC's ``-F``),
+                or ``None`` for ABC's default of 0.
+            preserve_levels: If ``True`` (ABC's default), never increase the depth.
+            zero_cost_rewrite: If ``True`` (ABC's default here), let the rewriting
+                part apply replacements that do not reduce the size.
+            zero_cost_refactor: If ``True`` (ABC's default here), the same for the
+                refactoring part.
+
+        Returns:
+            The command, ready for :func:`~aigverse.abc.run_script` or
+            :func:`~aigverse.abc.run_many`.
+
+        Raises:
+            ValueError: If an option is outside the range ABC accepts.
+        """
+        command = "orchestrate"
+        if max_cut_size is not None:
+            check_option("orchestrate", "K", max_cut_size, name="max_cut_size")
+            command += f" -K {max_cut_size}"
+        if max_inserts is not None:
+            check_option("orchestrate", "N", max_inserts, name="max_inserts")
+            command += f" -N {max_inserts}"
+        if odc_levels is not None:
+            check_option("orchestrate", "F", odc_levels, name="odc_levels")
+            command += f" -F {odc_levels}"
+        # every one of these switches toggles a default of "on"
+        if not preserve_levels:
+            command += " -l"
+        if not zero_cost_rewrite:
+            command += " -z"
+        if not zero_cost_refactor:
+            command += " -Z"
+        return Command(command)
+
+    def __call__(
+        self,
+        ntk: AigT,
+        *,
+        max_cut_size: int | None = None,
+        max_inserts: int | None = None,
+        odc_levels: int | None = None,
+        preserve_levels: bool = True,
+        zero_cost_rewrite: bool = True,
+        zero_cost_refactor: bool = True,
+        timeout: float | None = None,
+        verbose: bool = False,
+        binary: str | os.PathLike[str] | None = None,
+    ) -> AigT:
+        """Runs ABC's ``orchestrate`` command on a network.
+
+        Interleaves rewriting, refactoring and resubstitution rather than running
+        them one after another, choosing per node which of the three to apply. It is
+        a single command doing the job of a whole schedule.
+
+        Note that ABC enables zero-cost replacements here by default, unlike in the
+        standalone :obj:`rewrite` and :obj:`refactor` commands.
+
+        Args:
+            ntk: The network to optimize.
+            max_cut_size: Resubstitution cut size (ABC's ``-K``, 4 to 16), or ``None``
+                for ABC's default of 8.
+            max_inserts: Nodes resubstitution may add (ABC's ``-N``, 0 to 3), or
+                ``None`` for ABC's default of 1.
+            odc_levels: Fanout levels used for don't-care computation (ABC's ``-F``),
+                or ``None`` for ABC's default of 0.
+            preserve_levels: If ``True`` (ABC's default), never increase the depth.
+            zero_cost_rewrite: If ``True`` (ABC's default here), let the rewriting
+                part apply replacements that do not reduce the size.
+            zero_cost_refactor: If ``True`` (ABC's default here), the same for the
+                refactoring part.
+            timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
+            verbose: If ``True``, print everything ABC wrote.
+            binary: Overrides the resolved ABC executable for this call only.
+
+        Returns:
+            The optimized network, of the same type as ``ntk``.
+
+        Raises:
+            ValueError: If an option is outside the range ABC accepts.
+        """
+        command = self.cmd(
+            max_cut_size=max_cut_size,
+            max_inserts=max_inserts,
+            odc_levels=odc_levels,
+            preserve_levels=preserve_levels,
+            zero_cost_rewrite=zero_cost_rewrite,
+            zero_cost_refactor=zero_cost_refactor,
+        )
+        return run_script(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
+
+
+#: Runs ABC's ``orchestrate`` command on a network, or builds it as a command.
+orchestrate = _Orchestrate()

--- a/python/aigverse/abc/_commands.py
+++ b/python/aigverse/abc/_commands.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Final
 
 from ._options import check_option
-from ._runner import AigT, Command, run_script
+from ._runner import AigT, Command, CommandWrapper, run_script
 
 if TYPE_CHECKING:
     import os
@@ -42,7 +42,7 @@ __all__ = [
 ]
 
 
-class Balance:
+class Balance(CommandWrapper):
     """Runs ABC's ``balance`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -120,7 +120,7 @@ balance: Final[Balance] = Balance()
 """Runs ABC's ``balance`` command on a network, or builds it as a command; see :class:`Balance`."""
 
 
-class Rewrite:
+class Rewrite(CommandWrapper):
     """Runs ABC's ``rewrite`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -177,7 +177,7 @@ rewrite: Final[Rewrite] = Rewrite()
 """Runs ABC's ``rewrite`` command on a network, or builds it as a command; see :class:`Rewrite`."""
 
 
-class Refactor:
+class Refactor(CommandWrapper):
     """Runs ABC's ``refactor`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -272,7 +272,7 @@ refactor: Final[Refactor] = Refactor()
 """Runs ABC's ``refactor`` command on a network, or builds it as a command; see :class:`Refactor`."""
 
 
-class Resub:
+class Resub(CommandWrapper):
     """Runs ABC's ``resub`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -389,7 +389,7 @@ resub: Final[Resub] = Resub()
 """Runs ABC's ``resub`` command on a network, or builds it as a command; see :class:`Resub`."""
 
 
-class Orchestrate:
+class Orchestrate(CommandWrapper):
     """Runs ABC's ``orchestrate`` command on a network, or builds it as a command."""
 
     @staticmethod

--- a/python/aigverse/abc/_commands.py
+++ b/python/aigverse/abc/_commands.py
@@ -116,8 +116,8 @@ class Balance:
         return run_script(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
 
 
-#: Runs ABC's ``balance`` command on a network, or builds it as a command.
 balance: Final[Balance] = Balance()
+"""Runs ABC's ``balance`` command on a network, or builds it as a command; see :class:`Balance`."""
 
 
 class Rewrite:
@@ -173,8 +173,8 @@ class Rewrite:
         return run_script(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
 
 
-#: Runs ABC's ``rewrite`` command on a network, or builds it as a command.
 rewrite: Final[Rewrite] = Rewrite()
+"""Runs ABC's ``rewrite`` command on a network, or builds it as a command; see :class:`Rewrite`."""
 
 
 class Refactor:
@@ -268,8 +268,8 @@ class Refactor:
         return run_script(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
 
 
-#: Runs ABC's ``refactor`` command on a network, or builds it as a command.
 refactor: Final[Refactor] = Refactor()
+"""Runs ABC's ``refactor`` command on a network, or builds it as a command; see :class:`Refactor`."""
 
 
 class Resub:
@@ -385,8 +385,8 @@ class Resub:
         return run_script(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
 
 
-#: Runs ABC's ``resub`` command on a network, or builds it as a command.
 resub: Final[Resub] = Resub()
+"""Runs ABC's ``resub`` command on a network, or builds it as a command; see :class:`Resub`."""
 
 
 class Orchestrate:
@@ -500,5 +500,5 @@ class Orchestrate:
         return run_script(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
 
 
-#: Runs ABC's ``orchestrate`` command on a network, or builds it as a command.
 orchestrate: Final[Orchestrate] = Orchestrate()
+"""Runs ABC's ``orchestrate`` command on a network, or builds it as a command; see :class:`Orchestrate`."""

--- a/python/aigverse/abc/_commands.py
+++ b/python/aigverse/abc/_commands.py
@@ -20,7 +20,7 @@ that ``preserve_levels=False`` reads as what it does.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from ._options import check_option
 from ._runner import AigT, Command, run_script
@@ -28,10 +28,21 @@ from ._runner import AigT, Command, run_script
 if TYPE_CHECKING:
     import os
 
-__all__ = ["balance", "orchestrate", "refactor", "resub", "rewrite"]
+__all__ = [
+    "Balance",
+    "Orchestrate",
+    "Refactor",
+    "Resub",
+    "Rewrite",
+    "balance",
+    "orchestrate",
+    "refactor",
+    "resub",
+    "rewrite",
+]
 
 
-class _Balance:
+class Balance:
     """Runs ABC's ``balance`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -106,10 +117,10 @@ class _Balance:
 
 
 #: Runs ABC's ``balance`` command on a network, or builds it as a command.
-balance = _Balance()
+balance: Final[Balance] = Balance()
 
 
-class _Rewrite:
+class Rewrite:
     """Runs ABC's ``rewrite`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -163,10 +174,10 @@ class _Rewrite:
 
 
 #: Runs ABC's ``rewrite`` command on a network, or builds it as a command.
-rewrite = _Rewrite()
+rewrite: Final[Rewrite] = Rewrite()
 
 
-class _Refactor:
+class Refactor:
     """Runs ABC's ``refactor`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -258,10 +269,10 @@ class _Refactor:
 
 
 #: Runs ABC's ``refactor`` command on a network, or builds it as a command.
-refactor = _Refactor()
+refactor: Final[Refactor] = Refactor()
 
 
-class _Resub:
+class Resub:
     """Runs ABC's ``resub`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -375,10 +386,10 @@ class _Resub:
 
 
 #: Runs ABC's ``resub`` command on a network, or builds it as a command.
-resub = _Resub()
+resub: Final[Resub] = Resub()
 
 
-class _Orchestrate:
+class Orchestrate:
     """Runs ABC's ``orchestrate`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -490,4 +501,4 @@ class _Orchestrate:
 
 
 #: Runs ABC's ``orchestrate`` command on a network, or builds it as a command.
-orchestrate = _Orchestrate()
+orchestrate: Final[Orchestrate] = Orchestrate()

--- a/python/aigverse/abc/_runner.py
+++ b/python/aigverse/abc/_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import shlex
 import subprocess
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar, cast
 
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
     import os
     from collections.abc import Sequence
 
-__all__ = ["run_commands", "run_script"]
+__all__ = ["Command", "run_commands", "run_script"]
 
 AigT = TypeVar("AigT", bound=Aig)
 
@@ -67,12 +68,35 @@ def _find_error(output: str) -> str | None:
     return None
 
 
-def join_commands(commands: str | Sequence[str]) -> str:
+@dataclass(frozen=True)
+class Command:
+    """One ABC command with its switches, built without being run.
+
+    Every wrapper's ``cmd()`` returns one of these, e.g.
+    ``abc.rewrite.cmd(zero_cost=True)``. It renders as the command ABC takes, and
+    :func:`run_script`, :func:`run_commands` and
+    :func:`~aigverse.abc.run_many` accept it wherever they accept a command
+    string -- a whole script is a sequence of them.
+    """
+
+    #: The command as ABC takes it, e.g. ``"rewrite -z"``.
+    text: str
+
+    def __str__(self) -> str:
+        """Renders the command in ABC's own syntax.
+
+        Returns:
+            The command as ABC takes it.
+        """
+        return self.text
+
+
+def join_commands(commands: str | Command | Sequence[str | Command]) -> str:
     """Normalizes user-supplied ABC commands into a single command string.
 
     Args:
-        commands: A single ``;``-separated command string, or a sequence of
-            individual commands.
+        commands: A single ``;``-separated command string, a :class:`Command`, or
+            a sequence of individual commands.
 
     Returns:
         The commands as one ``;``-separated string.
@@ -80,7 +104,7 @@ def join_commands(commands: str | Sequence[str]) -> str:
     Raises:
         ValueError: If no command was given, or a command contains a NUL byte.
     """
-    joined = commands if isinstance(commands, str) else "; ".join(commands)
+    joined = str(commands) if isinstance(commands, (str, Command)) else "; ".join(str(command) for command in commands)
     if not joined.strip():
         msg = "no ABC commands given"
         raise ValueError(msg)
@@ -182,7 +206,7 @@ def check_gia_supported(ntk: Aig) -> None:
 
 
 def run_commands(
-    commands: str | Sequence[str],
+    commands: str | Command | Sequence[str | Command],
     *,
     timeout: float | None = None,
     use_init_file: bool = False,
@@ -195,8 +219,8 @@ def run_commands(
     ``version`` or ``print_stats`` on files the caller manages themselves.
 
     Args:
-        commands: A single ``;``-separated command string, or a sequence of
-            individual commands.
+        commands: A single ``;``-separated command string, a :class:`Command`,
+            or a sequence of individual commands.
         timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
         use_init_file: If ``False`` (default), ABC is invoked with ``-s`` so that
             no ``abc.rc`` is read and behaviour does not depend on the local
@@ -279,7 +303,7 @@ def run_commands(
 
 def run_script(
     ntk: AigT,
-    commands: str | Sequence[str],
+    commands: str | Command | Sequence[str | Command],
     *,
     timeout: float | None = None,
     use_init_file: bool = False,
@@ -313,8 +337,8 @@ def run_script(
 
     Args:
         ntk: The network to optimize.
-        commands: A single ``;``-separated ABC command string, or a sequence of
-            individual commands.
+        commands: A single ``;``-separated ABC command string, a
+            :class:`Command`, or a sequence of individual commands.
         timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
         use_init_file: If ``False`` (default), ABC is invoked with ``-s`` so that
             no ``abc.rc`` is read and results do not depend on the local install.

--- a/python/aigverse/abc/_runner.py
+++ b/python/aigverse/abc/_runner.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     import os
     from collections.abc import Sequence
 
-__all__ = ["Command", "run_commands", "run_script"]
+__all__ = ["Command", "CommandWrapper", "run_commands", "run_script"]
 
 AigT = TypeVar("AigT", bound=Aig)
 
@@ -89,6 +89,24 @@ class Command:
             The command as ABC takes it.
         """
         return self.text
+
+
+class CommandWrapper:
+    """What every wrapper is: callable on a network, with a ``cmd()`` that only builds.
+
+    ``abc.rewrite`` and its siblings are module-level instances of one subclass each,
+    so a subclass's lowercased name is the instance's public name, which is what
+    ``repr()`` shows in place of an object address.
+    """
+
+    def __repr__(self) -> str:
+        """Renders the wrapper as the public name it is reached by.
+
+        Returns:
+            The dotted name, e.g. ``aigverse.abc.rewrite`` or ``aigverse.abc.gia.dc2``.
+        """
+        module = type(self).__module__.removesuffix("._commands")
+        return f"{module}.{type(self).__name__.lower()}"
 
 
 def join_commands(commands: str | Command | Sequence[str | Command]) -> str:

--- a/python/aigverse/abc/gia.py
+++ b/python/aigverse/abc/gia.py
@@ -47,7 +47,15 @@ from typing import TYPE_CHECKING, overload
 from ._batch import run_many as _base_run_many
 from ._errors import AbcExecutionError, AbcTimeoutError
 from ._options import check_option
-from ._runner import AigT, budgeted_timeout, check_gia_supported, check_supported, resolve_binary, run_commands
+from ._runner import (
+    AigT,
+    Command,
+    budgeted_timeout,
+    check_gia_supported,
+    check_supported,
+    resolve_binary,
+    run_commands,
+)
 from ._runner import run_script as _base_run_script
 from ._stats import AbcStats, collect_stats
 
@@ -117,7 +125,7 @@ class CecStatus(Enum):
 
 def _run(
     ntk: AigT,
-    command: str,
+    command: Command,
     *,
     timeout: float | None,
     verbose: bool,
@@ -138,530 +146,927 @@ def _run(
     return _base_run_script(ntk, command, timeout=timeout, gia=True, verbose=verbose, binary=binary)
 
 
-def balance(
-    ntk: AigT,
-    *,
-    delay_only: bool = False,
-    and_only: bool = False,
-    strict_area: bool = False,
-    max_fanout: int | None = None,
-    timeout: float | None = None,
-    verbose: bool = False,
-    binary: str | os.PathLike[str] | None = None,
-) -> AigT:
-    """Runs ABC's ``&b`` command on a network.
-
-    The ``&``-space counterpart of :func:`~aigverse.abc.balance`. Unlike the
-    classic command it understands XOR and MUX structures, so it can restructure
-    where the classic one only re-associates AND trees.
-
-    Args:
-        ntk: The network to optimize.
-        delay_only: If ``True``, balance for delay without regard to area.
-        and_only: If ``True``, use only AND nodes instead of AND/XOR/MUX.
-        strict_area: If ``True``, control area strictly while balancing for
-            delay. Only has an effect together with ``delay_only``.
-        max_fanout: Fanout count above which a divisor is skipped (ABC's ``-N``,
-            at least 0), or ``None`` for ABC's default. Lowering it keeps the
-            command away from high-fanout nodes.
-        timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
-        verbose: If ``True``, print everything ABC wrote.
-        binary: Overrides the resolved ABC executable for this call only.
-
-    Returns:
-        The optimized network, of the same type as ``ntk``.
-
-    Raises:
-        ValueError: If ``max_fanout`` is outside the range ABC accepts.
-    """
-    command = "&b"
-    if max_fanout is not None:
-        check_option("&b", "N", max_fanout, name="max_fanout")
-        command += f" -N {max_fanout}"
-    if delay_only:
-        command += " -d"
-    if and_only:
-        command += " -a"
-    if strict_area:
-        command += " -s"
-    return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
-
-
-def resub(
-    ntk: AigT,
-    *,
-    max_inserts: int | None = None,
-    max_support: int | None = None,
-    max_divisors: int | None = None,
-    timeout: float | None = None,
-    verbose: bool = False,
-    binary: str | os.PathLike[str] | None = None,
-) -> AigT:
-    """Runs ABC's ``&resub`` command on a network.
-
-    The ``&``-space counterpart of :func:`~aigverse.abc.resub`.
-
-    Args:
-        ntk: The network to optimize.
-        max_inserts: Limit on the number of nodes added (ABC's ``-N``, at least
-            0), or ``None`` for ABC's default.
-        max_support: Limit on the support size (ABC's ``-S``, at least 1), or
-            ``None`` for ABC's default.
-        max_divisors: Limit on the divisor count (ABC's ``-D``, at least 1), or
-            ``None`` for ABC's default.
-        timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
-        verbose: If ``True``, print everything ABC wrote.
-        binary: Overrides the resolved ABC executable for this call only.
-
-    Returns:
-        The optimized network, of the same type as ``ntk``.
-
-    Raises:
-        ValueError: If a limit is outside the range ABC accepts.
-    """
-    command = "&resub"
-    for switch, value, name in (
-        ("N", max_inserts, "max_inserts"),
-        ("S", max_support, "max_support"),
-        ("D", max_divisors, "max_divisors"),
-    ):
-        if value is None:
-            continue
-        check_option("&resub", switch, value, name=name)
-        command += f" -{switch} {value}"
-    return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
-
-
-def dc2(
-    ntk: AigT,
-    *,
-    update_levels: bool = True,
-    timeout: float | None = None,
-    verbose: bool = False,
-    binary: str | os.PathLike[str] | None = None,
-) -> AigT:
-    """Runs ABC's ``&dc2`` command on a network.
-
-    Heavy rewriting, and the closest ``&``-space equivalent of
-    :func:`~aigverse.abc.rewrite` and :func:`~aigverse.abc.refactor` -- neither of
-    which has a direct ``&`` counterpart.
-
-    Args:
-        ntk: The network to optimize.
-        update_levels: If ``True`` (ABC's default), track levels while rewriting.
-        timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
-        verbose: If ``True``, print everything ABC wrote.
-        binary: Overrides the resolved ABC executable for this call only.
-
-    Returns:
-        The optimized network, of the same type as ``ntk``.
-    """
-    command = "&dc2" if update_levels else "&dc2 -l"
-    return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
-
-
-def syn2(
-    ntk: AigT,
-    *,
-    delay_relaxation: int | None = None,
-    cut_minimization: bool = False,
-    delay_optimization: bool = False,
-    coarsen: bool = True,
-    old_algorithm: bool = False,
-    timeout: float | None = None,
-    verbose: bool = False,
-    binary: str | os.PathLike[str] | None = None,
-) -> AigT:
-    """Runs ABC's ``&syn2`` script on a network.
-
-    The lightest of the three ``&`` synthesis scripts.
-
-    .. warning::
-        These scripts buy depth with area, and they spend it whether or not there
-        is depth to be had. On a design where they find none, the AND count grows
-        and nothing comes back for it -- a 16-bit carry-lookahead adder goes from
-        186 gates to 698 under ``&syn2`` here. That is ABC behaving as designed,
-        not a failure; compare the result before keeping it.
-
-    Args:
-        ntk: The network to optimize.
-        delay_relaxation: Delay relaxation ratio (ABC's ``-R``, at least 0), or
-            ``None`` for ABC's default of 20. Higher values allow more delay in
-            exchange for area.
-        cut_minimization: If ``True``, enable cut minimization.
-        delay_optimization: If ``True``, run the additional delay optimization.
-        coarsen: If ``True`` (ABC's default), coarsen the subject graph before
-            mapping, which gives the mapper larger cuts to work with.
-        old_algorithm: If ``True``, use ABC's previous implementation instead of
-            the current one.
-        timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
-        verbose: If ``True``, print everything ABC wrote.
-        binary: Overrides the resolved ABC executable for this call only.
-
-    Returns:
-        The optimized network, of the same type as ``ntk``.
-
-    Raises:
-        ValueError: If ``delay_relaxation`` is outside the range ABC accepts.
-    """
-    command = "&syn2"
-    if delay_relaxation is not None:
-        check_option("&syn2", "R", delay_relaxation, name="delay_relaxation")
-        command += f" -R {delay_relaxation}"
-    if old_algorithm:
-        command += " -a"
-    if not coarsen:
-        command += " -k"
-    if cut_minimization:
-        command += " -m"
-    if delay_optimization:
-        command += " -d"
-    return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
-
-
-def syn3(
-    ntk: AigT,
-    *,
-    timeout: float | None = None,
-    verbose: bool = False,
-    binary: str | os.PathLike[str] | None = None,
-) -> AigT:
-    """Runs ABC's ``&syn3`` script on a network.
-
-    A different restructuring schedule from :func:`syn2`; which of the two wins is
-    design-dependent, so both are worth trying.
-
-    .. warning::
-        Like :func:`syn2`, this trades area for depth and will grow the network on
-        designs where there is no depth to recover.
-
-    Args:
-        ntk: The network to optimize.
-        timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
-        verbose: If ``True``, print everything ABC wrote.
-        binary: Overrides the resolved ABC executable for this call only.
-
-    Returns:
-        The optimized network, of the same type as ``ntk``.
-    """
-    return _run(ntk, "&syn3", timeout=timeout, verbose=verbose, binary=binary)
-
-
-def syn4(
-    ntk: AigT,
-    *,
-    timeout: float | None = None,
-    verbose: bool = False,
-    binary: str | os.PathLike[str] | None = None,
-) -> AigT:
-    """Runs ABC's ``&syn4`` script on a network.
-
-    The most aggressive of the three, and the one that spends the most area to
-    buy depth.
-
-    .. warning::
-        Like :func:`syn2`, this trades area for depth, and it spends the most of
-        the three. Expect the AND count to grow, sometimes considerably.
-
-    Args:
-        ntk: The network to optimize.
-        timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
-        verbose: If ``True``, print everything ABC wrote.
-        binary: Overrides the resolved ABC executable for this call only.
-
-    Returns:
-        The optimized network, of the same type as ``ntk``.
-    """
-    return _run(ntk, "&syn4", timeout=timeout, verbose=verbose, binary=binary)
-
-
-def fraig(
-    ntk: AigT,
-    *,
-    conflict_limit: int | None = None,
-    timeout: float | None = None,
-    verbose: bool = False,
-    binary: str | os.PathLike[str] | None = None,
-) -> AigT:
-    """Runs ABC's ``&fraig`` command on a network.
-
-    Combinational SAT sweeping: proves internal nodes functionally equivalent and
-    merges them. This removes redundancy that no amount of structural rewriting
-    can see, which makes it a good final pass -- and a good one to run *between*
-    two structural scripts that each introduced their own duplicates.
-
-    Args:
-        ntk: The network to optimize.
-        conflict_limit: Maximum SAT conflicts per node (ABC's ``-C``, at least 0),
-            or ``None`` for ABC's default. Lower values bound the runtime on hard
-            instances at the cost of missing some merges. It is the only one of
-            ``&fraig``'s two dozen switches wrapped here; the rest tune the SAT
-            sweeper internally and are reachable through :func:`run_script`.
-        timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
-        verbose: If ``True``, print everything ABC wrote.
-        binary: Overrides the resolved ABC executable for this call only.
-
-    Returns:
-        The optimized network, of the same type as ``ntk``.
-
-    Raises:
-        ValueError: If ``conflict_limit`` is outside the range ABC accepts.
-    """
-    command = "&fraig"
-    if conflict_limit is not None:
-        check_option("&fraig", "C", conflict_limit, name="conflict_limit")
-        command += f" -C {conflict_limit}"
-    return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
-
-
-def deepsyn(
-    ntk: AigT,
-    *,
-    timeout: float | None = None,
-    iterations: int | None = None,
-    patience: int | None = None,
-    stop_at_nodes: int | None = None,
-    seed: int | None = None,
-    two_input_luts: bool = False,
-    optimize: bool = False,
-    verbose: bool = False,
-    binary: str | os.PathLike[str] | None = None,
-) -> AigT:
-    """Runs ABC's ``&deepsyn`` command on a network.
-
-    A search rather than a pass: it repeatedly restructures the network with
-    randomized parameters and keeps whatever came out smallest. That makes it the
-    strongest thing in this module and also the slowest, and it means two runs
-    with different ``seed`` values can give different results.
-
-    Give it a budget. Unlike the single-pass commands, ``timeout`` here is handed
-    to ABC as its own internal limit, so ABC stops cleanly and returns the best
-    result it has found rather than being killed with nothing to show.
-
-    ABC's ``-c`` switch, which computes structural choices, is deliberately not
-    exposed: it leaves an AIG *with choices* in the GIA store, which ``&write``
-    cannot serialize -- ABC aborts on an internal assertion rather than reporting
-    an error, so the result could never come back across the bridge.
-
-    Args:
-        ntk: The network to optimize.
-        timeout: Seconds ABC may spend searching (ABC's ``-T``), or ``None`` for
-            no limit. Strongly recommended.
-        iterations: Number of search iterations (ABC's ``-I``, at least 1), or
-            ``None`` for ABC's default of 1.
-        patience: Number of steps without improvement after which the search
-            gives up (ABC's ``-J``, at least 1), or ``None`` for ABC's default,
-            which is effectively unlimited.
-        stop_at_nodes: Stop once the network is this small (ABC's ``-A``), or
-            ``None`` for no such limit.
-        seed: Random seed (ABC's ``-S``, 0 to 100), or ``None`` for ABC's default.
-        two_input_luts: If ``True``, search over two-input LUTs.
-        optimize: If ``True``, enable ABC's additional optimization step.
-        verbose: If ``True``, print everything ABC wrote.
-        binary: Overrides the resolved ABC executable for this call only.
-
-    Returns:
-        The optimized network, of the same type as ``ntk``.
-
-    Raises:
-        ValueError: If an option is outside the range ABC accepts.
-    """
-    command = "&deepsyn"
-    # switches in ABC's own order, with the budget handed over as `-T` so that
-    # ABC stops on its own terms and keeps the best result it has found
-    for switch, value, name in (
-        ("I", iterations, "iterations"),
-        ("J", patience, "patience"),
-        ("T", None if timeout is None else int(timeout), "timeout"),
-        ("A", stop_at_nodes, "stop_at_nodes"),
-        ("S", seed, "seed"),
-    ):
-        if value is None:
-            continue
-        check_option("&deepsyn", switch, value, name=name)
-        command += f" -{switch} {value}"
-    if two_input_luts:
-        command += " -t"
-    if optimize:
-        command += " -o"
-    return _run(ntk, command, timeout=budgeted_timeout(timeout), verbose=verbose, binary=binary)
-
-
-def transduction(
-    ntk: AigT,
-    *,
-    transduction_type: int | None = None,
-    fanin_sort: int | None = None,
-    script_parameters: int | None = None,
-    seed: int | None = None,
-    randomize_seed: int | None = None,
-    truth_tables: bool = False,
-    mspf: bool = False,
-    preserve_levels: bool = False,
-    timeout: float | None = None,
-    verbose: bool = False,
-    binary: str | os.PathLike[str] | None = None,
-) -> AigT:
-    """Runs ABC's ``&transduction`` command on a network.
-
-    Transduction reasons about permissible functions node by node, so it finds
-    redundancy that structural rewriting cannot. It is BDD-based and its cost
-    grows steeply with the network, so it is realistically limited to small
-    designs -- treat a few thousand AND nodes as the upper end and pass a
-    ``timeout``.
-
-    ABC offers no internal budget for this command, so ``timeout`` kills the
-    process and yields nothing.
-
-    Contributed to ABC by Yukio Miyasaka.
-
-    Args:
-        ntk: The network to optimize.
-        transduction_type: Which variant to run (ABC's ``-T``, 0 to 8), or
-            ``None`` for ABC's default of 1 (``Resub``). Types 6 to 8 are the
-            repeat scripts and are considerably more expensive.
-        fanin_sort: Order in which fanins are visited (ABC's ``-S``, 0 to 4), or
-            ``None`` for ABC's default of 0 (topological). The order decides which
-            of several valid reductions is found first.
-        script_parameters: Parameters for the repeat scripts (ABC's ``-P``, at
-            least 0), or ``None`` for ABC's default of 0. Only meaningful for
-            ``transduction_type`` 6 to 8.
-        seed: Seed used to shuffle the inputs (ABC's ``-I``), or ``None`` not to
-            shuffle. Different seeds explore different results.
-        randomize_seed: Seed from which *all* parameters are drawn at random
-            (ABC's ``-R``), or ``None`` to use the parameters as given. Setting it
-            overrides the individual choices above.
-        truth_tables: If ``True``, reason with truth tables instead of BDDs, which
-            is faster on small functions and infeasible on wide ones.
-        mspf: If ``True``, use maximum set of permissible functions instead of
-            compatible ones. Stronger and more expensive.
-        preserve_levels: If ``True``, do not increase the depth. ABC's default
-            here is ``False``, unlike the classic commands.
-        timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
-        verbose: If ``True``, print everything ABC wrote.
-        binary: Overrides the resolved ABC executable for this call only.
-
-    Returns:
-        The optimized network, of the same type as ``ntk``.
-
-    Raises:
-        ValueError: If an option is outside the range ABC accepts.
-    """
-    # -V 0 silences the progress report, which is on by default and would
-    # otherwise be mistaken for something having gone wrong.
-    command = "&transduction -V 0"
-    if transduction_type is not None:
-        check_option("&transduction", "T", transduction_type, name="transduction_type")
-        command += f" -T {transduction_type}"
-    for switch, value, name in (
-        ("S", fanin_sort, "fanin_sort"),
-        ("I", seed, "seed"),
-        ("P", script_parameters, "script_parameters"),
-        ("R", randomize_seed, "randomize_seed"),
-    ):
-        if value is None:
-            continue
-        check_option("&transduction", switch, value, name=name)
-        command += f" -{switch} {value}"
-    if truth_tables:
-        command += " -t"
-    if mspf:
-        command += " -m"
-    if preserve_levels:
-        command += " -l"
-    return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
-
-
-def transtoch(
-    ntk: AigT,
-    *,
-    restarts: int | None = None,
-    hops: int | None = None,
-    seed: int | None = None,
-    threads: int | None = None,
-    mspf: bool = True,
-    resub_shared: bool = True,
-    reset_hops_on_improvement: bool = True,
-    drf_hop: bool = False,
-    drf_iterate: bool = False,
-    truth_tables: bool = False,
-    start_from_smallest: bool = False,
-    start_from_given: bool = False,
-    timeout: float | None = None,
-    verbose: bool = False,
-    binary: str | os.PathLike[str] | None = None,
-) -> AigT:
-    """Runs ABC's ``&transtoch`` command on a network.
-
-    Stochastic transduction: it runs :func:`transduction` repeatedly with
-    randomized parameters and keeps the best result. The most expensive command
-    in this module by a wide margin, and only practical on genuinely small
-    designs. Always pass a ``timeout``.
-
-    ABC offers no internal budget for this command either, so ``timeout`` kills
-    the process and yields nothing. Bound the work with ``restarts`` as well.
-
-    Contributed to ABC by Yukio Miyasaka.
-
-    Args:
-        ntk: The network to optimize.
-        restarts: Number of restarts (ABC's ``-N``), or ``None`` for ABC's
-            default. Each restart costs a full transduction run.
-        hops: Perturbation steps between restarts (ABC's ``-M``), or ``None`` for
-            ABC's default of 10.
-        seed: Random seed (ABC's ``-R``), or ``None`` for ABC's default.
-        threads: Worker threads (ABC's ``-P``, at least 1), or ``None`` for ABC's
-            default of 1.
-        mspf: If ``True`` (ABC's default here), use maximum sets of permissible
-            functions rather than compatible ones.
-        resub_shared: If ``True`` (ABC's default here), use the ``ResubShared``
-            transduction variant.
-        reset_hops_on_improvement: If ``True`` (ABC's default here), reset the hop
-            counter whenever a new minimum is found, so a productive direction is
-            followed further.
-        drf_hop: If ``True``, perturb with ``drf -z`` instead of
-            ``if; mfs2; strash``.
-        drf_iterate: If ``True``, iterate with ``drf -z`` instead of ``&dc2``.
-        truth_tables: If ``True``, reason with truth tables instead of BDDs.
-        start_from_smallest: If ``True``, restart from the smallest network found
-            so far rather than from the last one.
-        start_from_given: If ``True``, restart from the network as given rather
-            than from an intermediate result.
-        timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
-        verbose: If ``True``, print everything ABC wrote.
-        binary: Overrides the resolved ABC executable for this call only.
-
-    Returns:
-        The optimized network, of the same type as ``ntk``.
-
-    Raises:
-        ValueError: If an option is outside the range ABC accepts.
-    """
-    command = "&transtoch -V 0"
-    for switch, value, name in (
-        ("N", restarts, "restarts"),
-        ("M", hops, "hops"),
-        ("R", seed, "seed"),
-        ("P", threads, "threads"),
-    ):
-        if value is None:
-            continue
-        check_option("&transtoch", switch, value, name=name)
-        command += f" -{switch} {value}"
-    # the first three toggle a default of "on"
-    for switch, enabled in (
-        ("m", not mspf),
-        ("g", not resub_shared),
-        ("r", not reset_hops_on_improvement),
-        ("z", drf_hop),
-        ("f", drf_iterate),
-        ("t", truth_tables),
-        ("s", start_from_smallest),
-        ("o", start_from_given),
-    ):
-        if enabled:
-            command += f" -{switch}"
-    return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
+class _Balance:
+    """Runs ABC's ``&b`` command on a network, or builds it as a command."""
+
+    @staticmethod
+    def cmd(
+        *,
+        delay_only: bool = False,
+        and_only: bool = False,
+        strict_area: bool = False,
+        max_fanout: int | None = None,
+    ) -> Command:
+        """Builds ABC's ``&b`` command without running it.
+
+        Args:
+            delay_only: If ``True``, balance for delay without regard to area.
+            and_only: If ``True``, use only AND nodes instead of AND/XOR/MUX.
+            strict_area: If ``True``, control area strictly while balancing for
+                delay. Only has an effect together with ``delay_only``.
+            max_fanout: Fanout count above which a divisor is skipped (ABC's ``-N``,
+                at least 0), or ``None`` for ABC's default. Lowering it keeps the
+                command away from high-fanout nodes.
+
+        Returns:
+            The command, ready for :obj:`run_script` or :obj:`run_many`.
+
+        Raises:
+            ValueError: If ``max_fanout`` is outside the range ABC accepts.
+        """
+        command = "&b"
+        if max_fanout is not None:
+            check_option("&b", "N", max_fanout, name="max_fanout")
+            command += f" -N {max_fanout}"
+        if delay_only:
+            command += " -d"
+        if and_only:
+            command += " -a"
+        if strict_area:
+            command += " -s"
+        return Command(command)
+
+    def __call__(
+        self,
+        ntk: AigT,
+        *,
+        delay_only: bool = False,
+        and_only: bool = False,
+        strict_area: bool = False,
+        max_fanout: int | None = None,
+        timeout: float | None = None,
+        verbose: bool = False,
+        binary: str | os.PathLike[str] | None = None,
+    ) -> AigT:
+        """Runs ABC's ``&b`` command on a network.
+
+        The ``&``-space counterpart of :obj:`~aigverse.abc.balance`. Unlike the
+        classic command it understands XOR and MUX structures, so it can restructure
+        where the classic one only re-associates AND trees.
+
+        Args:
+            ntk: The network to optimize.
+            delay_only: If ``True``, balance for delay without regard to area.
+            and_only: If ``True``, use only AND nodes instead of AND/XOR/MUX.
+            strict_area: If ``True``, control area strictly while balancing for
+                delay. Only has an effect together with ``delay_only``.
+            max_fanout: Fanout count above which a divisor is skipped (ABC's ``-N``,
+                at least 0), or ``None`` for ABC's default. Lowering it keeps the
+                command away from high-fanout nodes.
+            timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
+            verbose: If ``True``, print everything ABC wrote.
+            binary: Overrides the resolved ABC executable for this call only.
+
+        Returns:
+            The optimized network, of the same type as ``ntk``.
+
+        Raises:
+            ValueError: If ``max_fanout`` is outside the range ABC accepts.
+        """
+        command = self.cmd(
+            delay_only=delay_only,
+            and_only=and_only,
+            strict_area=strict_area,
+            max_fanout=max_fanout,
+        )
+        return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
+
+
+#: Runs ABC's ``&b`` command on a network, or builds it as a command.
+balance = _Balance()
+
+
+class _Resub:
+    """Runs ABC's ``&resub`` command on a network, or builds it as a command."""
+
+    @staticmethod
+    def cmd(
+        *,
+        max_inserts: int | None = None,
+        max_support: int | None = None,
+        max_divisors: int | None = None,
+    ) -> Command:
+        """Builds ABC's ``&resub`` command without running it.
+
+        Args:
+            max_inserts: Limit on the number of nodes added (ABC's ``-N``, at least
+                0), or ``None`` for ABC's default.
+            max_support: Limit on the support size (ABC's ``-S``, at least 1), or
+                ``None`` for ABC's default.
+            max_divisors: Limit on the divisor count (ABC's ``-D``, at least 1), or
+                ``None`` for ABC's default.
+
+        Returns:
+            The command, ready for :obj:`run_script` or :obj:`run_many`.
+
+        Raises:
+            ValueError: If a limit is outside the range ABC accepts.
+        """
+        command = "&resub"
+        for switch, value, name in (
+            ("N", max_inserts, "max_inserts"),
+            ("S", max_support, "max_support"),
+            ("D", max_divisors, "max_divisors"),
+        ):
+            if value is None:
+                continue
+            check_option("&resub", switch, value, name=name)
+            command += f" -{switch} {value}"
+        return Command(command)
+
+    def __call__(
+        self,
+        ntk: AigT,
+        *,
+        max_inserts: int | None = None,
+        max_support: int | None = None,
+        max_divisors: int | None = None,
+        timeout: float | None = None,
+        verbose: bool = False,
+        binary: str | os.PathLike[str] | None = None,
+    ) -> AigT:
+        """Runs ABC's ``&resub`` command on a network.
+
+        The ``&``-space counterpart of :obj:`~aigverse.abc.resub`.
+
+        Args:
+            ntk: The network to optimize.
+            max_inserts: Limit on the number of nodes added (ABC's ``-N``, at least
+                0), or ``None`` for ABC's default.
+            max_support: Limit on the support size (ABC's ``-S``, at least 1), or
+                ``None`` for ABC's default.
+            max_divisors: Limit on the divisor count (ABC's ``-D``, at least 1), or
+                ``None`` for ABC's default.
+            timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
+            verbose: If ``True``, print everything ABC wrote.
+            binary: Overrides the resolved ABC executable for this call only.
+
+        Returns:
+            The optimized network, of the same type as ``ntk``.
+
+        Raises:
+            ValueError: If a limit is outside the range ABC accepts.
+        """
+        command = self.cmd(
+            max_inserts=max_inserts,
+            max_support=max_support,
+            max_divisors=max_divisors,
+        )
+        return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
+
+
+#: Runs ABC's ``&resub`` command on a network, or builds it as a command.
+resub = _Resub()
+
+
+class _Dc2:
+    """Runs ABC's ``&dc2`` command on a network, or builds it as a command."""
+
+    @staticmethod
+    def cmd(*, update_levels: bool = True) -> Command:
+        """Builds ABC's ``&dc2`` command without running it.
+
+        Args:
+            update_levels: If ``True`` (ABC's default), track levels while rewriting.
+
+        Returns:
+            The command, ready for :obj:`run_script` or :obj:`run_many`.
+        """
+        command = "&dc2" if update_levels else "&dc2 -l"
+        return Command(command)
+
+    def __call__(
+        self,
+        ntk: AigT,
+        *,
+        update_levels: bool = True,
+        timeout: float | None = None,
+        verbose: bool = False,
+        binary: str | os.PathLike[str] | None = None,
+    ) -> AigT:
+        """Runs ABC's ``&dc2`` command on a network.
+
+        Heavy rewriting, and the closest ``&``-space equivalent of
+        :obj:`~aigverse.abc.rewrite` and :obj:`~aigverse.abc.refactor` -- neither of
+        which has a direct ``&`` counterpart.
+
+        Args:
+            ntk: The network to optimize.
+            update_levels: If ``True`` (ABC's default), track levels while rewriting.
+            timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
+            verbose: If ``True``, print everything ABC wrote.
+            binary: Overrides the resolved ABC executable for this call only.
+
+        Returns:
+            The optimized network, of the same type as ``ntk``.
+        """
+        command = self.cmd(update_levels=update_levels)
+        return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
+
+
+#: Runs ABC's ``&dc2`` command on a network, or builds it as a command.
+dc2 = _Dc2()
+
+
+class _Syn2:
+    """Runs ABC's ``&syn2`` script on a network, or builds it as a command."""
+
+    @staticmethod
+    def cmd(
+        *,
+        delay_relaxation: int | None = None,
+        cut_minimization: bool = False,
+        delay_optimization: bool = False,
+        coarsen: bool = True,
+        old_algorithm: bool = False,
+    ) -> Command:
+        """Builds ABC's ``&syn2`` command without running it.
+
+        Args:
+            delay_relaxation: Delay relaxation ratio (ABC's ``-R``, at least 0), or
+                ``None`` for ABC's default of 20. Higher values allow more delay in
+                exchange for area.
+            cut_minimization: If ``True``, enable cut minimization.
+            delay_optimization: If ``True``, run the additional delay optimization.
+            coarsen: If ``True`` (ABC's default), coarsen the subject graph before
+                mapping, which gives the mapper larger cuts to work with.
+            old_algorithm: If ``True``, use ABC's previous implementation instead of
+                the current one.
+
+        Returns:
+            The command, ready for :obj:`run_script` or :obj:`run_many`.
+
+        Raises:
+            ValueError: If ``delay_relaxation`` is outside the range ABC accepts.
+        """
+        command = "&syn2"
+        if delay_relaxation is not None:
+            check_option("&syn2", "R", delay_relaxation, name="delay_relaxation")
+            command += f" -R {delay_relaxation}"
+        if old_algorithm:
+            command += " -a"
+        if not coarsen:
+            command += " -k"
+        if cut_minimization:
+            command += " -m"
+        if delay_optimization:
+            command += " -d"
+        return Command(command)
+
+    def __call__(
+        self,
+        ntk: AigT,
+        *,
+        delay_relaxation: int | None = None,
+        cut_minimization: bool = False,
+        delay_optimization: bool = False,
+        coarsen: bool = True,
+        old_algorithm: bool = False,
+        timeout: float | None = None,
+        verbose: bool = False,
+        binary: str | os.PathLike[str] | None = None,
+    ) -> AigT:
+        """Runs ABC's ``&syn2`` script on a network.
+
+        The lightest of the three ``&`` synthesis scripts.
+
+        .. warning::
+            These scripts buy depth with area, and they spend it whether or not there
+            is depth to be had. On a design where they find none, the AND count grows
+            and nothing comes back for it -- a 16-bit carry-lookahead adder goes from
+            186 gates to 698 under ``&syn2`` here. That is ABC behaving as designed,
+            not a failure; compare the result before keeping it.
+
+        Args:
+            ntk: The network to optimize.
+            delay_relaxation: Delay relaxation ratio (ABC's ``-R``, at least 0), or
+                ``None`` for ABC's default of 20. Higher values allow more delay in
+                exchange for area.
+            cut_minimization: If ``True``, enable cut minimization.
+            delay_optimization: If ``True``, run the additional delay optimization.
+            coarsen: If ``True`` (ABC's default), coarsen the subject graph before
+                mapping, which gives the mapper larger cuts to work with.
+            old_algorithm: If ``True``, use ABC's previous implementation instead of
+                the current one.
+            timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
+            verbose: If ``True``, print everything ABC wrote.
+            binary: Overrides the resolved ABC executable for this call only.
+
+        Returns:
+            The optimized network, of the same type as ``ntk``.
+
+        Raises:
+            ValueError: If ``delay_relaxation`` is outside the range ABC accepts.
+        """
+        command = self.cmd(
+            delay_relaxation=delay_relaxation,
+            cut_minimization=cut_minimization,
+            delay_optimization=delay_optimization,
+            coarsen=coarsen,
+            old_algorithm=old_algorithm,
+        )
+        return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
+
+
+#: Runs ABC's ``&syn2`` script on a network, or builds it as a command.
+syn2 = _Syn2()
+
+
+class _Syn3:
+    """Runs ABC's ``&syn3`` script on a network, or builds it as a command."""
+
+    @staticmethod
+    def cmd() -> Command:
+        """Builds ABC's ``&syn3`` command without running it.
+
+        Returns:
+            The command, ready for :obj:`run_script` or :obj:`run_many`.
+        """
+        return Command("&syn3")
+
+    def __call__(
+        self,
+        ntk: AigT,
+        *,
+        timeout: float | None = None,
+        verbose: bool = False,
+        binary: str | os.PathLike[str] | None = None,
+    ) -> AigT:
+        """Runs ABC's ``&syn3`` script on a network.
+
+        A different restructuring schedule from :obj:`syn2`; which of the two wins is
+        design-dependent, so both are worth trying.
+
+        .. warning::
+            Like :obj:`syn2`, this trades area for depth and will grow the network on
+            designs where there is no depth to recover.
+
+        Args:
+            ntk: The network to optimize.
+            timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
+            verbose: If ``True``, print everything ABC wrote.
+            binary: Overrides the resolved ABC executable for this call only.
+
+        Returns:
+            The optimized network, of the same type as ``ntk``.
+        """
+        return _run(ntk, self.cmd(), timeout=timeout, verbose=verbose, binary=binary)
+
+
+#: Runs ABC's ``&syn3`` script on a network, or builds it as a command.
+syn3 = _Syn3()
+
+
+class _Syn4:
+    """Runs ABC's ``&syn4`` script on a network, or builds it as a command."""
+
+    @staticmethod
+    def cmd() -> Command:
+        """Builds ABC's ``&syn4`` command without running it.
+
+        Returns:
+            The command, ready for :obj:`run_script` or :obj:`run_many`.
+        """
+        return Command("&syn4")
+
+    def __call__(
+        self,
+        ntk: AigT,
+        *,
+        timeout: float | None = None,
+        verbose: bool = False,
+        binary: str | os.PathLike[str] | None = None,
+    ) -> AigT:
+        """Runs ABC's ``&syn4`` script on a network.
+
+        The most aggressive of the three, and the one that spends the most area to
+        buy depth.
+
+        .. warning::
+            Like :obj:`syn2`, this trades area for depth, and it spends the most of
+            the three. Expect the AND count to grow, sometimes considerably.
+
+        Args:
+            ntk: The network to optimize.
+            timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
+            verbose: If ``True``, print everything ABC wrote.
+            binary: Overrides the resolved ABC executable for this call only.
+
+        Returns:
+            The optimized network, of the same type as ``ntk``.
+        """
+        return _run(ntk, self.cmd(), timeout=timeout, verbose=verbose, binary=binary)
+
+
+#: Runs ABC's ``&syn4`` script on a network, or builds it as a command.
+syn4 = _Syn4()
+
+
+class _Fraig:
+    """Runs ABC's ``&fraig`` command on a network, or builds it as a command."""
+
+    @staticmethod
+    def cmd(*, conflict_limit: int | None = None) -> Command:
+        """Builds ABC's ``&fraig`` command without running it.
+
+        Args:
+            conflict_limit: Maximum SAT conflicts per node (ABC's ``-C``, at least 0),
+                or ``None`` for ABC's default. Lower values bound the runtime on hard
+                instances at the cost of missing some merges. It is the only one of
+                ``&fraig``'s two dozen switches wrapped here; the rest tune the SAT
+                sweeper internally and are reachable through :func:`run_script`.
+
+        Returns:
+            The command, ready for :obj:`run_script` or :obj:`run_many`.
+
+        Raises:
+            ValueError: If ``conflict_limit`` is outside the range ABC accepts.
+        """
+        command = "&fraig"
+        if conflict_limit is not None:
+            check_option("&fraig", "C", conflict_limit, name="conflict_limit")
+            command += f" -C {conflict_limit}"
+        return Command(command)
+
+    def __call__(
+        self,
+        ntk: AigT,
+        *,
+        conflict_limit: int | None = None,
+        timeout: float | None = None,
+        verbose: bool = False,
+        binary: str | os.PathLike[str] | None = None,
+    ) -> AigT:
+        """Runs ABC's ``&fraig`` command on a network.
+
+        Combinational SAT sweeping: proves internal nodes functionally equivalent and
+        merges them. This removes redundancy that no amount of structural rewriting
+        can see, which makes it a good final pass -- and a good one to run *between*
+        two structural scripts that each introduced their own duplicates.
+
+        Args:
+            ntk: The network to optimize.
+            conflict_limit: Maximum SAT conflicts per node (ABC's ``-C``, at least 0),
+                or ``None`` for ABC's default. Lower values bound the runtime on hard
+                instances at the cost of missing some merges. It is the only one of
+                ``&fraig``'s two dozen switches wrapped here; the rest tune the SAT
+                sweeper internally and are reachable through :func:`run_script`.
+            timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
+            verbose: If ``True``, print everything ABC wrote.
+            binary: Overrides the resolved ABC executable for this call only.
+
+        Returns:
+            The optimized network, of the same type as ``ntk``.
+
+        Raises:
+            ValueError: If ``conflict_limit`` is outside the range ABC accepts.
+        """
+        command = self.cmd(conflict_limit=conflict_limit)
+        return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
+
+
+#: Runs ABC's ``&fraig`` command on a network, or builds it as a command.
+fraig = _Fraig()
+
+
+class _Deepsyn:
+    """Runs ABC's ``&deepsyn`` command on a network, or builds it as a command."""
+
+    @staticmethod
+    def cmd(
+        *,
+        timeout: float | None = None,
+        iterations: int | None = None,
+        patience: int | None = None,
+        stop_at_nodes: int | None = None,
+        seed: int | None = None,
+        two_input_luts: bool = False,
+        optimize: bool = False,
+    ) -> Command:
+        """Builds ABC's ``&deepsyn`` command without running it.
+
+        Unlike the single-pass commands, ``timeout`` is a switch here: it is the
+        budget ABC enforces itself (``-T``), so it belongs to the command and
+        survives into a batch.
+
+        Args:
+            timeout: Seconds ABC may spend searching (ABC's ``-T``), or ``None`` for
+                no limit. Strongly recommended.
+            iterations: Number of search iterations (ABC's ``-I``, at least 1), or
+                ``None`` for ABC's default of 1.
+            patience: Number of steps without improvement after which the search
+                gives up (ABC's ``-J``, at least 1), or ``None`` for ABC's default,
+                which is effectively unlimited.
+            stop_at_nodes: Stop once the network is this small (ABC's ``-A``), or
+                ``None`` for no such limit.
+            seed: Random seed (ABC's ``-S``, 0 to 100), or ``None`` for ABC's default.
+            two_input_luts: If ``True``, search over two-input LUTs.
+            optimize: If ``True``, enable ABC's additional optimization step.
+
+        Returns:
+            The command, ready for :obj:`run_script` or :obj:`run_many`.
+
+        Raises:
+            ValueError: If an option is outside the range ABC accepts.
+        """
+        command = "&deepsyn"
+        # switches in ABC's own order, with the budget handed over as `-T` so that
+        # ABC stops on its own terms and keeps the best result it has found
+        for switch, value, name in (
+            ("I", iterations, "iterations"),
+            ("J", patience, "patience"),
+            ("T", None if timeout is None else int(timeout), "timeout"),
+            ("A", stop_at_nodes, "stop_at_nodes"),
+            ("S", seed, "seed"),
+        ):
+            if value is None:
+                continue
+            check_option("&deepsyn", switch, value, name=name)
+            command += f" -{switch} {value}"
+        if two_input_luts:
+            command += " -t"
+        if optimize:
+            command += " -o"
+        return Command(command)
+
+    def __call__(
+        self,
+        ntk: AigT,
+        *,
+        timeout: float | None = None,
+        iterations: int | None = None,
+        patience: int | None = None,
+        stop_at_nodes: int | None = None,
+        seed: int | None = None,
+        two_input_luts: bool = False,
+        optimize: bool = False,
+        verbose: bool = False,
+        binary: str | os.PathLike[str] | None = None,
+    ) -> AigT:
+        """Runs ABC's ``&deepsyn`` command on a network.
+
+        A search rather than a pass: it repeatedly restructures the network with
+        randomized parameters and keeps whatever came out smallest. That makes it the
+        strongest thing in this module and also the slowest, and it means two runs
+        with different ``seed`` values can give different results.
+
+        Give it a budget. Unlike the single-pass commands, ``timeout`` here is handed
+        to ABC as its own internal limit, so ABC stops cleanly and returns the best
+        result it has found rather than being killed with nothing to show.
+
+        ABC's ``-c`` switch, which computes structural choices, is deliberately not
+        exposed: it leaves an AIG *with choices* in the GIA store, which ``&write``
+        cannot serialize -- ABC aborts on an internal assertion rather than reporting
+        an error, so the result could never come back across the bridge.
+
+        Args:
+            ntk: The network to optimize.
+            timeout: Seconds ABC may spend searching (ABC's ``-T``), or ``None`` for
+                no limit. Strongly recommended.
+            iterations: Number of search iterations (ABC's ``-I``, at least 1), or
+                ``None`` for ABC's default of 1.
+            patience: Number of steps without improvement after which the search
+                gives up (ABC's ``-J``, at least 1), or ``None`` for ABC's default,
+                which is effectively unlimited.
+            stop_at_nodes: Stop once the network is this small (ABC's ``-A``), or
+                ``None`` for no such limit.
+            seed: Random seed (ABC's ``-S``, 0 to 100), or ``None`` for ABC's default.
+            two_input_luts: If ``True``, search over two-input LUTs.
+            optimize: If ``True``, enable ABC's additional optimization step.
+            verbose: If ``True``, print everything ABC wrote.
+            binary: Overrides the resolved ABC executable for this call only.
+
+        Returns:
+            The optimized network, of the same type as ``ntk``.
+
+        Raises:
+            ValueError: If an option is outside the range ABC accepts.
+        """
+        command = self.cmd(
+            timeout=timeout,
+            iterations=iterations,
+            patience=patience,
+            stop_at_nodes=stop_at_nodes,
+            seed=seed,
+            two_input_luts=two_input_luts,
+            optimize=optimize,
+        )
+        return _run(ntk, command, timeout=budgeted_timeout(timeout), verbose=verbose, binary=binary)
+
+
+#: Runs ABC's ``&deepsyn`` command on a network, or builds it as a command.
+deepsyn = _Deepsyn()
+
+
+class _Transduction:
+    """Runs ABC's ``&transduction`` command on a network, or builds it as a command."""
+
+    @staticmethod
+    def cmd(
+        *,
+        transduction_type: int | None = None,
+        fanin_sort: int | None = None,
+        script_parameters: int | None = None,
+        seed: int | None = None,
+        randomize_seed: int | None = None,
+        truth_tables: bool = False,
+        mspf: bool = False,
+        preserve_levels: bool = False,
+    ) -> Command:
+        """Builds ABC's ``&transduction`` command without running it.
+
+        Args:
+            transduction_type: Which variant to run (ABC's ``-T``, 0 to 8), or
+                ``None`` for ABC's default of 1 (``Resub``). Types 6 to 8 are the
+                repeat scripts and are considerably more expensive.
+            fanin_sort: Order in which fanins are visited (ABC's ``-S``, 0 to 4), or
+                ``None`` for ABC's default of 0 (topological). The order decides which
+                of several valid reductions is found first.
+            script_parameters: Parameters for the repeat scripts (ABC's ``-P``, at
+                least 0), or ``None`` for ABC's default of 0. Only meaningful for
+                ``transduction_type`` 6 to 8.
+            seed: Seed used to shuffle the inputs (ABC's ``-I``), or ``None`` not to
+                shuffle. Different seeds explore different results.
+            randomize_seed: Seed from which *all* parameters are drawn at random
+                (ABC's ``-R``), or ``None`` to use the parameters as given. Setting it
+                overrides the individual choices above.
+            truth_tables: If ``True``, reason with truth tables instead of BDDs, which
+                is faster on small functions and infeasible on wide ones.
+            mspf: If ``True``, use maximum set of permissible functions instead of
+                compatible ones. Stronger and more expensive.
+            preserve_levels: If ``True``, do not increase the depth. ABC's default
+                here is ``False``, unlike the classic commands.
+
+        Returns:
+            The command, ready for :obj:`run_script` or :obj:`run_many`.
+
+        Raises:
+            ValueError: If an option is outside the range ABC accepts.
+        """
+        # -V 0 silences the progress report, which is on by default and would
+        # otherwise be mistaken for something having gone wrong.
+        command = "&transduction -V 0"
+        if transduction_type is not None:
+            check_option("&transduction", "T", transduction_type, name="transduction_type")
+            command += f" -T {transduction_type}"
+        for switch, value, name in (
+            ("S", fanin_sort, "fanin_sort"),
+            ("I", seed, "seed"),
+            ("P", script_parameters, "script_parameters"),
+            ("R", randomize_seed, "randomize_seed"),
+        ):
+            if value is None:
+                continue
+            check_option("&transduction", switch, value, name=name)
+            command += f" -{switch} {value}"
+        if truth_tables:
+            command += " -t"
+        if mspf:
+            command += " -m"
+        if preserve_levels:
+            command += " -l"
+        return Command(command)
+
+    def __call__(
+        self,
+        ntk: AigT,
+        *,
+        transduction_type: int | None = None,
+        fanin_sort: int | None = None,
+        script_parameters: int | None = None,
+        seed: int | None = None,
+        randomize_seed: int | None = None,
+        truth_tables: bool = False,
+        mspf: bool = False,
+        preserve_levels: bool = False,
+        timeout: float | None = None,
+        verbose: bool = False,
+        binary: str | os.PathLike[str] | None = None,
+    ) -> AigT:
+        """Runs ABC's ``&transduction`` command on a network.
+
+        Transduction reasons about permissible functions node by node, so it finds
+        redundancy that structural rewriting cannot. It is BDD-based and its cost
+        grows steeply with the network, so it is realistically limited to small
+        designs -- treat a few thousand AND nodes as the upper end and pass a
+        ``timeout``.
+
+        ABC offers no internal budget for this command, so ``timeout`` kills the
+        process and yields nothing.
+
+        Contributed to ABC by Yukio Miyasaka.
+
+        Args:
+            ntk: The network to optimize.
+            transduction_type: Which variant to run (ABC's ``-T``, 0 to 8), or
+                ``None`` for ABC's default of 1 (``Resub``). Types 6 to 8 are the
+                repeat scripts and are considerably more expensive.
+            fanin_sort: Order in which fanins are visited (ABC's ``-S``, 0 to 4), or
+                ``None`` for ABC's default of 0 (topological). The order decides which
+                of several valid reductions is found first.
+            script_parameters: Parameters for the repeat scripts (ABC's ``-P``, at
+                least 0), or ``None`` for ABC's default of 0. Only meaningful for
+                ``transduction_type`` 6 to 8.
+            seed: Seed used to shuffle the inputs (ABC's ``-I``), or ``None`` not to
+                shuffle. Different seeds explore different results.
+            randomize_seed: Seed from which *all* parameters are drawn at random
+                (ABC's ``-R``), or ``None`` to use the parameters as given. Setting it
+                overrides the individual choices above.
+            truth_tables: If ``True``, reason with truth tables instead of BDDs, which
+                is faster on small functions and infeasible on wide ones.
+            mspf: If ``True``, use maximum set of permissible functions instead of
+                compatible ones. Stronger and more expensive.
+            preserve_levels: If ``True``, do not increase the depth. ABC's default
+                here is ``False``, unlike the classic commands.
+            timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
+            verbose: If ``True``, print everything ABC wrote.
+            binary: Overrides the resolved ABC executable for this call only.
+
+        Returns:
+            The optimized network, of the same type as ``ntk``.
+
+        Raises:
+            ValueError: If an option is outside the range ABC accepts.
+        """
+        command = self.cmd(
+            transduction_type=transduction_type,
+            fanin_sort=fanin_sort,
+            script_parameters=script_parameters,
+            seed=seed,
+            randomize_seed=randomize_seed,
+            truth_tables=truth_tables,
+            mspf=mspf,
+            preserve_levels=preserve_levels,
+        )
+        return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
+
+
+#: Runs ABC's ``&transduction`` command on a network, or builds it as a command.
+transduction = _Transduction()
+
+
+class _Transtoch:
+    """Runs ABC's ``&transtoch`` command on a network, or builds it as a command."""
+
+    @staticmethod
+    def cmd(
+        *,
+        restarts: int | None = None,
+        hops: int | None = None,
+        seed: int | None = None,
+        threads: int | None = None,
+        mspf: bool = True,
+        resub_shared: bool = True,
+        reset_hops_on_improvement: bool = True,
+        drf_hop: bool = False,
+        drf_iterate: bool = False,
+        truth_tables: bool = False,
+        start_from_smallest: bool = False,
+        start_from_given: bool = False,
+    ) -> Command:
+        """Builds ABC's ``&transtoch`` command without running it.
+
+        Args:
+            restarts: Number of restarts (ABC's ``-N``), or ``None`` for ABC's
+                default. Each restart costs a full transduction run.
+            hops: Perturbation steps between restarts (ABC's ``-M``), or ``None`` for
+                ABC's default of 10.
+            seed: Random seed (ABC's ``-R``), or ``None`` for ABC's default.
+            threads: Worker threads (ABC's ``-P``, at least 1), or ``None`` for ABC's
+                default of 1.
+            mspf: If ``True`` (ABC's default here), use maximum sets of permissible
+                functions rather than compatible ones.
+            resub_shared: If ``True`` (ABC's default here), use the ``ResubShared``
+                transduction variant.
+            reset_hops_on_improvement: If ``True`` (ABC's default here), reset the hop
+                counter whenever a new minimum is found, so a productive direction is
+                followed further.
+            drf_hop: If ``True``, perturb with ``drf -z`` instead of
+                ``if; mfs2; strash``.
+            drf_iterate: If ``True``, iterate with ``drf -z`` instead of ``&dc2``.
+            truth_tables: If ``True``, reason with truth tables instead of BDDs.
+            start_from_smallest: If ``True``, restart from the smallest network found
+                so far rather than from the last one.
+            start_from_given: If ``True``, restart from the network as given rather
+                than from an intermediate result.
+
+        Returns:
+            The command, ready for :obj:`run_script` or :obj:`run_many`.
+
+        Raises:
+            ValueError: If an option is outside the range ABC accepts.
+        """
+        command = "&transtoch -V 0"
+        for switch, value, name in (
+            ("N", restarts, "restarts"),
+            ("M", hops, "hops"),
+            ("R", seed, "seed"),
+            ("P", threads, "threads"),
+        ):
+            if value is None:
+                continue
+            check_option("&transtoch", switch, value, name=name)
+            command += f" -{switch} {value}"
+        # the first three toggle a default of "on"
+        for switch, enabled in (
+            ("m", not mspf),
+            ("g", not resub_shared),
+            ("r", not reset_hops_on_improvement),
+            ("z", drf_hop),
+            ("f", drf_iterate),
+            ("t", truth_tables),
+            ("s", start_from_smallest),
+            ("o", start_from_given),
+        ):
+            if enabled:
+                command += f" -{switch}"
+        return Command(command)
+
+    def __call__(
+        self,
+        ntk: AigT,
+        *,
+        restarts: int | None = None,
+        hops: int | None = None,
+        seed: int | None = None,
+        threads: int | None = None,
+        mspf: bool = True,
+        resub_shared: bool = True,
+        reset_hops_on_improvement: bool = True,
+        drf_hop: bool = False,
+        drf_iterate: bool = False,
+        truth_tables: bool = False,
+        start_from_smallest: bool = False,
+        start_from_given: bool = False,
+        timeout: float | None = None,
+        verbose: bool = False,
+        binary: str | os.PathLike[str] | None = None,
+    ) -> AigT:
+        """Runs ABC's ``&transtoch`` command on a network.
+
+        Stochastic transduction: it runs :obj:`transduction` repeatedly with
+        randomized parameters and keeps the best result. The most expensive command
+        in this module by a wide margin, and only practical on genuinely small
+        designs. Always pass a ``timeout``.
+
+        ABC offers no internal budget for this command either, so ``timeout`` kills
+        the process and yields nothing. Bound the work with ``restarts`` as well.
+
+        Contributed to ABC by Yukio Miyasaka.
+
+        Args:
+            ntk: The network to optimize.
+            restarts: Number of restarts (ABC's ``-N``), or ``None`` for ABC's
+                default. Each restart costs a full transduction run.
+            hops: Perturbation steps between restarts (ABC's ``-M``), or ``None`` for
+                ABC's default of 10.
+            seed: Random seed (ABC's ``-R``), or ``None`` for ABC's default.
+            threads: Worker threads (ABC's ``-P``, at least 1), or ``None`` for ABC's
+                default of 1.
+            mspf: If ``True`` (ABC's default here), use maximum sets of permissible
+                functions rather than compatible ones.
+            resub_shared: If ``True`` (ABC's default here), use the ``ResubShared``
+                transduction variant.
+            reset_hops_on_improvement: If ``True`` (ABC's default here), reset the hop
+                counter whenever a new minimum is found, so a productive direction is
+                followed further.
+            drf_hop: If ``True``, perturb with ``drf -z`` instead of
+                ``if; mfs2; strash``.
+            drf_iterate: If ``True``, iterate with ``drf -z`` instead of ``&dc2``.
+            truth_tables: If ``True``, reason with truth tables instead of BDDs.
+            start_from_smallest: If ``True``, restart from the smallest network found
+                so far rather than from the last one.
+            start_from_given: If ``True``, restart from the network as given rather
+                than from an intermediate result.
+            timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
+            verbose: If ``True``, print everything ABC wrote.
+            binary: Overrides the resolved ABC executable for this call only.
+
+        Returns:
+            The optimized network, of the same type as ``ntk``.
+
+        Raises:
+            ValueError: If an option is outside the range ABC accepts.
+        """
+        command = self.cmd(
+            restarts=restarts,
+            hops=hops,
+            seed=seed,
+            threads=threads,
+            mspf=mspf,
+            resub_shared=resub_shared,
+            reset_hops_on_improvement=reset_hops_on_improvement,
+            drf_hop=drf_hop,
+            drf_iterate=drf_iterate,
+            truth_tables=truth_tables,
+            start_from_smallest=start_from_smallest,
+            start_from_given=start_from_given,
+        )
+        return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
+
+
+#: Runs ABC's ``&transtoch`` command on a network, or builds it as a command.
+transtoch = _Transtoch()
 
 
 def cec(
@@ -793,7 +1198,7 @@ def stats(
 
 def run_script(
     ntk: AigT,
-    commands: str | Sequence[str],
+    commands: str | Command | Sequence[str | Command],
     *,
     timeout: float | None = None,
     use_init_file: bool = False,
@@ -808,8 +1213,8 @@ def run_script(
 
     Args:
         ntk: The network to optimize.
-        commands: A single ``;``-separated ABC command string, or a sequence of
-            individual commands.
+        commands: A single ``;``-separated ABC command string, a
+            :class:`~aigverse.abc.Command`, or a sequence of individual commands.
         timeout: Seconds to wait for ABC to terminate, or ``None`` for no limit.
         use_init_file: If ``False`` (default), ABC is invoked with ``-s`` so that
             no ``abc.rc`` is read.
@@ -841,7 +1246,7 @@ def run_script(
 @overload
 def run_many(
     networks: Iterable[AigT],
-    commands: str | Sequence[str],
+    commands: str | Command | Sequence[str | Command],
     *,
     jobs: int | None = ...,
     timeout: float | None = ...,
@@ -854,7 +1259,7 @@ def run_many(
 @overload
 def run_many(
     networks: Iterable[AigT],
-    commands: str | Sequence[str],
+    commands: str | Command | Sequence[str | Command],
     *,
     jobs: int | None = ...,
     timeout: float | None = ...,
@@ -869,7 +1274,7 @@ def run_many(
 @overload
 def run_many(
     networks: Iterable[AigT],
-    commands: str | Sequence[str],
+    commands: str | Command | Sequence[str | Command],
     *,
     jobs: int | None = ...,
     timeout: float | None = ...,
@@ -881,7 +1286,7 @@ def run_many(
 
 def run_many(
     networks: Iterable[AigT],
-    commands: str | Sequence[str],
+    commands: str | Command | Sequence[str | Command],
     *,
     jobs: int | None = None,
     timeout: float | None = None,
@@ -897,8 +1302,9 @@ def run_many(
 
     Args:
         networks: The networks to optimize. Consumed in full before any work starts.
-        commands: A single ``;``-separated ABC command string, or a sequence of
-            individual commands. The same script runs on every network.
+        commands: A single ``;``-separated ABC command string, a
+            :class:`~aigverse.abc.Command`, or a sequence of individual commands.
+            The same script runs on every network.
         jobs: How many ABC processes to keep running at once. ``None`` (default)
             uses the number of CPUs available to this process, capped at the number
             of networks; ``1`` runs inline without a thread pool.

--- a/python/aigverse/abc/gia.py
+++ b/python/aigverse/abc/gia.py
@@ -242,8 +242,8 @@ class Balance:
         return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
 
 
-#: Runs ABC's ``&b`` command on a network, or builds it as a command.
 balance: Final[Balance] = Balance()
+"""Runs ABC's ``&b`` command on a network, or builds it as a command; see :class:`Balance`."""
 
 
 class Resub:
@@ -325,8 +325,8 @@ class Resub:
         return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
 
 
-#: Runs ABC's ``&resub`` command on a network, or builds it as a command.
 resub: Final[Resub] = Resub()
+"""Runs ABC's ``&resub`` command on a network, or builds it as a command; see :class:`Resub`."""
 
 
 class Dc2:
@@ -374,8 +374,8 @@ class Dc2:
         return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
 
 
-#: Runs ABC's ``&dc2`` command on a network, or builds it as a command.
 dc2: Final[Dc2] = Dc2()
+"""Runs ABC's ``&dc2`` command on a network, or builds it as a command; see :class:`Dc2`."""
 
 
 class Syn2:
@@ -478,8 +478,8 @@ class Syn2:
         return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
 
 
-#: Runs ABC's ``&syn2`` script on a network, or builds it as a command.
 syn2: Final[Syn2] = Syn2()
+"""Runs ABC's ``&syn2`` script on a network, or builds it as a command; see :class:`Syn2`."""
 
 
 class Syn3:
@@ -523,8 +523,8 @@ class Syn3:
         return _run(ntk, self.cmd(), timeout=timeout, verbose=verbose, binary=binary)
 
 
-#: Runs ABC's ``&syn3`` script on a network, or builds it as a command.
 syn3: Final[Syn3] = Syn3()
+"""Runs ABC's ``&syn3`` script on a network, or builds it as a command; see :class:`Syn3`."""
 
 
 class Syn4:
@@ -568,8 +568,8 @@ class Syn4:
         return _run(ntk, self.cmd(), timeout=timeout, verbose=verbose, binary=binary)
 
 
-#: Runs ABC's ``&syn4`` script on a network, or builds it as a command.
 syn4: Final[Syn4] = Syn4()
+"""Runs ABC's ``&syn4`` script on a network, or builds it as a command; see :class:`Syn4`."""
 
 
 class Fraig:
@@ -635,8 +635,8 @@ class Fraig:
         return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
 
 
-#: Runs ABC's ``&fraig`` command on a network, or builds it as a command.
 fraig: Final[Fraig] = Fraig()
+"""Runs ABC's ``&fraig`` command on a network, or builds it as a command; see :class:`Fraig`."""
 
 
 class Deepsyn:
@@ -766,8 +766,8 @@ class Deepsyn:
         return _run(ntk, command, timeout=budgeted_timeout(timeout), verbose=verbose, binary=binary)
 
 
-#: Runs ABC's ``&deepsyn`` command on a network, or builds it as a command.
 deepsyn: Final[Deepsyn] = Deepsyn()
+"""Runs ABC's ``&deepsyn`` command on a network, or builds it as a command; see :class:`Deepsyn`."""
 
 
 class Transduction:
@@ -913,8 +913,8 @@ class Transduction:
         return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
 
 
-#: Runs ABC's ``&transduction`` command on a network, or builds it as a command.
 transduction: Final[Transduction] = Transduction()
+"""Runs ABC's ``&transduction`` command on a network, or builds it as a command; see :class:`Transduction`."""
 
 
 class Transtoch:
@@ -1077,8 +1077,8 @@ class Transtoch:
         return _run(ntk, command, timeout=timeout, verbose=verbose, binary=binary)
 
 
-#: Runs ABC's ``&transtoch`` command on a network, or builds it as a command.
 transtoch: Final[Transtoch] = Transtoch()
+"""Runs ABC's ``&transtoch`` command on a network, or builds it as a command; see :class:`Transtoch`."""
 
 
 def cec(

--- a/python/aigverse/abc/gia.py
+++ b/python/aigverse/abc/gia.py
@@ -42,7 +42,7 @@ from __future__ import annotations
 import tempfile
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, Final, overload
 
 from ._batch import run_many as _base_run_many
 from ._errors import AbcExecutionError, AbcTimeoutError
@@ -68,7 +68,17 @@ if TYPE_CHECKING:
     from ._errors import AbcError
 
 __all__ = [
+    "Balance",
     "CecStatus",
+    "Dc2",
+    "Deepsyn",
+    "Fraig",
+    "Resub",
+    "Syn2",
+    "Syn3",
+    "Syn4",
+    "Transduction",
+    "Transtoch",
     "balance",
     "cec",
     "dc2",
@@ -146,7 +156,7 @@ def _run(
     return _base_run_script(ntk, command, timeout=timeout, gia=True, verbose=verbose, binary=binary)
 
 
-class _Balance:
+class Balance:
     """Runs ABC's ``&b`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -233,10 +243,10 @@ class _Balance:
 
 
 #: Runs ABC's ``&b`` command on a network, or builds it as a command.
-balance = _Balance()
+balance: Final[Balance] = Balance()
 
 
-class _Resub:
+class Resub:
     """Runs ABC's ``&resub`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -316,10 +326,10 @@ class _Resub:
 
 
 #: Runs ABC's ``&resub`` command on a network, or builds it as a command.
-resub = _Resub()
+resub: Final[Resub] = Resub()
 
 
-class _Dc2:
+class Dc2:
     """Runs ABC's ``&dc2`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -365,10 +375,10 @@ class _Dc2:
 
 
 #: Runs ABC's ``&dc2`` command on a network, or builds it as a command.
-dc2 = _Dc2()
+dc2: Final[Dc2] = Dc2()
 
 
-class _Syn2:
+class Syn2:
     """Runs ABC's ``&syn2`` script on a network, or builds it as a command."""
 
     @staticmethod
@@ -469,10 +479,10 @@ class _Syn2:
 
 
 #: Runs ABC's ``&syn2`` script on a network, or builds it as a command.
-syn2 = _Syn2()
+syn2: Final[Syn2] = Syn2()
 
 
-class _Syn3:
+class Syn3:
     """Runs ABC's ``&syn3`` script on a network, or builds it as a command."""
 
     @staticmethod
@@ -514,10 +524,10 @@ class _Syn3:
 
 
 #: Runs ABC's ``&syn3`` script on a network, or builds it as a command.
-syn3 = _Syn3()
+syn3: Final[Syn3] = Syn3()
 
 
-class _Syn4:
+class Syn4:
     """Runs ABC's ``&syn4`` script on a network, or builds it as a command."""
 
     @staticmethod
@@ -559,10 +569,10 @@ class _Syn4:
 
 
 #: Runs ABC's ``&syn4`` script on a network, or builds it as a command.
-syn4 = _Syn4()
+syn4: Final[Syn4] = Syn4()
 
 
-class _Fraig:
+class Fraig:
     """Runs ABC's ``&fraig`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -626,10 +636,10 @@ class _Fraig:
 
 
 #: Runs ABC's ``&fraig`` command on a network, or builds it as a command.
-fraig = _Fraig()
+fraig: Final[Fraig] = Fraig()
 
 
-class _Deepsyn:
+class Deepsyn:
     """Runs ABC's ``&deepsyn`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -647,7 +657,9 @@ class _Deepsyn:
 
         Unlike the single-pass commands, ``timeout`` is a switch here: it is the
         budget ABC enforces itself (``-T``), so it belongs to the command and
-        survives into a batch.
+        survives into a batch. What does not survive is the process backstop that
+        :obj:`deepsyn` adds on top of it, so give a batch a ``timeout`` of its own
+        for the case where ABC ignores its own budget.
 
         Args:
             timeout: Seconds ABC may spend searching (ABC's ``-T``), or ``None`` for
@@ -755,10 +767,10 @@ class _Deepsyn:
 
 
 #: Runs ABC's ``&deepsyn`` command on a network, or builds it as a command.
-deepsyn = _Deepsyn()
+deepsyn: Final[Deepsyn] = Deepsyn()
 
 
-class _Transduction:
+class Transduction:
     """Runs ABC's ``&transduction`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -902,10 +914,10 @@ class _Transduction:
 
 
 #: Runs ABC's ``&transduction`` command on a network, or builds it as a command.
-transduction = _Transduction()
+transduction: Final[Transduction] = Transduction()
 
 
-class _Transtoch:
+class Transtoch:
     """Runs ABC's ``&transtoch`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -1066,7 +1078,7 @@ class _Transtoch:
 
 
 #: Runs ABC's ``&transtoch`` command on a network, or builds it as a command.
-transtoch = _Transtoch()
+transtoch: Final[Transtoch] = Transtoch()
 
 
 def cec(

--- a/python/aigverse/abc/gia.py
+++ b/python/aigverse/abc/gia.py
@@ -50,6 +50,7 @@ from ._options import check_option
 from ._runner import (
     AigT,
     Command,
+    CommandWrapper,
     budgeted_timeout,
     check_gia_supported,
     check_supported,
@@ -156,7 +157,7 @@ def _run(
     return _base_run_script(ntk, command, timeout=timeout, gia=True, verbose=verbose, binary=binary)
 
 
-class Balance:
+class Balance(CommandWrapper):
     """Runs ABC's ``&b`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -246,7 +247,7 @@ balance: Final[Balance] = Balance()
 """Runs ABC's ``&b`` command on a network, or builds it as a command; see :class:`Balance`."""
 
 
-class Resub:
+class Resub(CommandWrapper):
     """Runs ABC's ``&resub`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -329,7 +330,7 @@ resub: Final[Resub] = Resub()
 """Runs ABC's ``&resub`` command on a network, or builds it as a command; see :class:`Resub`."""
 
 
-class Dc2:
+class Dc2(CommandWrapper):
     """Runs ABC's ``&dc2`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -378,7 +379,7 @@ dc2: Final[Dc2] = Dc2()
 """Runs ABC's ``&dc2`` command on a network, or builds it as a command; see :class:`Dc2`."""
 
 
-class Syn2:
+class Syn2(CommandWrapper):
     """Runs ABC's ``&syn2`` script on a network, or builds it as a command."""
 
     @staticmethod
@@ -482,7 +483,7 @@ syn2: Final[Syn2] = Syn2()
 """Runs ABC's ``&syn2`` script on a network, or builds it as a command; see :class:`Syn2`."""
 
 
-class Syn3:
+class Syn3(CommandWrapper):
     """Runs ABC's ``&syn3`` script on a network, or builds it as a command."""
 
     @staticmethod
@@ -527,7 +528,7 @@ syn3: Final[Syn3] = Syn3()
 """Runs ABC's ``&syn3`` script on a network, or builds it as a command; see :class:`Syn3`."""
 
 
-class Syn4:
+class Syn4(CommandWrapper):
     """Runs ABC's ``&syn4`` script on a network, or builds it as a command."""
 
     @staticmethod
@@ -572,7 +573,7 @@ syn4: Final[Syn4] = Syn4()
 """Runs ABC's ``&syn4`` script on a network, or builds it as a command; see :class:`Syn4`."""
 
 
-class Fraig:
+class Fraig(CommandWrapper):
     """Runs ABC's ``&fraig`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -639,7 +640,7 @@ fraig: Final[Fraig] = Fraig()
 """Runs ABC's ``&fraig`` command on a network, or builds it as a command; see :class:`Fraig`."""
 
 
-class Deepsyn:
+class Deepsyn(CommandWrapper):
     """Runs ABC's ``&deepsyn`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -770,7 +771,7 @@ deepsyn: Final[Deepsyn] = Deepsyn()
 """Runs ABC's ``&deepsyn`` command on a network, or builds it as a command; see :class:`Deepsyn`."""
 
 
-class Transduction:
+class Transduction(CommandWrapper):
     """Runs ABC's ``&transduction`` command on a network, or builds it as a command."""
 
     @staticmethod
@@ -917,7 +918,7 @@ transduction: Final[Transduction] = Transduction()
 """Runs ABC's ``&transduction`` command on a network, or builds it as a command; see :class:`Transduction`."""
 
 
-class Transtoch:
+class Transtoch(CommandWrapper):
     """Runs ABC's ``&transtoch`` command on a network, or builds it as a command."""
 
     @staticmethod

--- a/test/abc/test_batch.py
+++ b/test/abc/test_batch.py
@@ -18,8 +18,11 @@ from aigverse.abc import (
     AbcError,
     AbcExecutionError,
     AbcTimeoutError,
+    balance,
     expand_script,
     gia,
+    refactor,
+    rewrite,
     run_many,
     run_script,
     set_abc_binary,
@@ -487,6 +490,24 @@ def test_gia_batch_uses_the_gia_transfer(and_aig: Aig, fake_abc: Callable[[str],
     assert isinstance(failure, AbcExecutionError)
     assert "&read in.aig" in failure.command
     assert "&write out.aig" in failure.command
+
+
+@requires_posix
+def test_a_batch_takes_the_commands_the_wrappers_build(and_aig: Aig, fake_abc: Callable[[str], Path]) -> None:
+    """A schedule of parameterized commands must reach ABC as one script.
+
+    Args:
+        and_aig: A small network to batch.
+        fake_abc: Builds the stand-in executable.
+    """
+    shim = fake_abc("print(\"** cmd error: unknown command 'nope'\")\nsys.exit(0)")
+    schedule = [balance.cmd(), rewrite.cmd(zero_cost=True), refactor.cmd(max_support=12)]
+
+    results = run_many([and_aig], schedule, binary=shim, return_exceptions=True)
+
+    failure = results[0]
+    assert isinstance(failure, AbcExecutionError)
+    assert "balance; rewrite -z; refactor -N 12" in failure.command
 
 
 @requires_posix

--- a/test/abc/test_commands.py
+++ b/test/abc/test_commands.py
@@ -1,8 +1,10 @@
 """Tests for the individual ABC command wrappers.
 
-The command strings these build are asserted against a stand-in ABC that always
-fails, because the generated script is carried on the raised error. That keeps the
-argument translation covered without needing ABC installed.
+Each wrapper builds its command through `cmd()`, so the argument translation is
+asserted directly on the command it returns, without ABC and without a shim. That
+a call actually issues the command it built is pinned separately, against a
+stand-in ABC that always fails and therefore carries the generated script on the
+raised error.
 """
 
 from __future__ import annotations
@@ -14,6 +16,7 @@ import pytest
 
 from aigverse.abc import (
     AbcExecutionError,
+    Command,
     balance,
     gia,
     orchestrate,
@@ -29,7 +32,7 @@ if TYPE_CHECKING:
     from aigverse.networks import Aig
 
 # The fake-ABC shims rely on the executable bit, which does not carry over on Windows.
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="the fake ABC shims rely on POSIX executable bits")
+requires_posix = pytest.mark.skipif(sys.platform == "win32", reason="the fake ABC shims rely on POSIX executable bits")
 
 _FAILING = 'print("** cmd error: stop right there")'
 
@@ -49,22 +52,22 @@ def _command_for(run: Callable[[], object]) -> str:
 
 
 @pytest.mark.parametrize(
-    ("call", "expected"),
+    ("build", "expected"),
     [
-        (lambda ntk, abc: balance(ntk, binary=abc), "balance"),
-        (lambda ntk, abc: balance(ntk, minimize_levels=False, binary=abc), "balance -l"),
-        (lambda ntk, abc: balance(ntk, exor=True, duplicate=True, binary=abc), "balance -d -x"),
-        (lambda ntk, abc: balance(ntk, duplicate_critical=True, binary=abc), "balance -s"),
-        (lambda ntk, abc: refactor(ntk, min_saved=0, binary=abc), "refactor -M 0"),
-        (lambda ntk, abc: resub(ntk, min_saved=0, odc_levels=2, binary=abc), "resub -M 0 -F 2"),
-        (lambda ntk, abc: rewrite(ntk, binary=abc), "rewrite"),
-        (lambda ntk, abc: rewrite(ntk, zero_cost=True, binary=abc), "rewrite -z"),
-        (lambda ntk, abc: rewrite(ntk, preserve_levels=False, binary=abc), "rewrite -l"),
-        (lambda ntk, abc: refactor(ntk, binary=abc), "refactor"),
-        (lambda ntk, abc: refactor(ntk, max_support=12, zero_cost=True, binary=abc), "refactor -N 12 -z"),
-        (lambda ntk, abc: resub(ntk, binary=abc), "resub"),
-        (lambda ntk, abc: resub(ntk, max_cut_size=6, binary=abc), "resub -K 6"),
-        (lambda ntk, abc: resub(ntk, max_cut_size=12, max_inserts=2, binary=abc), "resub -K 12 -N 2"),
+        (balance.cmd, "balance"),
+        (lambda: balance.cmd(minimize_levels=False), "balance -l"),
+        (lambda: balance.cmd(exor=True, duplicate=True), "balance -d -x"),
+        (lambda: balance.cmd(duplicate_critical=True), "balance -s"),
+        (lambda: refactor.cmd(min_saved=0), "refactor -M 0"),
+        (lambda: resub.cmd(min_saved=0, odc_levels=2), "resub -M 0 -F 2"),
+        (rewrite.cmd, "rewrite"),
+        (lambda: rewrite.cmd(zero_cost=True), "rewrite -z"),
+        (lambda: rewrite.cmd(preserve_levels=False), "rewrite -l"),
+        (refactor.cmd, "refactor"),
+        (lambda: refactor.cmd(max_support=12, zero_cost=True), "refactor -N 12 -z"),
+        (resub.cmd, "resub"),
+        (lambda: resub.cmd(max_cut_size=6), "resub -K 6"),
+        (lambda: resub.cmd(max_cut_size=12, max_inserts=2), "resub -K 12 -N 2"),
     ],
     ids=[
         "balance-default",
@@ -83,88 +86,63 @@ def _command_for(run: Callable[[], object]) -> str:
         "resub-cut-size-and-inserts",
     ],
 )
-def test_options_translate_to_abc_switches(
-    call: Callable[[Aig, Path], object],
-    expected: str,
-    and_aig: Aig,
-    fake_abc: Callable[[str], Path],
-) -> None:
+def test_options_translate_to_abc_switches(build: Callable[[], Command], expected: str) -> None:
     """Keyword arguments must map onto exactly the ABC switches they claim to.
 
     Args:
-        call: Invokes the wrapper under test with a network and a binary.
+        build: Builds the command of the wrapper under test.
         expected: The ABC command the wrapper is expected to build.
-        and_aig: A minimal two-input AND network.
-        fake_abc: Factory for the stand-in ABC executable.
     """
-    shim = fake_abc(_FAILING)
-    script = _command_for(lambda: call(and_aig, shim))
-
-    # the generated script wraps the command in the read and write steps
-    assert f"; {expected}; " in script
+    assert str(build()) == expected
 
 
-def test_level_switch_is_inverted(and_aig: Aig, fake_abc: Callable[[str], Path]) -> None:
+def test_level_switch_is_inverted() -> None:
     """ABC's `-l` toggles a default of "preserve levels", so it must appear only
     when preservation is switched off -- getting this backwards silently changes
     what every wrapper optimizes for.
-
-    Args:
-        and_aig: A minimal two-input AND network.
-        fake_abc: Factory for the stand-in ABC executable.
     """
-    shim = fake_abc(_FAILING)
-    assert " -l" not in _command_for(lambda: rewrite(and_aig, preserve_levels=True, binary=shim))
-    assert " -l" in _command_for(lambda: rewrite(and_aig, preserve_levels=False, binary=shim))
+    assert " -l" not in str(rewrite.cmd(preserve_levels=True))
+    assert " -l" in str(rewrite.cmd(preserve_levels=False))
 
 
 @pytest.mark.parametrize(
-    ("call", "message"),
+    ("build", "message"),
     [
-        (lambda ntk: refactor(ntk, max_support=0), "max_support must be between 1 and 15"),
-        (lambda ntk: resub(ntk, max_cut_size=3), "max_cut_size must be between 4 and 16"),
-        (lambda ntk: resub(ntk, max_cut_size=17), "max_cut_size must be between 4 and 16"),
-        (lambda ntk: resub(ntk, max_inserts=4), "max_inserts must be between 0 and 3"),
+        (lambda: refactor.cmd(max_support=0), "max_support must be between 1 and 15"),
+        (lambda: resub.cmd(max_cut_size=3), "max_cut_size must be between 4 and 16"),
+        (lambda: resub.cmd(max_cut_size=17), "max_cut_size must be between 4 and 16"),
+        (lambda: resub.cmd(max_inserts=4), "max_inserts must be between 0 and 3"),
     ],
     ids=["refactor-support", "resub-cut-too-small", "resub-cut-too-large", "resub-inserts"],
 )
-def test_out_of_range_options_are_rejected(
-    call: Callable[[Aig], object],
-    message: str,
-    and_aig: Aig,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Values ABC would reject are caught here, before a process is started.
+def test_out_of_range_options_are_rejected(build: Callable[[], Command], message: str) -> None:
+    """Values ABC would reject are caught while the command is built, before any
+    process could be started.
 
     Args:
-        call: Invokes the wrapper under test with an out-of-range option.
+        build: Builds the command with an out-of-range option.
         message: Expected substring of the raised error.
-        and_aig: A minimal two-input AND network.
-        monkeypatch: Used to hide any installed ABC.
     """
-    monkeypatch.delenv("AIGVERSE_ABC", raising=False)
-    monkeypatch.setenv("PATH", "")
-
     with pytest.raises(ValueError, match=message):
-        call(and_aig)
+        build()
 
 
 @pytest.mark.parametrize(
-    ("call", "expected"),
+    ("build", "expected"),
     [
-        (lambda ntk, abc: gia.balance(ntk, binary=abc), "&b"),
-        (lambda ntk, abc: gia.balance(ntk, delay_only=True, and_only=True, binary=abc), "&b -d -a"),
-        (lambda ntk, abc: gia.balance(ntk, max_fanout=64, strict_area=True, binary=abc), "&b -N 64 -s"),
-        (lambda ntk, abc: gia.resub(ntk, binary=abc), "&resub"),
-        (lambda ntk, abc: gia.resub(ntk, max_inserts=2, max_support=6, binary=abc), "&resub -N 2 -S 6"),
-        (lambda ntk, abc: gia.dc2(ntk, binary=abc), "&dc2"),
-        (lambda ntk, abc: gia.dc2(ntk, update_levels=False, binary=abc), "&dc2 -l"),
-        (lambda ntk, abc: gia.syn2(ntk, binary=abc), "&syn2"),
-        (lambda ntk, abc: gia.syn2(ntk, delay_relaxation=0, binary=abc), "&syn2 -R 0"),
-        (lambda ntk, abc: gia.syn2(ntk, old_algorithm=True, coarsen=False, binary=abc), "&syn2 -a -k"),
-        (lambda ntk, abc: gia.syn3(ntk, binary=abc), "&syn3"),
-        (lambda ntk, abc: gia.syn4(ntk, binary=abc), "&syn4"),
-        (lambda ntk, abc: gia.fraig(ntk, conflict_limit=100, binary=abc), "&fraig -C 100"),
+        (gia.balance.cmd, "&b"),
+        (lambda: gia.balance.cmd(delay_only=True, and_only=True), "&b -d -a"),
+        (lambda: gia.balance.cmd(max_fanout=64, strict_area=True), "&b -N 64 -s"),
+        (gia.resub.cmd, "&resub"),
+        (lambda: gia.resub.cmd(max_inserts=2, max_support=6), "&resub -N 2 -S 6"),
+        (gia.dc2.cmd, "&dc2"),
+        (lambda: gia.dc2.cmd(update_levels=False), "&dc2 -l"),
+        (gia.syn2.cmd, "&syn2"),
+        (lambda: gia.syn2.cmd(delay_relaxation=0), "&syn2 -R 0"),
+        (lambda: gia.syn2.cmd(old_algorithm=True, coarsen=False), "&syn2 -a -k"),
+        (gia.syn3.cmd, "&syn3"),
+        (gia.syn4.cmd, "&syn4"),
+        (lambda: gia.fraig.cmd(conflict_limit=100), "&fraig -C 100"),
     ],
     ids=[
         "gia-balance-default",
@@ -182,100 +160,62 @@ def test_out_of_range_options_are_rejected(
         "gia-fraig-conflict-limit",
     ],
 )
-def test_gia_options_translate_to_abc_switches(
-    call: Callable[[Aig, Path], object],
-    expected: str,
-    and_aig: Aig,
-    fake_abc: Callable[[str], Path],
-) -> None:
-    """The `&`-space wrappers must build their commands and take the GIA path.
+def test_gia_options_translate_to_abc_switches(build: Callable[[], Command], expected: str) -> None:
+    """The `&`-space wrappers must build exactly the commands they claim to.
 
     Args:
-        call: Invokes the wrapper under test with a network and a binary.
+        build: Builds the command of the wrapper under test.
         expected: The ABC command the wrapper is expected to build.
-        and_aig: A minimal two-input AND network.
-        fake_abc: Factory for the stand-in ABC executable.
     """
-    shim = fake_abc(_FAILING)
-    script = _command_for(lambda: call(and_aig, shim))
-
-    assert f"; {expected}; " in script
-    # a `&` command against the classic store would silently see nothing.
-    # Not anchored to the start: a resource file registered via AIGVERSE_ABC_RC
-    # prepends a `source` step to what ABC is actually asked to run.
-    assert "&read in.aig" in script
-    assert "read_aiger" not in script
-    assert script.endswith("&write out.aig")
+    assert str(build()) == expected
 
 
-def test_delay_relaxation_of_zero_is_not_dropped(and_aig: Aig, fake_abc: Callable[[str], Path]) -> None:
-    """`0` is a meaningful relaxation ratio and must survive the `None` default.
-
-    Args:
-        and_aig: A minimal two-input AND network.
-        fake_abc: Factory for the stand-in ABC executable.
-    """
-    shim = fake_abc(_FAILING)
-    assert "-R 0" in _command_for(lambda: gia.syn2(and_aig, delay_relaxation=0, binary=shim))
+def test_delay_relaxation_of_zero_is_not_dropped() -> None:
+    """`0` is a meaningful relaxation ratio and must survive the `None` default."""
+    assert "-R 0" in str(gia.syn2.cmd(delay_relaxation=0))
 
 
 @pytest.mark.parametrize(
-    ("call", "message"),
+    ("build", "message"),
     [
-        (lambda ntk: gia.resub(ntk, max_inserts=-1), "max_inserts must be at least 0"),
-        (lambda ntk: gia.syn2(ntk, delay_relaxation=-1), "delay_relaxation must be at least 0"),
-        (lambda ntk: gia.fraig(ntk, conflict_limit=-1), "conflict_limit must be at least 0"),
+        (lambda: gia.resub.cmd(max_inserts=-1), "max_inserts must be at least 0"),
+        (lambda: gia.syn2.cmd(delay_relaxation=-1), "delay_relaxation must be at least 0"),
+        (lambda: gia.fraig.cmd(conflict_limit=-1), "conflict_limit must be at least 0"),
     ],
     ids=["gia-resub-inserts", "gia-syn2-relaxation", "gia-fraig-conflicts"],
 )
-def test_negative_gia_options_are_rejected(
-    call: Callable[[Aig], object],
-    message: str,
-    and_aig: Aig,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Negative limits are caught here, before a process is started.
+def test_negative_gia_options_are_rejected(build: Callable[[], Command], message: str) -> None:
+    """Negative limits are caught while the command is built.
 
     Args:
-        call: Invokes the wrapper under test with a negative option.
+        build: Builds the command with a negative option.
         message: Expected substring of the raised error.
-        and_aig: A minimal two-input AND network.
-        monkeypatch: Used to hide any installed ABC.
     """
-    monkeypatch.delenv("AIGVERSE_ABC", raising=False)
-    monkeypatch.setenv("PATH", "")
-
     with pytest.raises(ValueError, match=message):
-        call(and_aig)
+        build()
 
 
 @pytest.mark.parametrize(
-    ("call", "expected"),
+    ("build", "expected"),
     [
-        (lambda ntk, exe: orchestrate(ntk, binary=exe), "orchestrate"),
-        (lambda ntk, exe: orchestrate(ntk, max_cut_size=12, binary=exe), "orchestrate -K 12"),
+        (orchestrate.cmd, "orchestrate"),
+        (lambda: orchestrate.cmd(max_cut_size=12), "orchestrate -K 12"),
         # every one of these three toggles a default of "on" for orchestrate
-        (lambda ntk, exe: orchestrate(ntk, preserve_levels=False, binary=exe), "orchestrate -l"),
-        (lambda ntk, exe: orchestrate(ntk, zero_cost_rewrite=False, binary=exe), "orchestrate -z"),
-        (lambda ntk, exe: orchestrate(ntk, zero_cost_refactor=False, binary=exe), "orchestrate -Z"),
-        (lambda ntk, exe: gia.deepsyn(ntk, binary=exe), "&deepsyn"),
-        (lambda ntk, exe: gia.deepsyn(ntk, timeout=30, seed=7, binary=exe), "&deepsyn -T 30 -S 7"),
+        (lambda: orchestrate.cmd(preserve_levels=False), "orchestrate -l"),
+        (lambda: orchestrate.cmd(zero_cost_rewrite=False), "orchestrate -z"),
+        (lambda: orchestrate.cmd(zero_cost_refactor=False), "orchestrate -Z"),
+        (gia.deepsyn.cmd, "&deepsyn"),
+        (lambda: gia.deepsyn.cmd(timeout=30, seed=7), "&deepsyn -T 30 -S 7"),
+        (lambda: gia.deepsyn.cmd(patience=5, two_input_luts=True, optimize=True), "&deepsyn -J 5 -t -o"),
         (
-            lambda ntk, exe: gia.deepsyn(ntk, patience=5, two_input_luts=True, optimize=True, binary=exe),
-            "&deepsyn -J 5 -t -o",
-        ),
-        (
-            lambda ntk, exe: gia.transduction(ntk, fanin_sort=2, mspf=True, preserve_levels=True, binary=exe),
+            lambda: gia.transduction.cmd(fanin_sort=2, mspf=True, preserve_levels=True),
             "&transduction -V 0 -S 2 -m -l",
         ),
-        (
-            lambda ntk, exe: gia.transtoch(ntk, mspf=False, resub_shared=False, binary=exe),
-            "&transtoch -V 0 -m -g",
-        ),
-        (lambda ntk, exe: gia.transduction(ntk, binary=exe), "&transduction -V 0"),
-        (lambda ntk, exe: gia.transduction(ntk, transduction_type=8, binary=exe), "&transduction -V 0 -T 8"),
-        (lambda ntk, exe: gia.transtoch(ntk, binary=exe), "&transtoch -V 0"),
-        (lambda ntk, exe: gia.transtoch(ntk, restarts=2, threads=4, binary=exe), "&transtoch -V 0 -N 2 -P 4"),
+        (lambda: gia.transtoch.cmd(mspf=False, resub_shared=False), "&transtoch -V 0 -m -g"),
+        (gia.transduction.cmd, "&transduction -V 0"),
+        (lambda: gia.transduction.cmd(transduction_type=8), "&transduction -V 0 -T 8"),
+        (gia.transtoch.cmd, "&transtoch -V 0"),
+        (lambda: gia.transtoch.cmd(restarts=2, threads=4), "&transtoch -V 0 -N 2 -P 4"),
     ],
     ids=[
         "orchestrate-default",
@@ -294,72 +234,111 @@ def test_negative_gia_options_are_rejected(
         "transtoch-restarts-and-threads",
     ],
 )
-def test_high_effort_options_translate_to_abc_switches(
-    call: Callable[[Aig, Path], object],
-    expected: str,
-    and_aig: Aig,
-    fake_abc: Callable[[str], Path],
-) -> None:
+def test_high_effort_options_translate_to_abc_switches(build: Callable[[], Command], expected: str) -> None:
     """The high-effort wrappers must build exactly the commands they claim to.
 
     Args:
-        call: Invokes the wrapper under test with a network and a binary.
+        build: Builds the command of the wrapper under test.
         expected: The ABC command the wrapper is expected to build.
-        and_aig: A minimal two-input AND network.
-        fake_abc: Factory for the stand-in ABC executable.
     """
-    shim = fake_abc(_FAILING)
-    assert f"; {expected}; " in _command_for(lambda: call(and_aig, shim))
+    assert str(build()) == expected
 
 
-def test_orchestrate_zero_cost_defaults_are_not_inverted(and_aig: Aig, fake_abc: Callable[[str], Path]) -> None:
+def test_orchestrate_zero_cost_defaults_are_not_inverted() -> None:
     """`orchestrate` enables zero-cost replacements by default, unlike `rewrite`.
 
     Emitting `-z`/`-Z` for the default would turn them off, quietly making
     `orchestrate` weaker than ABC intends. Worth its own test because the two
     commands read the same switch in opposite directions.
+    """
+    default = str(orchestrate.cmd())
+    assert " -z" not in default
+    assert " -Z" not in default
+
+    # ... whereas the standalone command has to be asked for it
+    assert " -z" in str(rewrite.cmd(zero_cost=True))
+
+
+@pytest.mark.parametrize(
+    ("build", "message"),
+    [
+        (lambda: orchestrate.cmd(max_cut_size=3), "max_cut_size must be between 4 and 16"),
+        (lambda: orchestrate.cmd(odc_levels=-1), "odc_levels must be at least 0"),
+        (lambda: gia.deepsyn.cmd(seed=101), "seed must be between 0 and 100"),
+        (lambda: gia.deepsyn.cmd(timeout=-1), "timeout must be at least 0"),
+        (lambda: gia.transduction.cmd(transduction_type=9), "transduction_type must be between 0 and 8"),
+        (lambda: gia.transtoch.cmd(threads=0), "threads must be at least 1"),
+    ],
+    ids=["orch-cut", "orch-odc", "deepsyn-seed", "deepsyn-budget", "transduction-type", "transtoch-threads"],
+)
+def test_high_effort_out_of_range_options_are_rejected(build: Callable[[], Command], message: str) -> None:
+    """Values ABC would reject are caught while the command is built.
+
+    Args:
+        build: Builds the command with an out-of-range option.
+        message: Expected substring of the raised error.
+    """
+    with pytest.raises(ValueError, match=message):
+        build()
+
+
+def test_a_command_is_hashable_and_compares_by_its_text() -> None:
+    """A study keys its rows by command, which needs equality and hashing."""
+    assert rewrite.cmd(zero_cost=True) == rewrite.cmd(zero_cost=True)
+    assert rewrite.cmd(zero_cost=True) != rewrite.cmd()
+    assert {rewrite.cmd(zero_cost=True): "row"}[Command("rewrite -z")] == "row"
+
+
+@requires_posix
+@pytest.mark.parametrize(
+    ("call", "build"),
+    [
+        (lambda ntk, exe: rewrite(ntk, zero_cost=True, binary=exe), lambda: rewrite.cmd(zero_cost=True)),
+        (lambda ntk, exe: resub(ntk, max_cut_size=12, binary=exe), lambda: resub.cmd(max_cut_size=12)),
+        (lambda ntk, exe: orchestrate(ntk, odc_levels=2, binary=exe), lambda: orchestrate.cmd(odc_levels=2)),
+    ],
+    ids=["rewrite", "resub", "orchestrate"],
+)
+def test_a_call_issues_the_command_it_builds(
+    call: Callable[[Aig, Path], object],
+    build: Callable[[], Command],
+    and_aig: Aig,
+    fake_abc: Callable[[str], Path],
+) -> None:
+    """Calling a wrapper must send ABC exactly what its `cmd()` returns.
+
+    Args:
+        call: Invokes the wrapper under test with a network and a binary.
+        build: Builds the command the same options are expected to produce.
+        and_aig: A minimal two-input AND network.
+        fake_abc: Factory for the stand-in ABC executable.
+    """
+    shim = fake_abc(_FAILING)
+    script = _command_for(lambda: call(and_aig, shim))
+
+    # the generated script wraps the command in the read and write steps
+    assert f"; {build()}; " in script
+
+
+@requires_posix
+def test_a_gia_call_issues_its_command_through_the_gia_transfer(
+    and_aig: Aig,
+    fake_abc: Callable[[str], Path],
+) -> None:
+    """A `&`-space call must reach ABC through `&read`/`&write`.
+
+    Against the classic store the command would silently see nothing.
 
     Args:
         and_aig: A minimal two-input AND network.
         fake_abc: Factory for the stand-in ABC executable.
     """
     shim = fake_abc(_FAILING)
-    default = _command_for(lambda: orchestrate(and_aig, binary=shim))
-    assert " -z" not in default
-    assert " -Z" not in default
+    script = _command_for(lambda: gia.syn2(and_aig, delay_relaxation=0, binary=shim))
 
-    # ... whereas the standalone command has to be asked for it
-    assert " -z" in _command_for(lambda: rewrite(and_aig, zero_cost=True, binary=shim))
-
-
-@pytest.mark.parametrize(
-    ("call", "message"),
-    [
-        (lambda ntk: orchestrate(ntk, max_cut_size=3), "max_cut_size must be between 4 and 16"),
-        (lambda ntk: orchestrate(ntk, odc_levels=-1), "odc_levels must be at least 0"),
-        (lambda ntk: gia.deepsyn(ntk, seed=101), "seed must be between 0 and 100"),
-        (lambda ntk: gia.deepsyn(ntk, timeout=-1), "timeout must be at least 0"),
-        (lambda ntk: gia.transduction(ntk, transduction_type=9), "transduction_type must be between 0 and 8"),
-        (lambda ntk: gia.transtoch(ntk, threads=0), "threads must be at least 1"),
-    ],
-    ids=["orch-cut", "orch-odc", "deepsyn-seed", "deepsyn-budget", "transduction-type", "transtoch-threads"],
-)
-def test_high_effort_out_of_range_options_are_rejected(
-    call: Callable[[Aig], object],
-    message: str,
-    and_aig: Aig,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Values ABC would reject are caught before a process is started.
-
-    Args:
-        call: Invokes the wrapper under test with an out-of-range option.
-        message: Expected substring of the raised error.
-        and_aig: A minimal two-input AND network.
-        monkeypatch: Used to hide any installed ABC.
-    """
-    monkeypatch.delenv("AIGVERSE_ABC", raising=False)
-    monkeypatch.setenv("PATH", "")
-
-    with pytest.raises(ValueError, match=message):
-        call(and_aig)
+    assert f"; {gia.syn2.cmd(delay_relaxation=0)}; " in script
+    # Not anchored to the start: a resource file registered via AIGVERSE_ABC_RC
+    # prepends a `source` step to what ABC is actually asked to run.
+    assert "&read in.aig" in script
+    assert "read_aiger" not in script
+    assert script.endswith("&write out.aig")

--- a/test/abc/test_commands.py
+++ b/test/abc/test_commands.py
@@ -9,6 +9,7 @@ raised error.
 
 from __future__ import annotations
 
+import inspect
 import sys
 from typing import TYPE_CHECKING
 
@@ -387,3 +388,44 @@ def test_a_call_rejects_an_out_of_range_option_before_it_needs_abc(
 
     with pytest.raises(ValueError, match="max_support must be between 1 and 15"):
         refactor(and_aig, max_support=0)
+
+
+_WRAPPERS = {
+    "balance": balance,
+    "rewrite": rewrite,
+    "refactor": refactor,
+    "resub": resub,
+    "orchestrate": orchestrate,
+    "gia.balance": gia.balance,
+    "gia.resub": gia.resub,
+    "gia.dc2": gia.dc2,
+    "gia.syn2": gia.syn2,
+    "gia.syn3": gia.syn3,
+    "gia.syn4": gia.syn4,
+    "gia.fraig": gia.fraig,
+    "gia.deepsyn": gia.deepsyn,
+    "gia.transduction": gia.transduction,
+    "gia.transtoch": gia.transtoch,
+}
+
+
+@pytest.mark.parametrize("wrapper", _WRAPPERS.values(), ids=_WRAPPERS)
+def test_a_call_offers_exactly_the_options_its_command_builds(wrapper: object) -> None:
+    """A call forwards its options to `cmd()` by hand, so the two signatures must
+    agree, apart from the network and the run parameters, or an option added to one
+    side is silently unreachable from the other.
+
+    Args:
+        wrapper: The wrapper under test.
+    """
+    assert callable(wrapper)
+    call = inspect.signature(wrapper).parameters
+    build = inspect.signature(wrapper.cmd).parameters  # ty: ignore[unresolved-attribute]
+
+    forwarded = set(call) - {"ntk", "verbose", "binary"}
+    # deepsyn's `timeout` is an ABC switch; everywhere else it is the run limit
+    if "timeout" not in build:
+        forwarded.discard("timeout")
+    assert set(build) == forwarded
+    for name, parameter in build.items():
+        assert parameter.default == call[name].default, name

--- a/test/abc/test_commands.py
+++ b/test/abc/test_commands.py
@@ -283,22 +283,26 @@ def test_high_effort_out_of_range_options_are_rejected(build: Callable[[], Comma
 
 
 def test_a_command_is_hashable_and_compares_by_its_text() -> None:
-    """A study keys its rows by command, which needs equality and hashing."""
+    """A command is frozen, so it can key a table of results and two builds of the
+    same options are the same command.
+    """
     assert rewrite.cmd(zero_cost=True) == rewrite.cmd(zero_cost=True)
     assert rewrite.cmd(zero_cost=True) != rewrite.cmd()
     assert {rewrite.cmd(zero_cost=True): "row"}[Command("rewrite -z")] == "row"
 
 
-@requires_posix
 @pytest.mark.parametrize(
     ("call", "build"),
     [
+        (lambda ntk, exe: balance(ntk, duplicate=True, binary=exe), lambda: balance.cmd(duplicate=True)),
         (lambda ntk, exe: rewrite(ntk, zero_cost=True, binary=exe), lambda: rewrite.cmd(zero_cost=True)),
+        (lambda ntk, exe: refactor(ntk, max_support=12, binary=exe), lambda: refactor.cmd(max_support=12)),
         (lambda ntk, exe: resub(ntk, max_cut_size=12, binary=exe), lambda: resub.cmd(max_cut_size=12)),
         (lambda ntk, exe: orchestrate(ntk, odc_levels=2, binary=exe), lambda: orchestrate.cmd(odc_levels=2)),
     ],
-    ids=["rewrite", "resub", "orchestrate"],
+    ids=["balance", "rewrite", "refactor", "resub", "orchestrate"],
 )
+@requires_posix
 def test_a_call_issues_the_command_it_builds(
     call: Callable[[Aig, Path], object],
     build: Callable[[], Command],
@@ -320,25 +324,66 @@ def test_a_call_issues_the_command_it_builds(
     assert f"; {build()}; " in script
 
 
+@pytest.mark.parametrize(
+    ("call", "build"),
+    [
+        (lambda ntk, exe: gia.balance(ntk, max_fanout=64, binary=exe), lambda: gia.balance.cmd(max_fanout=64)),
+        (lambda ntk, exe: gia.resub(ntk, max_inserts=2, binary=exe), lambda: gia.resub.cmd(max_inserts=2)),
+        (lambda ntk, exe: gia.dc2(ntk, update_levels=False, binary=exe), lambda: gia.dc2.cmd(update_levels=False)),
+        (lambda ntk, exe: gia.syn2(ntk, delay_relaxation=0, binary=exe), lambda: gia.syn2.cmd(delay_relaxation=0)),
+        (lambda ntk, exe: gia.syn3(ntk, binary=exe), gia.syn3.cmd),
+        (lambda ntk, exe: gia.syn4(ntk, binary=exe), gia.syn4.cmd),
+        (lambda ntk, exe: gia.fraig(ntk, conflict_limit=100, binary=exe), lambda: gia.fraig.cmd(conflict_limit=100)),
+        (lambda ntk, exe: gia.deepsyn(ntk, seed=7, binary=exe), lambda: gia.deepsyn.cmd(seed=7)),
+        (
+            lambda ntk, exe: gia.transduction(ntk, fanin_sort=2, binary=exe),
+            lambda: gia.transduction.cmd(fanin_sort=2),
+        ),
+        (lambda ntk, exe: gia.transtoch(ntk, restarts=2, binary=exe), lambda: gia.transtoch.cmd(restarts=2)),
+    ],
+    ids=["balance", "resub", "dc2", "syn2", "syn3", "syn4", "fraig", "deepsyn", "transduction", "transtoch"],
+)
 @requires_posix
 def test_a_gia_call_issues_its_command_through_the_gia_transfer(
+    call: Callable[[Aig, Path], object],
+    build: Callable[[], Command],
     and_aig: Aig,
     fake_abc: Callable[[str], Path],
 ) -> None:
-    """A `&`-space call must reach ABC through `&read`/`&write`.
+    """A `&`-space call must send what it built, and reach ABC through `&read`.
 
     Against the classic store the command would silently see nothing.
 
     Args:
+        call: Invokes the wrapper under test with a network and a binary.
+        build: Builds the command the same options are expected to produce.
         and_aig: A minimal two-input AND network.
         fake_abc: Factory for the stand-in ABC executable.
     """
     shim = fake_abc(_FAILING)
-    script = _command_for(lambda: gia.syn2(and_aig, delay_relaxation=0, binary=shim))
+    script = _command_for(lambda: call(and_aig, shim))
 
-    assert f"; {gia.syn2.cmd(delay_relaxation=0)}; " in script
+    assert f"; {build()}; " in script
     # Not anchored to the start: a resource file registered via AIGVERSE_ABC_RC
     # prepends a `source` step to what ABC is actually asked to run.
     assert "&read in.aig" in script
     assert "read_aiger" not in script
     assert script.endswith("&write out.aig")
+
+
+def test_a_call_rejects_an_out_of_range_option_before_it_needs_abc(
+    and_aig: Aig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bad option must be a `ValueError` even where no ABC is installed, which
+    only holds while the call builds its command before resolving a binary.
+
+    Args:
+        and_aig: A minimal two-input AND network.
+        monkeypatch: Used to hide any installed ABC.
+    """
+    monkeypatch.delenv("AIGVERSE_ABC", raising=False)
+    monkeypatch.setenv("PATH", "")
+
+    with pytest.raises(ValueError, match="max_support must be between 1 and 15"):
+        refactor(and_aig, max_support=0)

--- a/test/abc/test_commands.py
+++ b/test/abc/test_commands.py
@@ -18,6 +18,7 @@ import pytest
 from aigverse.abc import (
     AbcExecutionError,
     Command,
+    CommandWrapper,
     balance,
     gia,
     orchestrate,
@@ -429,3 +430,16 @@ def test_a_call_offers_exactly_the_options_its_command_builds(wrapper: object) -
     assert set(build) == forwarded
     for name, parameter in build.items():
         assert parameter.default == call[name].default, name
+
+
+@pytest.mark.parametrize("name", _WRAPPERS)
+def test_a_wrapper_reprs_as_its_public_name(name: str) -> None:
+    """A wrapper shows up in a traceback or a recipe table by the name it is reached
+    by, not by an object address.
+
+    Args:
+        name: The wrapper's name below `aigverse.abc`.
+    """
+    wrapper = _WRAPPERS[name]
+    assert isinstance(wrapper, CommandWrapper)
+    assert repr(wrapper) == f"aigverse.abc.{name}"

--- a/test/abc/test_fake_abc.py
+++ b/test/abc/test_fake_abc.py
@@ -59,7 +59,8 @@ def test_a_bare_command_object_is_taken_as_its_text(and_aig: Aig, fake_abc: Call
 
     with pytest.raises(AbcExecutionError, match="unknown command") as excinfo:
         run_commands(Command("nope -z"), binary=shim)
-    assert excinfo.value.command == "nope -z"
+    # a resource file registered via AIGVERSE_ABC_RC prepends a `source` step
+    assert excinfo.value.command.endswith("nope -z")
 
 
 @requires_posix

--- a/test/abc/test_fake_abc.py
+++ b/test/abc/test_fake_abc.py
@@ -12,7 +12,15 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from aigverse.abc import AbcExecutionError, AbcTimeoutError, abc_version, run_script, set_abc_binary
+from aigverse.abc import (
+    AbcExecutionError,
+    AbcTimeoutError,
+    Command,
+    abc_version,
+    run_commands,
+    run_script,
+    set_abc_binary,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -39,6 +47,19 @@ def test_happy_path_round_trips(and_aig: Aig, fake_abc: Callable[[str], Path]) -
     assert result.num_pis == and_aig.num_pis
     assert result.num_pos == and_aig.num_pos
     assert result.num_gates == and_aig.num_gates
+
+
+@requires_posix
+def test_a_bare_command_object_is_taken_as_its_text(and_aig: Aig, fake_abc: Callable[[str], Path]) -> None:
+    """`run_script` and `run_commands` take a single `Command`, not only a sequence."""
+    shim = fake_abc("print(\"** cmd error: unknown command 'nope'\")\nsys.exit(0)")
+    with pytest.raises(AbcExecutionError, match="unknown command") as excinfo:
+        run_script(and_aig, Command("nope -z"), binary=shim)
+    assert "; nope -z; " in excinfo.value.command
+
+    with pytest.raises(AbcExecutionError, match="unknown command") as excinfo:
+        run_commands(Command("nope -z"), binary=shim)
+    assert excinfo.value.command == "nope -z"
 
 
 @requires_posix


### PR DESCRIPTION
## Description

Every ABC wrapper translated keyword arguments into switches and immediately ran the result, so the translation half was unreachable without a run and `run_script`/`run_many` could take any bare command but nothing parameterized. Each wrapper is now a callable object whose `cmd()` returns a `Command` without running it, whose `__call__` keeps today's signature and delegates, and `join_commands` accepts a `Command` wherever it accepts a string. Read `_commands.py` and `gia.py` as one mechanical conversion; the added lines are the option docstrings that `cmd()` and `__call__` must each carry under `select = ["ALL"]`, and a signature-parity test pins that the two never drift.

Two things the diff does not show: autoapi renders a module-level instance as data, so the 15 converted names lose their rendered signature on the API page and their cross-references become `py:obj`, and it drops `#:` comments on annotated assignments, which is why each instance carries a string docstring pointing at its class (and why `check-docstring-first` is excluded for those two files).

Fixes #476

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry for any noteworthy addition, change, fix, or removal.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reusable `Command` objects for constructing ABC commands without executing them.
  - Added `.cmd()` builders to classic and GIA optimization wrappers.
  - Existing wrapper calls continue to execute commands.
  - `run_script`, `run_commands`, and batch execution now accept command objects alongside command strings.
  - Command objects can be combined into parameterized schedules and reused across executions.

- **Documentation**
  - Expanded ABC documentation and examples for command construction, batching, and store-specific execution.
  - Updated the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->