### PR TITLE
🔧 Hide the embedded static libraries' symbols from the split-mode extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,7 @@ releases may include breaking changes.
 ### Changed
 
 - 🔧 Stop the extensions from re-exporting the internals of the static libraries they
-  embed. nanobind attaches `--exclude-libs` and section garbage collection to the
-  nanobind library target, which a split-mode extension no longer links, so since
-  #463 each module exported mockturtle's `abc::exorcism` and its mutable globals for
-  the dynamic linker to interpose across all five ([#490]) ([**@marcelwa**])
+  embed ([#490]) ([**@marcelwa**])
 - ⚡️ Run `examples/abc_recipe_study.py`'s sweep as one batch per recipe instead of one
   ABC call at a time, with a new `--jobs` flag. Its CSV loses the `seconds` column,
   which a concurrent run cannot measure per item ([#467]) ([**@marcelwa**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ releases may include breaking changes.
 
 ### Changed
 
+- 🔧 Stop the extensions from re-exporting the internals of the static libraries they
+  embed. nanobind attaches `--exclude-libs` and section garbage collection to the
+  nanobind library target, which a split-mode extension no longer links, so since
+  #463 each module exported mockturtle's `abc::exorcism` and its mutable globals for
+  the dynamic linker to interpose across all five ([#490]) ([**@marcelwa**])
 - ⚡️ Run `examples/abc_recipe_study.py`'s sweep as one batch per recipe instead of one
   ABC call at a time, with a new `--jobs` flag. Its CSV loses the `seconds` column,
   which a concurrent run cannot measure per item ([#467]) ([**@marcelwa**])
@@ -233,6 +238,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#010)._
 
 <!-- PR links -->
 
+[#490]: https://github.com/marcelwa/aigverse/pull/490
 [#488]: https://github.com/marcelwa/aigverse/pull/488
 [#483]: https://github.com/marcelwa/aigverse/pull/483
 [#481]: https://github.com/marcelwa/aigverse/pull/481

--- a/cmake/AddAigversePythonBinding.cmake
+++ b/cmake/AddAigversePythonBinding.cmake
@@ -36,35 +36,16 @@ function(add_aigverse_python_binding target_name)
     set(module_name ${target_name})
   endif()
 
-  # Keep the statically linked dependencies local. nanobind attaches
-  # `--exclude-libs`, `-ffunction-sections`/`-fdata-sections` and
-  # `--gc-sections` to the nanobind library target as PUBLIC options, and a
-  # split-mode extension links no such target, so it inherits none of them.
-  # Without this block every module re-exports the internals of the static
-  # libraries it embeds -- five copies of mockturtle's `abc::exorcism`, mutable
-  # globals included, which the dynamic linker is then free to interpose across
-  # modules.
+  # Keep the statically linked dependencies local: a split-mode extension links
+  # no nanobind target and inherits none of its symbol hiding or section
+  # collection.
   if(APPLE)
     target_link_options(${target_name} PRIVATE
                         "LINKER:-exported_symbol,_PyInit_${module_name}")
-
-    # Apple's x86-64 ABI compares RTTI by pointer, so nanobind's exception type
-    # information has to stay exported for an exception to cross a module
-    # boundary. Its arm64 ABI compares the type names instead.
-    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-      target_link_options(
-        ${target_name}
-        PRIVATE
-        "LINKER:-exported_symbol,__ZTIN8nanobind4abi112python_errorE"
-        "LINKER:-exported_symbol,__ZTSN8nanobind4abi112python_errorE"
-        "LINKER:-exported_symbol,__ZTIN8nanobind4abi117builtin_exceptionE"
-        "LINKER:-exported_symbol,__ZTSN8nanobind4abi117builtin_exceptionE")
-    endif()
   elseif(UNIX)
     target_link_options(${target_name} PRIVATE "LINKER:--exclude-libs,ALL")
 
-    # Section garbage collection needs the per-function and per-data sections to
-    # collect; nanobind's own `-Os` does not emit them.
+    # `--gc-sections` collects nothing without these; nanobind emits only `-Os`.
     target_compile_options(
       ${target_name}
       PRIVATE

--- a/cmake/AddAigversePythonBinding.cmake
+++ b/cmake/AddAigversePythonBinding.cmake
@@ -31,6 +31,53 @@ function(add_aigverse_python_binding target_name)
   if(ARG_MODULE_NAME)
     set_target_properties(${target_name} PROPERTIES OUTPUT_NAME
                                                     ${ARG_MODULE_NAME})
+    set(module_name ${ARG_MODULE_NAME})
+  else()
+    set(module_name ${target_name})
+  endif()
+
+  # Keep the statically linked dependencies local. nanobind attaches
+  # `--exclude-libs`, `-ffunction-sections`/`-fdata-sections` and
+  # `--gc-sections` to the nanobind library target as PUBLIC options, and a
+  # split-mode extension links no such target, so it inherits none of them.
+  # Without this block every module re-exports the internals of the static
+  # libraries it embeds -- five copies of mockturtle's `abc::exorcism`, mutable
+  # globals included, which the dynamic linker is then free to interpose across
+  # modules.
+  if(APPLE)
+    target_link_options(${target_name} PRIVATE
+                        "LINKER:-exported_symbol,_PyInit_${module_name}")
+
+    # Apple's x86-64 ABI compares RTTI by pointer, so nanobind's exception type
+    # information has to stay exported for an exception to cross a module
+    # boundary. Its arm64 ABI compares the type names instead.
+    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+      target_link_options(
+        ${target_name}
+        PRIVATE
+        "LINKER:-exported_symbol,__ZTIN8nanobind4abi112python_errorE"
+        "LINKER:-exported_symbol,__ZTSN8nanobind4abi112python_errorE"
+        "LINKER:-exported_symbol,__ZTIN8nanobind4abi117builtin_exceptionE"
+        "LINKER:-exported_symbol,__ZTSN8nanobind4abi117builtin_exceptionE")
+    endif()
+  elseif(UNIX)
+    target_link_options(${target_name} PRIVATE "LINKER:--exclude-libs,ALL")
+
+    # Section garbage collection needs the per-function and per-data sections to
+    # collect; nanobind's own `-Os` does not emit them.
+    target_compile_options(
+      ${target_name}
+      PRIVATE
+        "$<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>,$<CONFIG:RelWithDebInfo>>:-ffunction-sections;-fdata-sections>"
+    )
+    target_link_options(
+      ${target_name}
+      PRIVATE
+      "$<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>,$<CONFIG:RelWithDebInfo>>:LINKER:--gc-sections>"
+    )
+  elseif(WIN32)
+    set_target_properties(${target_name} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS
+                                                    OFF)
   endif()
 
   target_link_libraries(

--- a/cmake/AddAigversePythonBinding.cmake
+++ b/cmake/AddAigversePythonBinding.cmake
@@ -36,16 +36,18 @@ function(add_aigverse_python_binding target_name)
     set(module_name ${target_name})
   endif()
 
-  # Keep the statically linked dependencies local: a split-mode extension links
-  # no nanobind target and inherits none of its symbol hiding or section
-  # collection.
+  # Keep the embedded static libraries' symbols local. nanobind hides only the
+  # module's own (`CXX_VISIBILITY_PRESET hidden`); mockturtle's and ABC's
+  # archives keep default visibility, so each extension re-exported them for the
+  # dynamic linker to interpose across all five. Ported from scpd.
   if(APPLE)
     target_link_options(${target_name} PRIVATE
                         "LINKER:-exported_symbol,_PyInit_${module_name}")
   elseif(UNIX)
     target_link_options(${target_name} PRIVATE "LINKER:--exclude-libs,ALL")
 
-    # `--gc-sections` collects nothing without these; nanobind emits only `-Os`.
+    # `--gc-sections` collects nothing without these. A linked build inherited
+    # both from `nanobind-static`; split mode links no nanobind target.
     target_compile_options(
       ${target_name}
       PRIVATE
@@ -56,9 +58,6 @@ function(add_aigverse_python_binding target_name)
       PRIVATE
       "$<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>,$<CONFIG:RelWithDebInfo>>:LINKER:--gc-sections>"
     )
-  elseif(WIN32)
-    set_target_properties(${target_name} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS
-                                                    OFF)
   endif()
 
   target_link_libraries(


### PR DESCRIPTION
## Description

Each extension statically links mockturtle's and ABC's archives, whose symbols keep default visibility: nanobind's `CXX_VISIBILITY_PRESET hidden` covers only the module's own objects, in linked and split mode alike, so `abc::exorcism` and its mutable globals were exported from every module for the dynamic linker to interpose across all five. This ports the export restrictions from [munich-quantum-toolkit/scpd#96](https://github.com/munich-quantum-toolkit/scpd/pull/96): a single exported `_PyInit_<module>` on macOS and `--exclude-libs,ALL` on Linux. It also re-adds `-ffunction-sections`/`-fdata-sections` plus `--gc-sections`, the one thing split mode did drop, since a linked build inherited them from `nanobind-static` and a split-mode extension links no nanobind target.

The four-symbol Intel macOS guard that scpd once carried is not needed here, and not only because no Intel wheel is built: in split mode `python_error` and `builtin_exception` have their key functions in the backend shared library, so an extension imports that typeinfo rather than carrying a copy of its own, and Apple's pointer comparison on x86-64 holds regardless of what the extension exports.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry for any noteworthy addition, change, fix, or removal.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

## Verification

Local Release builds before and after this PR, on Linux x86-64: `algorithms` drops from **84 exported symbols to 19**, with zero `exorcism` among them and `PyInit_algorithms` plus nanobind's `python_error` RTTI retained. `io` and `networks` are unchanged by design: their exports are libstdc++ `namespace std` instantiations, which `--exclude-libs` correctly leaves alone. Size moves little (−0.3% across the five modules), since `-Os` and `-Wl,-s` already do most of that work.

The new wheel passes **558 tests** in a clean CPython 3.11 venv with a locally built ABC and `AIGVERSE_REQUIRE_ABC=1`, and CI is green on all four platforms, the macOS and Windows wheel jobs being the real check on the export restrictions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changed**
  - Python extensions now expose only their intended public interface instead of re-exporting symbols from embedded libraries.
  - Improved platform-specific linking for smaller, optimized extension builds.
  - Windows extension builds no longer disable automatic symbol exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->