### PR TITLE
📝 Correct the ABI claim in the README and add an ABC example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@ releases may include breaking changes.
 
 ### Added
 
-- 📝 Add an ABC example to the README, showing how to run one of ABC's optimization
-  scripts on a network and check the result for equivalence ([#489]) ([**@marcelwa**])
+- 📝 Add an ABC example to the README ([#489]) ([**@marcelwa**])
 - 👷 Add a `cpp-lint` nox session that reproduces the `🚨 Clang-Tidy` check locally, running
   the same `cpp-linter` invocation CI runs over the files that differ from `origin/main`
   ([#488]) ([**@marcelwa**])
@@ -35,9 +34,7 @@ releases may include breaking changes.
 
 ### Fixed
 
-- 📝 Correct the README's Stable ABI floor, which is 3.10 rather than 3.12 since split
-  mode, and drop its claim of free-threading support, which is deferred to Python 3.15
-  ([#489]) ([**@marcelwa**])
+- 📝 Correct the README's Stable ABI and free-threading claims ([#489]) ([**@marcelwa**])
 - 🐛 Stop `equivalence_checking`, `aig_cut_rewriting`, `balancing`, and `cleanup_dangling`
   from returning silently wrong results when several threads call them on one shared
   network. Each wrote traversal state into the caller's network through a mockturtle view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Added
 
+- 📝 Add an ABC example to the README, showing how to run one of ABC's optimization
+  scripts on a network and check the result for equivalence ([#489]) ([**@marcelwa**])
 - 👷 Add a `cpp-lint` nox session that reproduces the `🚨 Clang-Tidy` check locally, running
   the same `cpp-linter` invocation CI runs over the files that differ from `origin/main`
   ([#488]) ([**@marcelwa**])
@@ -33,6 +35,9 @@ releases may include breaking changes.
 
 ### Fixed
 
+- 📝 Correct the README's Stable ABI floor, which is 3.10 rather than 3.12 since split
+  mode, and drop its claim of free-threading support, which is deferred to Python 3.15
+  ([#489]) ([**@marcelwa**])
 - 🐛 Stop `equivalence_checking`, `aig_cut_rewriting`, `balancing`, and `cleanup_dangling`
   from returning silently wrong results when several threads call them on one shared
   network. Each wrote traversal state into the caller's network through a mockturtle view
@@ -233,6 +238,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#010)._
 
 <!-- PR links -->
 
+[#489]: https://github.com/marcelwa/aigverse/pull/489
 [#488]: https://github.com/marcelwa/aigverse/pull/488
 [#483]: https://github.com/marcelwa/aigverse/pull/483
 [#481]: https://github.com/marcelwa/aigverse/pull/481

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ synthesis backends.
 
 ## 📦 Installation
 
-`aigverse` is available via PyPI for all major operating systems and supports all active Python versions,
-with [Stable ABI](https://docs.python.org/3/c-api/stable.html) for 3.12+ and
-[free-threading](https://docs.python.org/3/howto/free-threading-python.html) support for 3.14+.
+`aigverse` is available via PyPI for all major operating systems, with a single
+[Stable ABI](https://docs.python.org/3/c-api/stable.html) wheel per platform that covers every supported Python from
+3.10 up. Free-threaded interpreters are not supported yet, pending the stable ABI that Python 3.15 brings them.
 
 ```bash
 pip install aigverse
@@ -323,6 +323,32 @@ if equiv:
 else:
     print("AIGs are NOT equivalent!")
 ```
+
+### 🅰️ ABC Integration
+
+`aigverse` can hand networks to [ABC](https://github.com/berkeley-abc/abc) and read the result back, so ABC's
+optimization scripts are available as ordinary Python functions. No ABC is bundled: the bridge drives an executable you
+already have installed, found on `PATH` as `abc`, or pointed at with the `AIGVERSE_ABC` environment variable or
+`abc.set_abc_binary()`. Importing the module always succeeds, so use `abc.is_available()` to check before calling.
+
+```python
+from aigverse import abc
+from aigverse.algorithms import equivalence_checking
+from aigverse.generators import carry_lookahead_adder
+
+aig = carry_lookahead_adder(16)
+
+# Run ABC's `resyn2` script; a *new* network of the same type is returned
+optimized = abc.resyn2(aig)
+
+print(f"{aig.num_gates} -> {optimized.num_gates} AND gates")
+print(f"Equivalent: {equivalence_checking(aig, optimized)}")
+```
+
+Alongside the named scripts (`resyn`, `resyn2`, `resyn3`, `compress`, `compress2`, `resyn2rs`, `compress2rs`, and
+`dc2`) there are individual commands such as `abc.balance` and `abc.resub`, ABC9's `&`-space under `abc.gia`, and
+`abc.run_many` for running one script over many networks in parallel. See the
+[ABC documentation](https://aigverse.readthedocs.io/en/latest/abc.html) for details.
 
 ### 📄 File Format Support
 

--- a/README.md
+++ b/README.md
@@ -345,10 +345,9 @@ print(f"{aig.num_gates} -> {optimized.num_gates} AND gates")
 print(f"Equivalent: {equivalence_checking(aig, optimized)}")
 ```
 
-Alongside the named scripts (`resyn`, `resyn2`, `resyn3`, `compress`, `compress2`, `resyn2rs`, `compress2rs`, and
-`dc2`) there are individual commands such as `abc.balance` and `abc.resub`, ABC9's `&`-space under `abc.gia`, and
-`abc.run_many` for running one script over many networks in parallel. See the
-[ABC documentation](https://aigverse.readthedocs.io/en/latest/abc.html) for details.
+The other named scripts (`resyn`, `resyn3`, `compress`, `compress2`, `resyn2rs`, `compress2rs`, and `dc2`) work the
+same way, as do the individual commands `abc.balance`, `abc.rewrite`, `abc.refactor`, and `abc.resub`. See the
+[ABC documentation](https://aigverse.readthedocs.io/en/latest/abc.html) for the full set.
 
 ### 📄 File Format Support
 

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ from aigverse.generators import carry_lookahead_adder
 
 aig = carry_lookahead_adder(16)
 
-# Run ABC's `resyn2` script; a *new* network of the same type is returned
+# Returns a new network; the input is left untouched
 optimized = abc.resyn2(aig)
 
 print(f"{aig.num_gates} -> {optimized.num_gates} AND gates")


### PR DESCRIPTION
## Description

The installation paragraph still described the pre-split-mode build: #463 moved `wheel.py-api` to `cp310` and dropped free-threading, so the Stable ABI floor is 3.10 rather than 3.12 and no free-threaded wheels are built at all — the v0.1.5 wheels are four `cp310-abi3` and nothing else. This corrects both halves and adds the ABC example the usage tour was missing, since `aigverse.abc` is in the feature list but appears nowhere in the README. The new section is placed after Equivalence Checking because that is the first point where both symbols it uses are already introduced.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry for any noteworthy addition, change, fix, or removal.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

## Verification

The example was run verbatim against ABC built at the pinned `c6e8823c`, driving the published `aigverse==0.1.5` wheel on CPython 3.11 — `186 -> 133 AND gates`, `Equivalent: True` — as were the other eleven scripts and commands the section names, all of which preserve equivalence. Installing that wheel on 3.11 resolved the `cp310-abi3` wheel, which is itself the corrected claim in action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for integrating with the external ABC executable, including configuration, availability checks, supported scripts, commands, and usage examples.
  * Clarified Stable ABI wheel coverage for Python 3.10 and newer.
  * Documented that free-threaded interpreters are not currently supported.
  * Updated changelog entries with recent corrections and the related pull request reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->