### PR TITLE
🪟 Add Windows on ARM to CI and CD

### DIFF
--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -55,12 +55,12 @@ jobs:
           enable-cache: true
           save-cache: ${{ github.ref == 'refs/heads/main' }}
 
-      # numpy's win_arm64 wheels start at 3.11 (`adapters` is a hard dependency of the
-      # `test` group `nox -s tests` installs regardless of marker), so 3.10 has no
-      # installable numpy on this runner.
+      # numpy's win_arm64 wheels start at 3.11, but python-build-standalone has no
+      # native win_arm64 3.11 build -- uv falls back to an x64 one, which then fails
+      # to link against the arm64 extension -- so both 3.10 and 3.11 drop out here.
       - if: inputs.runs-on == 'windows-11-arm'
         name: Restrict interpreters on Windows ARM64
-        run: echo "NOX_PYTHON=-p 3.11 3.12 3.13 3.14" >> "$GITHUB_ENV"
+        run: echo "NOX_PYTHON=-p 3.12 3.13 3.14" >> "$GITHUB_ENV"
 
       # `nox -s tests` covers every supported Python version. The loader is pure
       # Python, and the cache path it builds is the sort of thing that differs

--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -55,6 +55,13 @@ jobs:
           enable-cache: true
           save-cache: ${{ github.ref == 'refs/heads/main' }}
 
+      # numpy's win_arm64 wheels start at 3.11 (`adapters` is a hard dependency of the
+      # `test` group `nox -s tests` installs regardless of marker), so 3.10 has no
+      # installable numpy on this runner.
+      - if: inputs.runs-on == 'windows-11-arm'
+        name: Restrict interpreters on Windows ARM64
+        run: echo "NOX_PYTHON=-p 3.11 3.12 3.13 3.14" >> "$GITHUB_ENV"
+
       # `nox -s tests` covers every supported Python version. The loader is pure
       # Python, and the cache path it builds is the sort of thing that differs
       # between platforms, so both axes are worth the matrix.
@@ -62,4 +69,4 @@ jobs:
       # Deliberately no pre-seeded benchmark cache: exercising the real download
       # path is the entire point of this job.
       - name: 📊 Test the benchmark loader
-        run: uvx nox -s tests --verbose -- -m network
+        run: uvx nox -s tests ${NOX_PYTHON:-} --verbose -- -m network

--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -71,4 +71,6 @@ jobs:
       # Deliberately no pre-seeded benchmark cache: exercising the real download
       # path is the entire point of this job.
       - name: 📊 Test the benchmark loader
-        run: uvx nox -s tests ${NOX_PYTHON:-} --verbose -- -m network
+        run: |
+          # shellcheck disable=SC2086  # word-split into separate -p / version args
+          uvx nox -s tests ${NOX_PYTHON:-} --verbose -- -m network

--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -55,12 +55,14 @@ jobs:
           enable-cache: true
           save-cache: ${{ github.ref == 'refs/heads/main' }}
 
-      # numpy's win_arm64 wheels start at 3.11, but python-build-standalone has no
-      # native win_arm64 3.11 build -- uv falls back to an x64 one, which then fails
-      # to link against the arm64 extension -- so both 3.10 and 3.11 drop out here.
+      # numpy's win_arm64 wheels start at 3.11, and uv downloads an emulated x86_64
+      # interpreter on Windows ARM64 unless the native one is requested by name, so
+      # 3.10 drops out and 3.11 is installed explicitly.
       - if: inputs.runs-on == 'windows-11-arm'
         name: Restrict interpreters on Windows ARM64
-        run: echo "NOX_PYTHON=-p 3.12 3.13 3.14" >> "$GITHUB_ENV"
+        run: |
+          uv python install cpython-3.11-windows-aarch64-none
+          echo "NOX_PYTHON=-p 3.11 3.12 3.13 3.14" >> "$GITHUB_ENV"
 
       # `nox -s tests` covers every supported Python version. The loader is pure
       # Python, and the cache path it builds is the sort of thing that differs

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, windows-2025]
+        runs-on:
+          [
+            ubuntu-24.04,
+            ubuntu-24.04-arm,
+            macos-15,
+            windows-2025,
+            windows-11-arm,
+          ]
     uses: ./.github/workflows/packaging-wheels.yml
     with:
       runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, windows-2025]
+        runs-on:
+          [
+            ubuntu-24.04,
+            ubuntu-24.04-arm,
+            macos-15,
+            windows-2025,
+            windows-11-arm,
+          ]
     uses: ./.github/workflows/python-tests.yml
     with:
       runs-on: ${{ matrix.runs-on }}
@@ -75,7 +82,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, windows-2025]
+        runs-on:
+          [
+            ubuntu-24.04,
+            ubuntu-24.04-arm,
+            macos-15,
+            windows-2025,
+            windows-11-arm,
+          ]
     uses: ./.github/workflows/benchmark-tests.yml
     with:
       runs-on: ${{ matrix.runs-on }}
@@ -123,7 +137,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, windows-2025]
+        runs-on:
+          [
+            ubuntu-24.04,
+            ubuntu-24.04-arm,
+            macos-15,
+            windows-2025,
+            windows-11-arm,
+          ]
     uses: ./.github/workflows/packaging-wheels.yml
     with:
       runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -44,7 +44,7 @@ jobs:
       # win_arm64 wheel, so a cp310 build's test run could never install. cp311
       # builds the same `cp310-abi3` wheel (`wheel.py-api` in pyproject.toml) and
       # can test it.
-      - if: runner.arch == 'ARM64'
+      - if: runner.arch == 'ARM64' && runner.os == 'Windows'
         name: Build with CPython 3.11 on Windows ARM64
         run: echo "CIBW_BUILD=cp311-*" >> "$GITHUB_ENV"
 

--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -40,6 +40,14 @@ jobs:
           # Defaults to x64; windows-11-arm needs telling explicitly.
           arch: ${{ runner.arch == 'ARM64' && 'arm64' || 'x64' }}
 
+      # nanobind-backend, which the wheel needs at import time, has no cp310
+      # win_arm64 wheel, so a cp310 build's test run could never install. cp311
+      # builds the same `cp310-abi3` wheel (`wheel.py-api` in pyproject.toml) and
+      # can test it.
+      - if: runner.arch == 'ARM64'
+        name: Build with CPython 3.11 on Windows ARM64
+        run: echo "CIBW_BUILD=cp311-*" >> "$GITHUB_ENV"
+
       # No compiler cache here, deliberately. Wheels compile against nanobind
       # headers inside uv's build-isolation environment, a directory named
       # randomly per run (`/tmp/build-env-r57r75a3`, then `/tmp/build-env-sjkp5_7v`),

--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -36,6 +36,9 @@ jobs:
 
       - name: Set up MSVC development environment (Windows only)
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        with:
+          # Defaults to x64; windows-11-arm needs telling explicitly.
+          arch: ${{ runner.arch == 'ARM64' && 'arm64' || 'x64' }}
 
       # No compiler cache here, deliberately. Wheels compile against nanobind
       # headers inside uv's build-isolation environment, a directory named

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -91,22 +91,23 @@ jobs:
         run: uv tool install sccache
 
       # torch ships neither a win_arm64 wheel nor an sdist, so `--full` (which installs
-      # it) is unusable here. python-build-standalone has no native win_arm64 3.11
-      # build either -- uv falls back to an x64 one, which then fails to link against
-      # the arm64 extension -- so 3.11 drops out of the matrix too. `nox -p` narrows
-      # the interpreter matrix; the runs below skip `--full` and explicitly exclude
-      # `torch` alongside `network` so the uninstalled dependency's tests are never
-      # collected.
+      # it) is unusable here; the runs below skip it and explicitly exclude `torch`
+      # alongside `network` so the uninstalled dependency's tests are never collected.
       #
-      # `minimums` narrows further still, to 3.14 alone: numpy's win_arm64 wheels only
-      # start at 2.3.0, which is the floor for 3.14 (`adapters` in pyproject.toml) but
-      # not for 3.12/3.13, so those would fall back to a from-source numpy build --
-      # which itself fails here, as Git's own `link.exe` shadows MSVC's on this image.
+      # uv downloads an emulated x86_64 interpreter on Windows ARM64 unless the native
+      # one is requested by name, and an x64 3.11 cannot load the arm64 extension, so
+      # install it explicitly. 3.10 has no native build at all and drops out.
+      #
+      # `minimums` narrows further, to 3.14 alone: numpy's win_arm64 wheels start at
+      # 2.3.0, and only the 3.14 floor (2.3.2, `adapters` in pyproject.toml) clears
+      # that. The lower floors would fall back to a from-source numpy build, which
+      # itself fails here, as Git's own `link.exe` shadows MSVC's on this image.
       - if: inputs.runs-on == 'windows-11-arm'
         name: Restrict interpreters on Windows ARM64
         run: |
+          uv python install cpython-3.11-windows-aarch64-none
           {
-            echo "NOX_PYTHON_TESTS=-p 3.12 3.13 3.14"
+            echo "NOX_PYTHON_TESTS=-p 3.11 3.12 3.13 3.14"
             echo "NOX_PYTHON_MINIMUMS=-p 3.14"
           } >> "$GITHUB_ENV"
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -52,6 +52,9 @@ jobs:
       - if: runner.os == 'Windows'
         name: Set up the MSVC development environment
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        with:
+          # Defaults to x64; windows-11-arm needs telling explicitly.
+          arch: ${{ runner.arch == 'ARM64' && 'arm64' || 'x64' }}
 
       - if: runner.os == 'Windows'
         name: Build with Ninja so that the compiler cache is used
@@ -87,6 +90,15 @@ jobs:
         name: Install sccache
         run: uv tool install sccache
 
+      # torch ships neither a win_arm64 wheel nor an sdist, and numpy's win_arm64 wheels
+      # start at 3.11, so `--full` (which installs torch) and Python 3.10 are both
+      # unusable on this runner. `nox -p` narrows the interpreter matrix; the runs
+      # below skip `--full` and explicitly exclude `torch` alongside `network` so the
+      # uninstalled dependency's tests are never collected.
+      - if: inputs.runs-on == 'windows-11-arm'
+        name: Restrict interpreters on Windows ARM64
+        run: echo "NOX_PYTHON=-p 3.11 3.12 3.13 3.14" >> "$GITHUB_ENV"
+
       # The declared floors are only a claim until something installs them, so
       # resolve every direct dependency down to its minimum and run the suite
       # against that. This shares the matrix rather than sitting in a job of its
@@ -97,12 +109,22 @@ jobs:
       # `--full` installs the optional groups and selects every marker; the
       # matrix narrows it back to exclude the network tests, which download
       # circuits and run in their own workflow so that a hiccup at github.com
-      # cannot redden an unrelated matrix.
-      - name: ⬇️ Test the lowest supported dependency versions
+      # cannot redden an unrelated matrix. Skipped on windows-11-arm, see above.
+      - if: inputs.runs-on != 'windows-11-arm'
+        name: ⬇️ Test the lowest supported dependency versions
         run: uvx nox -s minimums --verbose -- --full -m "not network"
 
-      - name: 🐍 Test
+      - if: inputs.runs-on == 'windows-11-arm'
+        name: ⬇️ Test the lowest supported dependency versions (Windows ARM64)
+        run: uvx nox -s minimums ${NOX_PYTHON} --verbose -- -m "not network and not torch"
+
+      - if: inputs.runs-on != 'windows-11-arm'
+        name: 🐍 Test
         run: uvx nox -s tests --verbose -- --full -m "not network"
+
+      - if: inputs.runs-on == 'windows-11-arm'
+        name: 🐍 Test (Windows ARM64)
+        run: uvx nox -s tests ${NOX_PYTHON} --verbose -- -m "not network and not torch"
 
       # A hit rate is a fact; a step duration is a guess about one. The other
       # platforms get this from ccache-action's post step. `--show-stats` is left

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -90,14 +90,25 @@ jobs:
         name: Install sccache
         run: uv tool install sccache
 
-      # torch ships neither a win_arm64 wheel nor an sdist, and numpy's win_arm64 wheels
-      # start at 3.11, so `--full` (which installs torch) and Python 3.10 are both
-      # unusable on this runner. `nox -p` narrows the interpreter matrix; the runs
-      # below skip `--full` and explicitly exclude `torch` alongside `network` so the
-      # uninstalled dependency's tests are never collected.
+      # torch ships neither a win_arm64 wheel nor an sdist, so `--full` (which installs
+      # it) is unusable here. python-build-standalone has no native win_arm64 3.11
+      # build either -- uv falls back to an x64 one, which then fails to link against
+      # the arm64 extension -- so 3.11 drops out of the matrix too. `nox -p` narrows
+      # the interpreter matrix; the runs below skip `--full` and explicitly exclude
+      # `torch` alongside `network` so the uninstalled dependency's tests are never
+      # collected.
+      #
+      # `minimums` narrows further still, to 3.14 alone: numpy's win_arm64 wheels only
+      # start at 2.3.0, which is the floor for 3.14 (`adapters` in pyproject.toml) but
+      # not for 3.12/3.13, so those would fall back to a from-source numpy build --
+      # which itself fails here, as Git's own `link.exe` shadows MSVC's on this image.
       - if: inputs.runs-on == 'windows-11-arm'
         name: Restrict interpreters on Windows ARM64
-        run: echo "NOX_PYTHON=-p 3.11 3.12 3.13 3.14" >> "$GITHUB_ENV"
+        run: |
+          {
+            echo "NOX_PYTHON_TESTS=-p 3.12 3.13 3.14"
+            echo "NOX_PYTHON_MINIMUMS=-p 3.14"
+          } >> "$GITHUB_ENV"
 
       # The declared floors are only a claim until something installs them, so
       # resolve every direct dependency down to its minimum and run the suite
@@ -116,7 +127,7 @@ jobs:
 
       - if: inputs.runs-on == 'windows-11-arm'
         name: ⬇️ Test the lowest supported dependency versions (Windows ARM64)
-        run: uvx nox -s minimums ${NOX_PYTHON} --verbose -- -m "not network and not torch"
+        run: uvx nox -s minimums ${NOX_PYTHON_MINIMUMS} --verbose -- -m "not network and not torch"
 
       - if: inputs.runs-on != 'windows-11-arm'
         name: 🐍 Test
@@ -124,7 +135,7 @@ jobs:
 
       - if: inputs.runs-on == 'windows-11-arm'
         name: 🐍 Test (Windows ARM64)
-        run: uvx nox -s tests ${NOX_PYTHON} --verbose -- -m "not network and not torch"
+        run: uvx nox -s tests ${NOX_PYTHON_TESTS} --verbose -- -m "not network and not torch"
 
       # A hit rate is a fact; a step duration is a guess about one. The other
       # platforms get this from ccache-action's post step. `--show-stats` is left

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -128,7 +128,9 @@ jobs:
 
       - if: inputs.runs-on == 'windows-11-arm'
         name: ⬇️ Test the lowest supported dependency versions (Windows ARM64)
-        run: uvx nox -s minimums ${NOX_PYTHON_MINIMUMS} --verbose -- -m "not network and not torch"
+        run: |
+          # shellcheck disable=SC2086  # word-split into separate -p / version args
+          uvx nox -s minimums ${NOX_PYTHON_MINIMUMS} --verbose -- -m "not network and not torch"
 
       - if: inputs.runs-on != 'windows-11-arm'
         name: 🐍 Test
@@ -136,7 +138,9 @@ jobs:
 
       - if: inputs.runs-on == 'windows-11-arm'
         name: 🐍 Test (Windows ARM64)
-        run: uvx nox -s tests ${NOX_PYTHON_TESTS} --verbose -- -m "not network and not torch"
+        run: |
+          # shellcheck disable=SC2086  # word-split into separate -p / version args
+          uvx nox -s tests ${NOX_PYTHON_TESTS} --verbose -- -m "not network and not torch"
 
       # A hit rate is a fact; a step duration is a guess about one. The other
       # platforms get this from ccache-action's post step. `--show-stats` is left

--- a/docs/machine_learning.md
+++ b/docs/machine_learning.md
@@ -140,6 +140,12 @@ as [PyTorch](https://docs.pytorch.org/docs/stable/dlpack.html),
 [TensorFlow](https://www.tensorflow.org/api_docs/python/tf/experimental/dlpack/from_dlpack), etc., through
 `from_dlpack`.
 
+:::{note}
+PyTorch publishes no `win_arm64` wheels, so the `torch` snippets below cannot run on Windows on ARM. The DLPack export
+itself is unaffected — consume it with [NumPy](https://numpy.org/doc/stable/reference/generated/numpy.from_dlpack.html)
+instead, as shown at the end of this section.
+:::
+
 Encoding and `dtype` mapping:
 
 - Edge encoding (`edge_attr`):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,16 @@ select = "cp310-*"
 inherit.repair-wheel-command = "append"
 repair-wheel-command = "uvx abi3audit --strict --report {wheel}"
 
+# torch ships neither a win_arm64 wheel nor an sdist, and numpy's win_arm64 wheels
+# only start at cp311 -- both are unusable against the cp310 wheel this project
+# builds, so the full test suite can't install here. A plain import is the only
+# check available; nox's own matrix covers this platform for cp311+ instead.
+[[tool.cibuildwheel.overrides]]
+select = "cp310-win_arm64"
+test-groups = []
+test-sources = []
+test-command = 'python -c "import aigverse"'
+
 
 [tool.uv]
 required-version = ">=0.5.20"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,12 @@ test-sources = ["test/"]
 # the -m here replaces the one in [tool.pytest] addopts rather than adding to it,
 # so the network exclusion has to be repeated or wheel CI would download circuits
 test-command = 'pytest test/ -m "(torch or not torch) and not network"'
+# nanobind-backend, a runtime dependency the extension resolves at import time, has
+# no cp310 win_arm64 wheel yet (cp311+ does), so testing the wheel with the cp310
+# interpreter cibuildwheel selects for it can never install. Users on cp311+ are
+# unaffected -- their interpreter's own nanobind-backend wheel is what gets picked
+# at install time, regardless of the abi3 tag this wheel was built with.
+test-skip = "cp310-win_arm64"
 
 
 [tool.cibuildwheel.macos]
@@ -166,16 +172,6 @@ repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel} --ignore-existin
 select = "cp310-*"
 inherit.repair-wheel-command = "append"
 repair-wheel-command = "uvx abi3audit --strict --report {wheel}"
-
-# torch ships neither a win_arm64 wheel nor an sdist, and numpy's win_arm64 wheels
-# only start at cp311 -- both are unusable against the cp310 wheel this project
-# builds, so the full test suite can't install here. A plain import is the only
-# check available; nox's own matrix covers this platform for cp311+ instead.
-[[tool.cibuildwheel.overrides]]
-select = "cp310-win_arm64"
-test-groups = []
-test-sources = []
-test-command = 'python -c "import aigverse"'
 
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,12 +153,6 @@ test-sources = ["test/"]
 # the -m here replaces the one in [tool.pytest] addopts rather than adding to it,
 # so the network exclusion has to be repeated or wheel CI would download circuits
 test-command = 'pytest test/ -m "(torch or not torch) and not network"'
-# nanobind-backend, a runtime dependency the extension resolves at import time, has
-# no cp310 win_arm64 wheel yet (cp311+ does), so testing the wheel with the cp310
-# interpreter cibuildwheel selects for it can never install. Users on cp311+ are
-# unaffected -- their interpreter's own nanobind-backend wheel is what gets picked
-# at install time, regardless of the abi3 tag this wheel was built with.
-test-skip = "cp310-win_arm64"
 
 
 [tool.cibuildwheel.macos]
@@ -168,10 +162,17 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 before-build = "uv pip install delvewheel>=1.11.2"
 repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel} --ignore-existing"
 
+# every abi3 wheel: cp310 everywhere, cp311 on Windows ARM64 (see packaging-wheels.yml)
 [[tool.cibuildwheel.overrides]]
-select = "cp310-*"
+select = "cp310-* cp311-win_arm64"
 inherit.repair-wheel-command = "append"
 repair-wheel-command = "uvx abi3audit --strict --report {wheel}"
+
+# torch publishes no win_arm64 wheel, so the wheel's own test run does without it
+[[tool.cibuildwheel.overrides]]
+select = "*-win_arm64"
+test-groups = ["test"]
+test-command = 'pytest test/ -m "not torch and not network"'
 
 
 [tool.uv]


### PR DESCRIPTION
## Summary

Adds the `windows-11-arm` GitHub-hosted runner to the CI/CD matrices, alongside the existing `ubuntu-24.04-arm` Linux Arm coverage.

- `python-tests`, `benchmark-tests`, and `packaging-wheels` matrices in `ci.yml`/`cd.yml` now include `windows-11-arm`.
- `ilammy/msvc-dev-cmd` needs `arch: arm64` explicitly on this runner (it defaults to `x64` and does not auto-detect the host).
- torch publishes no `win_arm64` wheel and no sdist, so `--full` is skipped there and `torch`-marked tests are excluded alongside `network`. numpy's `win_arm64` wheels only start at cp311, so 3.10 drops out; uv prefers an emulated x86_64 download on Windows ARM64 unless the native build is requested by name, so 3.11 is installed as `cpython-3.11-windows-aarch64-none` before nox runs. `minimums` runs on 3.14 alone, the only interpreter whose numpy floor (2.3.2) has a `win_arm64` wheel.
- nanobind-backend has no cp310 `win_arm64` wheel, so a cp310 wheel build could never run its test step there. `packaging-wheels` builds with cp311 on that runner instead, which yields the same `cp310-abi3` wheel (`wheel.py-api`) and can test it; a `[[tool.cibuildwheel.overrides]]` entry for `*-win_arm64` drops the torch group from that test run.
- `abc-tests` is left excluding Windows entirely, unchanged: ABC has no supported MSVC build, independent of architecture.

## Test plan

- [x] `uvx nox -s lint`
- [ ] CI green on `windows-11-arm` across `python-tests`, `benchmark-tests`, and `packaging-wheels`, with the wheel's pytest run actually executing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows ARM64 support for building and validating wheels across supported Python versions.
  * Expanded native Windows ARM64 coverage for testing and benchmarking.

* **Bug Fixes**
  * Improved ARM64 toolchain and interpreter configuration for more reliable builds and tests.
  * Excluded unavailable PyTorch-based tests on Windows ARM64 while retaining other coverage.

* **Documentation**
  * Clarified that PyTorch examples are unavailable on Windows ARM64 and recommended NumPy for DLPack examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->